### PR TITLE
Required namespace prefix for reindexing documents by query

### DIFF
--- a/insight-engine/latest/config/sharding/create.md
+++ b/insight-engine/latest/config/sharding/create.md
@@ -883,7 +883,7 @@ You can selectively reindex a small subset of the index based on a query. This e
 Example 1: To reindex people after changing the first name and last name tokenisation, use the following single-threaded query:
 
 ```http
-http://localhost:8983/solr/admin/cores?action=reindex&query=TYPE:person
+http://localhost:8983/solr/admin/cores?action=reindex&query=TYPE:"cm:person"
 ```
 
 Example 2: To reindex jobs that failed or threw an exception when indexing, use the following query:


### PR DESCRIPTION
Added "cm" prefix to reindex by query sample.