### PR TITLE
changed production search index name to prod

### DIFF
--- a/_config.production.yml
+++ b/_config.production.yml
@@ -1,3 +1,3 @@
 elasticsearch:
   url: https://search-docs-production-gjsdgg3cln5hrgcqi7s6ugtyle.us-east-1.es.amazonaws.com
-  index_name: production
+  index_name: prod


### PR DESCRIPTION
Changed name of elasticsearch index from 'production' to 'prod' in production releases