### PR TITLE
Remove File Transfer Receiver from Installation

### DIFF
--- a/content-services/community/install/zip/index.md
+++ b/content-services/community/install/zip/index.md
@@ -61,7 +61,6 @@ Here's a list of the files to download and install.
 | alfresco-content-services-community-distribution-6.2.0-ga.zip | Community Edition distribution zip for new installations or upgrades. Alfresco WAR files (in distribution zip) for a manual install into an existing Tomcat application server. This distribution zip also contains the Module Management Tool (MMT) and the sample extension files, such as `alfresco-global.properties`. |
 |alfresco-search-services-1.4.x.zip | Alfresco Search Services distribution zip.<br><br>See [Install Alfresco Search Services]({% link search-services/latest/install/index.md %}) for more information. |
 
-
 ## Preparing the filesystem and database
 
 These steps describe how to prepare a suitable location for data storage and the database.

--- a/content-services/community/install/zip/index.md
+++ b/content-services/community/install/zip/index.md
@@ -60,7 +60,7 @@ Here's a list of the files to download and install.
 | ---- | ----------- |
 | alfresco-content-services-community-distribution-6.2.0-ga.zip | Community Edition distribution zip for new installations or upgrades. Alfresco WAR files (in distribution zip) for a manual install into an existing Tomcat application server. This distribution zip also contains the Module Management Tool (MMT) and the sample extension files, such as `alfresco-global.properties`. |
 |alfresco-search-services-1.4.x.zip | Alfresco Search Services distribution zip.<br><br>See [Install Alfresco Search Services]({% link search-services/latest/install/index.md %}) for more information. |
-| alfresco-file-transfer-receiver-6.2.1.zip | File Transfer Receiver installation file. The File System Transfer Receiver transfers folders and content from an Community Edition core repository (the DM) to configured targets using the Transfer Service, for example, a remote file system.<br><br>See [Configure the File System Transfer Receiver]({% link content-services/community/admin/import-transfer.md %}#configure-file-system-transfer-receiver) for more information. |
+
 
 ## Preparing the filesystem and database
 


### PR DESCRIPTION
FTR is an optional extra component that is not necessary in the core installation. It is covered elsewhere in the docs.