### PR TITLE
[DOCS-6177] Fix redirects for 6.x Supported Platforms pages

### DIFF
--- a/content-services/latest/index.md
+++ b/content-services/latest/index.md
@@ -16,3 +16,5 @@ Some of the key capabilities of Content Service include:
 Alfresco customers should also take a look at the [Alfresco Support Handbook]({% link support/latest/index.md %}).
 
 > **Note:** See the [Supported platforms]({% link content-services/latest/support/index.md %}) page for compatibility between Content Services and other applications.
+
+> **Important:** You can navigate through older versions of this content, such as Content Services 5.2 and earlier, in the [Legacy documentation](https://github.com/Alfresco/docs-alfresco/blob/master/_archive){:target="_blank"}.

--- a/redirects/6.0/concepts/supported-platforms-ACS.html
+++ b/redirects/6.0/concepts/supported-platforms-ACS.html
@@ -1,1 +1,1 @@
-/content-services/6.0
+/content-services/6.0/support/

--- a/redirects/6.1/concepts/supported-platforms-ACS.html
+++ b/redirects/6.1/concepts/supported-platforms-ACS.html
@@ -1,1 +1,1 @@
-/content-services/6.1
+/content-services/6.1/support/

--- a/redirects/6.2/concepts/supported-platforms-ACS.html
+++ b/redirects/6.2/concepts/supported-platforms-ACS.html
@@ -1,1 +1,1 @@
-/content-services/latest
+/content-services/latest/support/


### PR DESCRIPTION
- Improve redirects for ACS 6.x Supported platforms pages.
- Add link to "Legacy documentation" from the `/latest` ACS landing page, so that customers can navigate the documentation for ACS 5.2 and earlier versions.