### PR TITLE
[DOCS-6186] Update old search redirects

### DIFF
--- a/redirects/4.0/concepts/solr-SSL-keystores.html
+++ b/redirects/4.0/concepts/solr-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/4.0/concepts/solr-backup-recovery.html
+++ b/redirects/4.0/concepts/solr-backup-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.0/concepts/solr-benefits.html
+++ b/redirects/4.0/concepts/solr-benefits.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solr-choosing.html
+++ b/redirects/4.0/concepts/solr-choosing.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/install/

--- a/redirects/4.0/concepts/solr-config-files.html
+++ b/redirects/4.0/concepts/solr-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solr-directory.html
+++ b/redirects/4.0/concepts/solr-directory.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solr-event-consistency.html
+++ b/redirects/4.0/concepts/solr-event-consistency.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/search-services/latest/install/

--- a/redirects/4.0/concepts/solr-home.html
+++ b/redirects/4.0/concepts/solr-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solr-index-fix.html
+++ b/redirects/4.0/concepts/solr-index-fix.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/4.0/concepts/solr-monitor-troubleshoot.html
+++ b/redirects/4.0/concepts/solr-monitor-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/admin/monitor/

--- a/redirects/4.0/concepts/solr-overview.html
+++ b/redirects/4.0/concepts/solr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solr-repo-SSL-keystores.html
+++ b/redirects/4.0/concepts/solr-repo-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest

--- a/redirects/4.0/concepts/solr-subsystem.html
+++ b/redirects/4.0/concepts/solr-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solr-troubleshooting.html
+++ b/redirects/4.0/concepts/solr-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.0/concepts/solr-unindex.html
+++ b/redirects/4.0/concepts/solr-unindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/4.0/concepts/solr-webapp-config.html
+++ b/redirects/4.0/concepts/solr-webapp-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/4.0/concepts/solrcore-properties-file.html
+++ b/redirects/4.0/concepts/solrcore-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/config/properties/

--- a/redirects/4.0/concepts/solrnodes-memory.html
+++ b/redirects/4.0/concepts/solrnodes-memory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/search-services/latest/using/

--- a/redirects/4.0/concepts/solrsecurity-intro.html
+++ b/redirects/4.0/concepts/solrsecurity-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/Youtube-Weblogic-Solr-publishing.html
+++ b/redirects/4.0/tasks/Youtube-Weblogic-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/security/

--- a/redirects/4.0/tasks/Youtube-Websphere-Solr-publishing.html
+++ b/redirects/4.0/tasks/Youtube-Websphere-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.0/tasks/adminconsole-search-solr.html
+++ b/redirects/4.0/tasks/adminconsole-search-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/security/

--- a/redirects/4.0/tasks/alf-jboss-solr-config.html
+++ b/redirects/4.0/tasks/alf-jboss-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/alf-weblogic-solr-config.html
+++ b/redirects/4.0/tasks/alf-weblogic-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/alf-websphere-solr-config.html
+++ b/redirects/4.0/tasks/alf-websphere-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/keys/

--- a/redirects/4.0/tasks/generate-keys-solr.html
+++ b/redirects/4.0/tasks/generate-keys-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/search-services/latest/config/security/

--- a/redirects/4.0/tasks/google-Websphere-Solr-publishing.html
+++ b/redirects/4.0/tasks/google-Websphere-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.0/tasks/googledocs-Weblogic-solr-publishing.html
+++ b/redirects/4.0/tasks/googledocs-Weblogic-solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.0/tasks/lucene-solr-migration.html
+++ b/redirects/4.0/tasks/lucene-solr-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.0/tasks/search_permissions_check.html
+++ b/redirects/4.0/tasks/search_permissions_check.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/search-services/latest/config/transactional/

--- a/redirects/4.0/tasks/set-solr-log4j.html
+++ b/redirects/4.0/tasks/set-solr-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/install/options/

--- a/redirects/4.0/tasks/solr-alfresco-config.html
+++ b/redirects/4.0/tasks/solr-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/solr-backup.html
+++ b/redirects/4.0/tasks/solr-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/solr-install-config.html
+++ b/redirects/4.0/tasks/solr-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/solr-recovery.html
+++ b/redirects/4.0/tasks/solr-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/solr-reindex.html
+++ b/redirects/4.0/tasks/solr-reindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.0/tasks/ssl-protect-solrwebapp.html
+++ b/redirects/4.0/tasks/ssl-protect-solrwebapp.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/concepts/solr-SSL-keystores.html
+++ b/redirects/4.1/concepts/solr-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/4.1/concepts/solr-backup-recovery.html
+++ b/redirects/4.1/concepts/solr-backup-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/concepts/solr-benefits.html
+++ b/redirects/4.1/concepts/solr-benefits.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solr-choosing.html
+++ b/redirects/4.1/concepts/solr-choosing.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/install/

--- a/redirects/4.1/concepts/solr-config-files.html
+++ b/redirects/4.1/concepts/solr-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solr-directory.html
+++ b/redirects/4.1/concepts/solr-directory.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solr-event-consistency.html
+++ b/redirects/4.1/concepts/solr-event-consistency.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/search-services/latest/install/

--- a/redirects/4.1/concepts/solr-home.html
+++ b/redirects/4.1/concepts/solr-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solr-index-fix.html
+++ b/redirects/4.1/concepts/solr-index-fix.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/4.1/concepts/solr-monitor-troubleshoot.html
+++ b/redirects/4.1/concepts/solr-monitor-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/admin/monitor/

--- a/redirects/4.1/concepts/solr-overview.html
+++ b/redirects/4.1/concepts/solr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solr-repo-SSL-keystores.html
+++ b/redirects/4.1/concepts/solr-repo-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest

--- a/redirects/4.1/concepts/solr-subsystem.html
+++ b/redirects/4.1/concepts/solr-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solr-troubleshooting.html
+++ b/redirects/4.1/concepts/solr-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/concepts/solr-unindex.html
+++ b/redirects/4.1/concepts/solr-unindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/4.1/concepts/solr-webapp-config.html
+++ b/redirects/4.1/concepts/solr-webapp-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/4.1/concepts/solrcore-properties-file.html
+++ b/redirects/4.1/concepts/solrcore-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/config/properties/

--- a/redirects/4.1/concepts/solrnodes-memory.html
+++ b/redirects/4.1/concepts/solrnodes-memory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/search-services/latest/using/

--- a/redirects/4.1/concepts/solrsecurity-intro.html
+++ b/redirects/4.1/concepts/solrsecurity-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/Youtube-Weblogic-Solr-publishing.html
+++ b/redirects/4.1/tasks/Youtube-Weblogic-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/security/

--- a/redirects/4.1/tasks/Youtube-Websphere-Solr-publishing.html
+++ b/redirects/4.1/tasks/Youtube-Websphere-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/tasks/adminconsole-search-solr.html
+++ b/redirects/4.1/tasks/adminconsole-search-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/security/

--- a/redirects/4.1/tasks/alf-jboss-solr-config.html
+++ b/redirects/4.1/tasks/alf-jboss-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/alf-weblogic-solr-config.html
+++ b/redirects/4.1/tasks/alf-weblogic-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/alf-websphere-solr-config.html
+++ b/redirects/4.1/tasks/alf-websphere-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/keys/

--- a/redirects/4.1/tasks/generate-keys-solr.html
+++ b/redirects/4.1/tasks/generate-keys-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/search-services/latest/config/security/

--- a/redirects/4.1/tasks/google-Websphere-Solr-publishing.html
+++ b/redirects/4.1/tasks/google-Websphere-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/tasks/googledocs-Weblogic-solr-publishing.html
+++ b/redirects/4.1/tasks/googledocs-Weblogic-solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/tasks/lucene-solr-migration.html
+++ b/redirects/4.1/tasks/lucene-solr-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.1/tasks/search_permissions_check.html
+++ b/redirects/4.1/tasks/search_permissions_check.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/search-services/latest/config/transactional/

--- a/redirects/4.1/tasks/set-solr-log4j.html
+++ b/redirects/4.1/tasks/set-solr-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/install/options/

--- a/redirects/4.1/tasks/solr-alfresco-config.html
+++ b/redirects/4.1/tasks/solr-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/solr-backup.html
+++ b/redirects/4.1/tasks/solr-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/solr-install-config.html
+++ b/redirects/4.1/tasks/solr-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/solr-recovery.html
+++ b/redirects/4.1/tasks/solr-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/solr-reindex.html
+++ b/redirects/4.1/tasks/solr-reindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.1/tasks/ssl-protect-solrwebapp.html
+++ b/redirects/4.1/tasks/ssl-protect-solrwebapp.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/concepts/intrans-metadata-conf-patch.html
+++ b/redirects/4.2/concepts/intrans-metadata-conf-patch.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/4.2/concepts/intrans-metadata-configure.html
+++ b/redirects/4.2/concepts/intrans-metadata-configure.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/properties/

--- a/redirects/4.2/concepts/intrans-metadata-create-index.html
+++ b/redirects/4.2/concepts/intrans-metadata-create-index.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/4.2/concepts/intrans-metadata-feature.html
+++ b/redirects/4.2/concepts/intrans-metadata-feature.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/4.2/concepts/intrans-metadata-overview.html
+++ b/redirects/4.2/concepts/intrans-metadata-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/install/

--- a/redirects/4.2/concepts/intrans-metadata-query.html
+++ b/redirects/4.2/concepts/intrans-metadata-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-model/
+/search-services/latest/config/transactional/

--- a/redirects/4.2/concepts/intrans-metadata.html
+++ b/redirects/4.2/concepts/intrans-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/4.2/concepts/search-examples.html
+++ b/redirects/4.2/concepts/search-examples.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/search-services/latest

--- a/redirects/4.2/concepts/search-fts-config.html
+++ b/redirects/4.2/concepts/search-fts-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/4.2/concepts/search-intro.html
+++ b/redirects/4.2/concepts/search-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/search-services/latest/install/

--- a/redirects/4.2/concepts/solr-SSL-keystores.html
+++ b/redirects/4.2/concepts/solr-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/4.2/concepts/solr-backup-recovery.html
+++ b/redirects/4.2/concepts/solr-backup-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/concepts/solr-benefits.html
+++ b/redirects/4.2/concepts/solr-benefits.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/search-services/latest/

--- a/redirects/4.2/concepts/solr-choosing.html
+++ b/redirects/4.2/concepts/solr-choosing.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/install/

--- a/redirects/4.2/concepts/solr-config-files.html
+++ b/redirects/4.2/concepts/solr-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/4.2/concepts/solr-directory.html
+++ b/redirects/4.2/concepts/solr-directory.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/search-services/latest/config/

--- a/redirects/4.2/concepts/solr-event-consistency.html
+++ b/redirects/4.2/concepts/solr-event-consistency.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/install/

--- a/redirects/4.2/concepts/solr-home.html
+++ b/redirects/4.2/concepts/solr-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.2/concepts/solr-index-fix.html
+++ b/redirects/4.2/concepts/solr-index-fix.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/4.2/concepts/solr-monitor-troubleshoot.html
+++ b/redirects/4.2/concepts/solr-monitor-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/admin/monitor/

--- a/redirects/4.2/concepts/solr-overview.html
+++ b/redirects/4.2/concepts/solr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/4.2/concepts/solr-repo-SSL-keystores.html
+++ b/redirects/4.2/concepts/solr-repo-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest

--- a/redirects/4.2/concepts/solr-subsystem.html
+++ b/redirects/4.2/concepts/solr-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/search-services/latest/config/

--- a/redirects/4.2/concepts/solr-troubleshooting.html
+++ b/redirects/4.2/concepts/solr-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/concepts/solr-unindex.html
+++ b/redirects/4.2/concepts/solr-unindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/4.2/concepts/solr-webapp-config.html
+++ b/redirects/4.2/concepts/solr-webapp-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/4.2/concepts/solrcore-properties-file.html
+++ b/redirects/4.2/concepts/solrcore-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/config/properties/

--- a/redirects/4.2/concepts/solrnodes-memory.html
+++ b/redirects/4.2/concepts/solrnodes-memory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/search-services/latest/using/

--- a/redirects/4.2/concepts/solrsecurity-intro.html
+++ b/redirects/4.2/concepts/solrsecurity-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/tasks/Youtube-Weblogic-Solr-publishing.html
+++ b/redirects/4.2/tasks/Youtube-Weblogic-Solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/security/

--- a/redirects/4.2/tasks/adminconsole-searchservice-solr.html
+++ b/redirects/4.2/tasks/adminconsole-searchservice-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/properties/

--- a/redirects/4.2/tasks/alf-weblogic-solr-config.html
+++ b/redirects/4.2/tasks/alf-weblogic-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/tasks/alf-websphere-solr-config.html
+++ b/redirects/4.2/tasks/alf-websphere-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/keys/

--- a/redirects/4.2/tasks/generate-keys-solr.html
+++ b/redirects/4.2/tasks/generate-keys-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/search-services/latest/config/security/

--- a/redirects/4.2/tasks/googledocs-Weblogic-solr-publishing.html
+++ b/redirects/4.2/tasks/googledocs-Weblogic-solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/tasks/lucene-solr-migration.html
+++ b/redirects/4.2/tasks/lucene-solr-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/tasks/remove-solr.html
+++ b/redirects/4.2/tasks/remove-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/upgrade/migrate/

--- a/redirects/4.2/tasks/search_permissions_check.html
+++ b/redirects/4.2/tasks/search_permissions_check.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/config/transactional/

--- a/redirects/4.2/tasks/set-solr-log4j.html
+++ b/redirects/4.2/tasks/set-solr-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.2/tasks/solr-alfresco-config.html
+++ b/redirects/4.2/tasks/solr-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.2/tasks/solr-backup.html
+++ b/redirects/4.2/tasks/solr-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.2/tasks/solr-install-config.html
+++ b/redirects/4.2/tasks/solr-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.2/tasks/solr-jboss-install.html
+++ b/redirects/4.2/tasks/solr-jboss-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/4.2/tasks/solr-recovery.html
+++ b/redirects/4.2/tasks/solr-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/4.2/tasks/solr-reindex.html
+++ b/redirects/4.2/tasks/solr-reindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/4.2/tasks/solr-tomcat-install.html
+++ b/redirects/4.2/tasks/solr-tomcat-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/4.2/tasks/ssl-protect-solrwebapp.html
+++ b/redirects/4.2/tasks/ssl-protect-solrwebapp.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/configure-solr4.html
+++ b/redirects/5.0/concepts/configure-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/intrans-metadata-conf-patch.html
+++ b/redirects/5.0/concepts/intrans-metadata-conf-patch.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/intrans-metadata-configure.html
+++ b/redirects/5.0/concepts/intrans-metadata-configure.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/properties/

--- a/redirects/5.0/concepts/intrans-metadata-create-index.html
+++ b/redirects/5.0/concepts/intrans-metadata-create-index.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.0/concepts/intrans-metadata-feature.html
+++ b/redirects/5.0/concepts/intrans-metadata-feature.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.0/concepts/intrans-metadata-overview.html
+++ b/redirects/5.0/concepts/intrans-metadata-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/search-services/latest/config/transactional/

--- a/redirects/5.0/concepts/intrans-metadata-query.html
+++ b/redirects/5.0/concepts/intrans-metadata-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-model/
+/search-services/latest/using/

--- a/redirects/5.0/concepts/intrans-metadata.html
+++ b/redirects/5.0/concepts/intrans-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/search-fts-config.html
+++ b/redirects/5.0/concepts/search-fts-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/5.0/concepts/search-migration.html
+++ b/redirects/5.0/concepts/search-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/solr-SSL-keystores.html
+++ b/redirects/5.0/concepts/solr-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.0/concepts/solr-backup-recovery.html
+++ b/redirects/5.0/concepts/solr-backup-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/solr-benefits.html
+++ b/redirects/5.0/concepts/solr-benefits.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.0/concepts/solr-config-files.html
+++ b/redirects/5.0/concepts/solr-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/solr-event-consistency.html
+++ b/redirects/5.0/concepts/solr-event-consistency.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/search-services/latest/install/

--- a/redirects/5.0/concepts/solr-home.html
+++ b/redirects/5.0/concepts/solr-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/solr-index-fix.html
+++ b/redirects/5.0/concepts/solr-index-fix.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/5.0/concepts/solr-monitor-troubleshoot.html
+++ b/redirects/5.0/concepts/solr-monitor-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/solr-overview.html
+++ b/redirects/5.0/concepts/solr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/solr-replication-adv.html
+++ b/redirects/5.0/concepts/solr-replication-adv.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/search-services/latest/config/replication/

--- a/redirects/5.0/concepts/solr-replication-conf.html
+++ b/redirects/5.0/concepts/solr-replication-conf.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/replication/

--- a/redirects/5.0/concepts/solr-replication.html
+++ b/redirects/5.0/concepts/solr-replication.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/search-services/latest/config/replication/

--- a/redirects/5.0/concepts/solr-repo-SSL-keystores.html
+++ b/redirects/5.0/concepts/solr-repo-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest

--- a/redirects/5.0/concepts/solr-troubleshooting.html
+++ b/redirects/5.0/concepts/solr-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/solr-unindex.html
+++ b/redirects/5.0/concepts/solr-unindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/5.0/concepts/solr4-config-files.html
+++ b/redirects/5.0/concepts/solr4-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/solr4-considerations.html
+++ b/redirects/5.0/concepts/solr4-considerations.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/install/

--- a/redirects/5.0/concepts/solr4-directory.html
+++ b/redirects/5.0/concepts/solr4-directory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/search-services/latest/config/

--- a/redirects/5.0/concepts/solr4-subsystem.html
+++ b/redirects/5.0/concepts/solr4-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.0/concepts/solradmin-center.html
+++ b/redirects/5.0/concepts/solradmin-center.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/concepts/solradmin-left.html
+++ b/redirects/5.0/concepts/solradmin-left.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/security/

--- a/redirects/5.0/concepts/solrcore-properties-file.html
+++ b/redirects/5.0/concepts/solrcore-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/config/properties/

--- a/redirects/5.0/concepts/solrcore4-properties-file.html
+++ b/redirects/5.0/concepts/solrcore4-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/properties/

--- a/redirects/5.0/concepts/solrnodes-memory.html
+++ b/redirects/5.0/concepts/solrnodes-memory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/search-services/latest/using/

--- a/redirects/5.0/concepts/solrsecurity-intro.html
+++ b/redirects/5.0/concepts/solrsecurity-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/tasks/adminconsole-searchservice-solr.html
+++ b/redirects/5.0/tasks/adminconsole-searchservice-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/properties/

--- a/redirects/5.0/tasks/adminconsole-searchservice-solr4.html
+++ b/redirects/5.0/tasks/adminconsole-searchservice-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/properties/

--- a/redirects/5.0/tasks/alf-weblogic-solr-config.html
+++ b/redirects/5.0/tasks/alf-weblogic-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/tasks/alf-websphere-solr-config.html
+++ b/redirects/5.0/tasks/alf-websphere-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/keys/

--- a/redirects/5.0/tasks/alfresco-sdk-advanced-configure-ssl-repo-solr.html
+++ b/redirects/5.0/tasks/alfresco-sdk-advanced-configure-ssl-repo-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/search-services/latest/install/options/

--- a/redirects/5.0/tasks/generate-keys-solr4.html
+++ b/redirects/5.0/tasks/generate-keys-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/search-services/latest/config/security/

--- a/redirects/5.0/tasks/googledocs-Weblogic-solr-publishing.html
+++ b/redirects/5.0/tasks/googledocs-Weblogic-solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/tasks/lucene-solr4-migration.html
+++ b/redirects/5.0/tasks/lucene-solr4-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/tasks/set-solr-log4j.html
+++ b/redirects/5.0/tasks/set-solr-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/install/options/

--- a/redirects/5.0/tasks/solr-backup.html
+++ b/redirects/5.0/tasks/solr-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.0/tasks/solr-jboss-install.html
+++ b/redirects/5.0/tasks/solr-jboss-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/5.0/tasks/solr-recovery.html
+++ b/redirects/5.0/tasks/solr-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/tasks/solr-reindex.html
+++ b/redirects/5.0/tasks/solr-reindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.0/tasks/solr-solr4-migration.html
+++ b/redirects/5.0/tasks/solr-solr4-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.0/tasks/solr-tomcat-install.html
+++ b/redirects/5.0/tasks/solr-tomcat-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/5.0/tasks/solr4-alfresco-config.html
+++ b/redirects/5.0/tasks/solr4-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.0/tasks/solr4-install-config.html
+++ b/redirects/5.0/tasks/solr4-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.0/tasks/ssl-protect-solrwebapp.html
+++ b/redirects/5.0/tasks/ssl-protect-solrwebapp.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/security/

--- a/redirects/5.0/tasks/upgrade-solr1.html
+++ b/redirects/5.0/tasks/upgrade-solr1.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/tomcat/
+/search-services/latest/config/

--- a/redirects/5.1/concepts/configure-solr4.html
+++ b/redirects/5.1/concepts/configure-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/5.1/concepts/intrans-metadata-conf-patch.html
+++ b/redirects/5.1/concepts/intrans-metadata-conf-patch.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.1/concepts/intrans-metadata-configure.html
+++ b/redirects/5.1/concepts/intrans-metadata-configure.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/properties/

--- a/redirects/5.1/concepts/intrans-metadata-create-index.html
+++ b/redirects/5.1/concepts/intrans-metadata-create-index.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.1/concepts/intrans-metadata-feature.html
+++ b/redirects/5.1/concepts/intrans-metadata-feature.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.1/concepts/intrans-metadata-overview.html
+++ b/redirects/5.1/concepts/intrans-metadata-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.1/concepts/intrans-metadata-query.html
+++ b/redirects/5.1/concepts/intrans-metadata-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-model/
+/search-services/latest/using/

--- a/redirects/5.1/concepts/intrans-metadata.html
+++ b/redirects/5.1/concepts/intrans-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/search-services/latest/config/

--- a/redirects/5.1/concepts/search-fts-config.html
+++ b/redirects/5.1/concepts/search-fts-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/5.1/concepts/search-migration.html
+++ b/redirects/5.1/concepts/search-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/concepts/solr-SSL-keystores.html
+++ b/redirects/5.1/concepts/solr-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.1/concepts/solr-backup-recovery.html
+++ b/redirects/5.1/concepts/solr-backup-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/concepts/solr-benefits.html
+++ b/redirects/5.1/concepts/solr-benefits.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.1/concepts/solr-core-templates.html
+++ b/redirects/5.1/concepts/solr-core-templates.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/search-services/latest/admin/

--- a/redirects/5.1/concepts/solr-event-consistency.html
+++ b/redirects/5.1/concepts/solr-event-consistency.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/search-services/latest/install/

--- a/redirects/5.1/concepts/solr-home.html
+++ b/redirects/5.1/concepts/solr-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/security/

--- a/redirects/5.1/concepts/solr-index-fix.html
+++ b/redirects/5.1/concepts/solr-index-fix.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/5.1/concepts/solr-monitor-troubleshoot.html
+++ b/redirects/5.1/concepts/solr-monitor-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/concepts/solr-overview.html
+++ b/redirects/5.1/concepts/solr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/concepts/solr-replication-adv.html
+++ b/redirects/5.1/concepts/solr-replication-adv.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/search-services/latest/config/replication/

--- a/redirects/5.1/concepts/solr-replication-conf.html
+++ b/redirects/5.1/concepts/solr-replication-conf.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/replication/

--- a/redirects/5.1/concepts/solr-replication.html
+++ b/redirects/5.1/concepts/solr-replication.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/search-services/latest/config/replication/

--- a/redirects/5.1/concepts/solr-repo-SSL-keystores.html
+++ b/redirects/5.1/concepts/solr-repo-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/

--- a/redirects/5.1/concepts/solr-shard-config.html
+++ b/redirects/5.1/concepts/solr-shard-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/

--- a/redirects/5.1/concepts/solr-shard-overview.html
+++ b/redirects/5.1/concepts/solr-shard-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/search-services/latest/install/

--- a/redirects/5.1/concepts/solr-shard-terms.html
+++ b/redirects/5.1/concepts/solr-shard-terms.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/search-services/latest/install/

--- a/redirects/5.1/concepts/solr-shared-properties.html
+++ b/redirects/5.1/concepts/solr-shared-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.1/concepts/solr-troubleshooting.html
+++ b/redirects/5.1/concepts/solr-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/concepts/solr-unindex.html
+++ b/redirects/5.1/concepts/solr-unindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/5.1/concepts/solr4-config-files.html
+++ b/redirects/5.1/concepts/solr4-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/5.1/concepts/solr4-considerations.html
+++ b/redirects/5.1/concepts/solr4-considerations.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/install/

--- a/redirects/5.1/concepts/solr4-directory.html
+++ b/redirects/5.1/concepts/solr4-directory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/search-services/latest/config/

--- a/redirects/5.1/concepts/solr4-subsystem.html
+++ b/redirects/5.1/concepts/solr4-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.1/concepts/solradmin-center.html
+++ b/redirects/5.1/concepts/solradmin-center.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/search-services/latest/config/security/

--- a/redirects/5.1/concepts/solrcore4-properties-file.html
+++ b/redirects/5.1/concepts/solrcore4-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/properties/

--- a/redirects/5.1/concepts/solrnodes-memory.html
+++ b/redirects/5.1/concepts/solrnodes-memory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/search-services/latest/config/transactional/

--- a/redirects/5.1/concepts/solrsecurity-intro.html
+++ b/redirects/5.1/concepts/solrsecurity-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/tasks/adminconsole-searchservice-solr4.html
+++ b/redirects/5.1/tasks/adminconsole-searchservice-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/properties/

--- a/redirects/5.1/tasks/alf-weblogic-solr-config.html
+++ b/redirects/5.1/tasks/alf-weblogic-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/tasks/alf-websphere-solr-config.html
+++ b/redirects/5.1/tasks/alf-websphere-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/keys/

--- a/redirects/5.1/tasks/alfresco-sdk-advanced-configure-ssl-repo-solr.html
+++ b/redirects/5.1/tasks/alfresco-sdk-advanced-configure-ssl-repo-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/search-services/latest/install/options/

--- a/redirects/5.1/tasks/generate-keys-solr4.html
+++ b/redirects/5.1/tasks/generate-keys-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/search-services/latest/config/security/

--- a/redirects/5.1/tasks/googledocs-Weblogic-solr-publishing.html
+++ b/redirects/5.1/tasks/googledocs-Weblogic-solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/tasks/install-solr-shards.html
+++ b/redirects/5.1/tasks/install-solr-shards.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/lucene-solr4-migration.html
+++ b/redirects/5.1/tasks/lucene-solr4-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/tasks/search_permissions_check.html
+++ b/redirects/5.1/tasks/search_permissions_check.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/search-services/latest/install/

--- a/redirects/5.1/tasks/set-solr-log4j.html
+++ b/redirects/5.1/tasks/set-solr-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/activemq/
+/search-services/latest/install/options/

--- a/redirects/5.1/tasks/solr-backup.html
+++ b/redirects/5.1/tasks/solr-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/solr-hash-shard.html
+++ b/redirects/5.1/tasks/solr-hash-shard.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/solr-jboss-install.html
+++ b/redirects/5.1/tasks/solr-jboss-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/5.1/tasks/solr-recovery.html
+++ b/redirects/5.1/tasks/solr-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/solr-reindex.html
+++ b/redirects/5.1/tasks/solr-reindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/solr-solr4-migration.html
+++ b/redirects/5.1/tasks/solr-solr4-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.1/tasks/solr-tomcat-install.html
+++ b/redirects/5.1/tasks/solr-tomcat-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/5.1/tasks/solr4-alfresco-config.html
+++ b/redirects/5.1/tasks/solr4-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/solr4-install-config.html
+++ b/redirects/5.1/tasks/solr4-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.1/tasks/ssl-protect-solrwebapp.html
+++ b/redirects/5.1/tasks/ssl-protect-solrwebapp.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/security/

--- a/redirects/5.1/tasks/upgrade-solr1.html
+++ b/redirects/5.1/tasks/upgrade-solr1.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest/config/

--- a/redirects/5.2/concepts/configure-solr4.html
+++ b/redirects/5.2/concepts/configure-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/external-properties-solr6.html
+++ b/redirects/5.2/concepts/external-properties-solr6.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/intrans-metadata-conf-patch.html
+++ b/redirects/5.2/concepts/intrans-metadata-conf-patch.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/intrans-metadata-configure.html
+++ b/redirects/5.2/concepts/intrans-metadata-configure.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/properties/

--- a/redirects/5.2/concepts/intrans-metadata-create-index.html
+++ b/redirects/5.2/concepts/intrans-metadata-create-index.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/intrans-metadata-feature.html
+++ b/redirects/5.2/concepts/intrans-metadata-feature.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/intrans-metadata-overview.html
+++ b/redirects/5.2/concepts/intrans-metadata-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/intrans-metadata-query.html
+++ b/redirects/5.2/concepts/intrans-metadata-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-model/
+/search-services/latest/using/

--- a/redirects/5.2/concepts/intrans-metadata.html
+++ b/redirects/5.2/concepts/intrans-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/search-api-defaults.html
+++ b/redirects/5.2/concepts/search-api-defaults.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-facetFields.html
+++ b/redirects/5.2/concepts/search-api-facetFields.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-facetIntervals.html
+++ b/redirects/5.2/concepts/search-api-facetIntervals.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-facetQueries.html
+++ b/redirects/5.2/concepts/search-api-facetQueries.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-fields.html
+++ b/redirects/5.2/concepts/search-api-fields.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/search-services/latest/using/

--- a/redirects/5.2/concepts/search-api-filterQueries.html
+++ b/redirects/5.2/concepts/search-api-filterQueries.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-highlight.html
+++ b/redirects/5.2/concepts/search-api-highlight.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-include.html
+++ b/redirects/5.2/concepts/search-api-include.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-includeRequest.html
+++ b/redirects/5.2/concepts/search-api-includeRequest.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-limits.html
+++ b/redirects/5.2/concepts/search-api-limits.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/metadata-extractors/
+/search-services/latest/config/filtered/

--- a/redirects/5.2/concepts/search-api-paging.html
+++ b/redirects/5.2/concepts/search-api-paging.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-pivots.html
+++ b/redirects/5.2/concepts/search-api-pivots.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-query.html
+++ b/redirects/5.2/concepts/search-api-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-range.html
+++ b/redirects/5.2/concepts/search-api-range.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-scope.html
+++ b/redirects/5.2/concepts/search-api-scope.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm/
+/search-services/latest/config/filtered/

--- a/redirects/5.2/concepts/search-api-sort.html
+++ b/redirects/5.2/concepts/search-api-sort.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/search-services/latest/using/

--- a/redirects/5.2/concepts/search-api-spellcheck.html
+++ b/redirects/5.2/concepts/search-api-spellcheck.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-stats.html
+++ b/redirects/5.2/concepts/search-api-stats.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/search-services/latest/admin/restapi/

--- a/redirects/5.2/concepts/search-api-templates.html
+++ b/redirects/5.2/concepts/search-api-templates.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/search-services/latest

--- a/redirects/5.2/concepts/search-api-timezone.html
+++ b/redirects/5.2/concepts/search-api-timezone.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.2/concepts/search-api.html
+++ b/redirects/5.2/concepts/search-api.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/search-fts-config.html
+++ b/redirects/5.2/concepts/search-fts-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/search-home.html
+++ b/redirects/5.2/concepts/search-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/

--- a/redirects/5.2/concepts/search-migration.html
+++ b/redirects/5.2/concepts/search-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/

--- a/redirects/5.2/concepts/solr-SSL-keystores.html
+++ b/redirects/5.2/concepts/solr-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.2/concepts/solr-backup-recovery.html
+++ b/redirects/5.2/concepts/solr-backup-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/concepts/solr-benefits.html
+++ b/redirects/5.2/concepts/solr-benefits.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.2/concepts/solr-core-templates.html
+++ b/redirects/5.2/concepts/solr-core-templates.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/search-services/latest/admin/

--- a/redirects/5.2/concepts/solr-event-consistency.html
+++ b/redirects/5.2/concepts/solr-event-consistency.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/install/

--- a/redirects/5.2/concepts/solr-home.html
+++ b/redirects/5.2/concepts/solr-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/config/security/

--- a/redirects/5.2/concepts/solr-index-fix.html
+++ b/redirects/5.2/concepts/solr-index-fix.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/5.2/concepts/solr-monitor-troubleshoot.html
+++ b/redirects/5.2/concepts/solr-monitor-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/concepts/solr-overview.html
+++ b/redirects/5.2/concepts/solr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/

--- a/redirects/5.2/concepts/solr-replication-adv.html
+++ b/redirects/5.2/concepts/solr-replication-adv.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/search-services/latest/config/replication/

--- a/redirects/5.2/concepts/solr-replication-conf.html
+++ b/redirects/5.2/concepts/solr-replication-conf.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/replication/

--- a/redirects/5.2/concepts/solr-replication.html
+++ b/redirects/5.2/concepts/solr-replication.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/search-services/latest/config/replication/

--- a/redirects/5.2/concepts/solr-repo-SSL-keystores.html
+++ b/redirects/5.2/concepts/solr-repo-SSL-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/solr-shard-config.html
+++ b/redirects/5.2/concepts/solr-shard-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/

--- a/redirects/5.2/concepts/solr-shard-overview.html
+++ b/redirects/5.2/concepts/solr-shard-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/search-services/latest/install/

--- a/redirects/5.2/concepts/solr-shard-terms.html
+++ b/redirects/5.2/concepts/solr-shard-terms.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/search-services/latest/install/

--- a/redirects/5.2/concepts/solr-shared-properties.html
+++ b/redirects/5.2/concepts/solr-shared-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/transactional/

--- a/redirects/5.2/concepts/solr-troubleshooting.html
+++ b/redirects/5.2/concepts/solr-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/concepts/solr-unindex.html
+++ b/redirects/5.2/concepts/solr-unindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/admin/monitor/

--- a/redirects/5.2/concepts/solr4-config-files.html
+++ b/redirects/5.2/concepts/solr4-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/solr4-considerations.html
+++ b/redirects/5.2/concepts/solr4-considerations.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/search-services/latest/install/

--- a/redirects/5.2/concepts/solr4-directory.html
+++ b/redirects/5.2/concepts/solr4-directory.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/solr4-subsystem.html
+++ b/redirects/5.2/concepts/solr4-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest

--- a/redirects/5.2/concepts/solr6-directories.html
+++ b/redirects/5.2/concepts/solr6-directories.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/tomcat/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/solr6-home.html
+++ b/redirects/5.2/concepts/solr6-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/

--- a/redirects/5.2/concepts/solr6-install-config.html
+++ b/redirects/5.2/concepts/solr6-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/

--- a/redirects/5.2/concepts/solr6-overview.html
+++ b/redirects/5.2/concepts/solr6-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/search-services/latest/admin/

--- a/redirects/5.2/concepts/solr6-shard-approaches.html
+++ b/redirects/5.2/concepts/solr6-shard-approaches.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/admin/

--- a/redirects/5.2/concepts/solr6-subsystem.html
+++ b/redirects/5.2/concepts/solr6-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.2/concepts/solradmin-center.html
+++ b/redirects/5.2/concepts/solradmin-center.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/search-services/latest/config/security/

--- a/redirects/5.2/concepts/solradmin-left.html
+++ b/redirects/5.2/concepts/solradmin-left.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/search-services/latest/config/security/

--- a/redirects/5.2/concepts/solrcore4-properties-file.html
+++ b/redirects/5.2/concepts/solrcore4-properties-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/config/properties/

--- a/redirects/5.2/concepts/solrsecurity-intro.html
+++ b/redirects/5.2/concepts/solrsecurity-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/tasks/adminconsole-searchservice-solr4.html
+++ b/redirects/5.2/tasks/adminconsole-searchservice-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/properties/

--- a/redirects/5.2/tasks/adminconsole-searchservice-solr6.html
+++ b/redirects/5.2/tasks/adminconsole-searchservice-solr6.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/properties/

--- a/redirects/5.2/tasks/alf-weblogic-solr-config.html
+++ b/redirects/5.2/tasks/alf-weblogic-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/tasks/alf-websphere-solr-config.html
+++ b/redirects/5.2/tasks/alf-websphere-solr-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/search-services/latest/config/keys/

--- a/redirects/5.2/tasks/generate-keys-solr4.html
+++ b/redirects/5.2/tasks/generate-keys-solr4.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/search-services/latest/config/security/

--- a/redirects/5.2/tasks/googledocs-Weblogic-solr-publishing.html
+++ b/redirects/5.2/tasks/googledocs-Weblogic-solr-publishing.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/tasks/install-config-solr.html
+++ b/redirects/5.2/tasks/install-config-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/search-services/latest/install/options/

--- a/redirects/5.2/tasks/install-solr-shards.html
+++ b/redirects/5.2/tasks/install-solr-shards.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/lucene-solr4-migration.html
+++ b/redirects/5.2/tasks/lucene-solr4-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/tasks/search_permissions_check.html
+++ b/redirects/5.2/tasks/search_permissions_check.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/search-services/latest/install/

--- a/redirects/5.2/tasks/set-solr-log4j.html
+++ b/redirects/5.2/tasks/set-solr-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/activemq/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr-backup.html
+++ b/redirects/5.2/tasks/solr-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr-hash-shard.html
+++ b/redirects/5.2/tasks/solr-hash-shard.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr-jboss-install.html
+++ b/redirects/5.2/tasks/solr-jboss-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/5.2/tasks/solr-recovery.html
+++ b/redirects/5.2/tasks/solr-recovery.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr-reindex.html
+++ b/redirects/5.2/tasks/solr-reindex.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr-solr4-migration.html
+++ b/redirects/5.2/tasks/solr-solr4-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/tasks/solr-tomcat-install.html
+++ b/redirects/5.2/tasks/solr-tomcat-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/search-services/latest/install/options/

--- a/redirects/5.2/tasks/solr4-alfresco-config.html
+++ b/redirects/5.2/tasks/solr4-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr4-install-config.html
+++ b/redirects/5.2/tasks/solr4-install-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr4-solr6-migration.html
+++ b/redirects/5.2/tasks/solr4-solr6-migration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/upgrade/migrate/

--- a/redirects/5.2/tasks/solr6-backup.html
+++ b/redirects/5.2/tasks/solr6-backup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/search-services/latest/config/

--- a/redirects/5.2/tasks/solr6-install-withoutSSL.html
+++ b/redirects/5.2/tasks/solr6-install-withoutSSL.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/search-services/latest/install/options/

--- a/redirects/5.2/tasks/solr6-install.html
+++ b/redirects/5.2/tasks/solr6-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/search-services/latest/install/options/

--- a/redirects/5.2/tasks/ssl-protect-solrwebapp.html
+++ b/redirects/5.2/tasks/ssl-protect-solrwebapp.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/search-services/latest/config/security/

--- a/redirects/5.2/tasks/upgrade-solr1.html
+++ b/redirects/5.2/tasks/upgrade-solr1.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/search-services/latest/config/


### PR DESCRIPTION
Search Services docs used to be embedded in Content Services. This PR attempts to update the legacy redirects to correctly redirect uses to Search Services rather than Content Services.