### PR TITLE
Update ACS helm chart docs

### DIFF
--- a/content-services/6.0/install/containers/helm.md
+++ b/content-services/6.0/install/containers/helm.md
@@ -37,7 +37,7 @@ The [Docker Compose customization guidelines]({% link content-services/6.0/insta
 Once you've created your custom image, you can either change the default values in the appropriate values file in the [helm/alfresco-content-services folder](https://github.com/Alfresco/acs-deployment/tree/master/helm/alfresco-content-services){:target="_blank"}, or you can override the values via the `--set` command-line option during the install:
 
 ```bash
-helm install alfresco-incubator/alfresco-content-services --set repository.image.repository="yourRegistry" --set repository.image.tag="yourTag" --set share.image.repository="yourRegistry" --set share.image.tag="yourTag"
+helm install alfresco/alfresco-content-services --set repository.image.repository="yourRegistry" --set repository.image.tag="yourTag" --set share.image.repository="yourRegistry" --set share.image.tag="yourTag"
 ```
 
 ## Helm deployment with AWS EKS
@@ -62,12 +62,11 @@ Follow the [AWS EKS Getting Started Guide](https://docs.aws.amazon.com/eks/lates
 
 As we'll be using Helm to deploy the Content Services chart, follow the [Using Helm with EKS](https://docs.aws.amazon.com/eks/latest/userguide/helm.html){:target="_blank"} instructions to set up Helm on your local machine.
 
-Helm also needs to know where to find charts. Run the following commands to add the standard Helm repository and the Alfresco incubator and stable repositories to your machine:
+Helm also needs to know where to find charts. Run the following commands to add the Nginx ingress and Alfresco repositories to your machine:
 
 ```bash
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
-helm repo add alfresco-incubator https://kubernetes-charts.alfresco.com/incubator
+helm repo add alfresco https://kubernetes-charts.alfresco.com/stable
 ```
 
 Optionally, follow the tutorial to [deploy the Kubernetes Dashboard](https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html){:target="_blank"}  to your cluster. This can be really useful for troubleshooting issues that you may occur.
@@ -293,7 +292,7 @@ Decide whether you want to install the latest version of Content Services (Enter
 Deploy the latest version of Content Services by running the following command (replace `YOUR-DOMAIN-NAME` with the hosted zone you created earlier):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -314,7 +313,7 @@ helm install acs alfresco-incubator/alfresco-content-services \
 2. Deploy the specific version of Content Services by running the following command (replace `YOUR-DOMAIN-NAME` with the hosted zone you created earlier, and `MAJOR` & `MINOR` with the appropriate values):
 
     ```bash
-    helm install acs alfresco-incubator/alfresco-content-services \
+    helm install acs alfresco/alfresco-content-services \
     --values=MAJOR.MINOR.N_values.yaml \
     --set externalPort="443" \
     --set externalProtocol="https" \

--- a/content-services/6.1/install/containers/helm-examples.md
+++ b/content-services/6.1/install/containers/helm-examples.md
@@ -117,7 +117,7 @@ To use the S3 Connector, RDS, and Amazon MQ, we have to disable the internal def
 When we bring all this together, you can deploy Content Services using the command below (replace all the `YOUR-XZY` properties with the values gathered during the setup of the services):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -171,7 +171,7 @@ Follow the steps to [set up an IAM user and an S3 bucket]({% link intelligence-s
 When we bring all this together, you can deploy Content Services using the command below (replace all the `YOUR-XZY` properties with the values gathered during the setup of the services):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -226,7 +226,7 @@ Follow the [EKS deployment]({% link content-services/6.1/install/containers/helm
 Deploy the latest version of Content Services (Enterprise) by running the command below. You'll need to replace `YOUR-DOMAIN-NAME` with the hosted zone you created previously, and replace `YOUR-BASIC-AUTH` and `YOUR-IPS` with the encoded basic authentication string and list of whitelisted IP addresses you prepared in the previous section.
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -247,7 +247,7 @@ helm install acs alfresco-incubator/alfresco-content-services \
 If you've previously deployed Content Services where external Search access was disabled (the default), you can run the following `helm upgrade` command to enable external access for `/solr` (replace `YOUR-BASIC-AUTH` and `YOUR-IPS` with the encoded basic authentication string, and list of whitelisted IP addresses you [prepared earlier](#prepare-data):
 
 ```bash
-helm upgrade acs alfresco-incubator/alfresco-content-services \
+helm upgrade acs alfresco/alfresco-content-services \
 --set alfresco-search.ingress.enabled=true \
 --set alfresco-search.ingress.basicAuth="YOUR-BASIC-AUTH" \
 --set alfresco-search.ingress.whitelist_ips="YOUR_IPS" \
@@ -303,7 +303,7 @@ kubectl create secret tls your-cert-secret --key privkey.pem --cert fullchain.pe
 Deploy the latest version of Content Services Enterprise by running the command below (replace `YOUR-DOMAIN-NAME` with the hosted zone you created, and replace the email values accordingly). See the table of [configuration options]({% link content-services/6.1/install/containers/helm.md %}#configuration-options) for the full list of available options.
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \

--- a/content-services/6.1/install/containers/helm.md
+++ b/content-services/6.1/install/containers/helm.md
@@ -49,7 +49,7 @@ The [Docker Compose customization guidelines]({% link content-services/6.1/insta
 Once you've created your custom image, you can either change the default values in the appropriate values file in the [helm/alfresco-content-services folder](https://github.com/Alfresco/acs-deployment/tree/master/helm/alfresco-content-services){:target="_blank"}, or you can override the values via the `--set` command-line option during the install:
 
 ```bash
-helm install alfresco-incubator/alfresco-content-services --set repository.image.repository="yourRegistry" --set repository.image.tag="yourTag" --set share.image.repository="yourRegistry" --set share.image.tag="yourTag"
+helm install alfresco/alfresco-content-services --set repository.image.repository="yourRegistry" --set repository.image.tag="yourTag" --set share.image.repository="yourRegistry" --set share.image.tag="yourTag"
 ```
 
 ## Helm deployment with AWS EKS
@@ -74,12 +74,11 @@ Follow the [AWS EKS Getting Started Guide](https://docs.aws.amazon.com/eks/lates
 
 As we'll be using Helm to deploy the Content Services chart, follow the [Using Helm with EKS](https://docs.aws.amazon.com/eks/latest/userguide/helm.html){:target="_blank"} instructions to set up Helm on your local machine.
 
-Helm also needs to know where to find charts. Run the following commands to add the standard Helm repository and the Alfresco incubator and stable repositories to your machine:
+Helm also needs to know where to find charts. Run the following commands to add the Nginx ingress and Alfresco repositories to your machine:
 
 ```bash
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
-helm repo add alfresco-incubator https://kubernetes-charts.alfresco.com/incubator
+helm repo add alfresco https://kubernetes-charts.alfresco.com/stable
 ```
 
 Optionally, follow the tutorial to [deploy the Kubernetes Dashboard](https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html){:target="_blank"}  to your cluster. This can be really useful for troubleshooting issues that you may occur.
@@ -313,7 +312,7 @@ Decide whether you want to install the latest version of Content Services (Enter
 Deploy the latest version of Content Services by running the following command (replace `YOUR-DOMAIN-NAME` with the hosted zone you created earlier):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -335,7 +334,7 @@ helm install acs alfresco-incubator/alfresco-content-services \
 2. Deploy the specific version of Content Services by running the following command (replace `YOUR-DOMAIN-NAME` with the hosted zone you created earlier, and `MAJOR` & `MINOR` with the appropriate values):
 
     ```bash
-    helm install acs alfresco-incubator/alfresco-content-services \
+    helm install acs alfresco/alfresco-content-services \
     --values=MAJOR.MINOR.N_values.yaml \
     --set externalPort="443" \
     --set externalProtocol="https" \

--- a/content-services/latest/install/containers/helm-examples.md
+++ b/content-services/latest/install/containers/helm-examples.md
@@ -117,7 +117,7 @@ To use the S3 Connector, RDS, and Amazon MQ, we have to disable the internal def
 When we bring all this together, you can deploy Content Services using the command below (replace all the `YOUR-XZY` properties with the values gathered during the setup of the services):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -171,7 +171,7 @@ Follow the steps to [set up an IAM user and an S3 bucket]({% link intelligence-s
 When we bring all this together, you can deploy Content Services using the command below (replace all the `YOUR-XZY` properties with the values gathered during the setup of the services):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -226,7 +226,7 @@ Follow the [EKS deployment]({% link content-services/latest/install/containers/h
 Deploy the latest version of Content Services (Enterprise) by running the command below. You'll need to replace `YOUR-DOMAIN-NAME` with the hosted zone you created previously, and replace `YOUR-BASIC-AUTH` and `YOUR-IPS` with the encoded basic authentication string and list of whitelisted IP addresses you prepared in the previous section.
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -247,7 +247,7 @@ helm install acs alfresco-incubator/alfresco-content-services \
 If you've previously deployed Content Services where external Search access was disabled (the default), you can run the following `helm upgrade` command to enable external access for `/solr` (replace `YOUR-BASIC-AUTH` and `YOUR-IPS` with the encoded basic authentication string, and list of whitelisted IP addresses you [prepared earlier](#prepare-data):
 
 ```bash
-helm upgrade acs alfresco-incubator/alfresco-content-services \
+helm upgrade acs alfresco/alfresco-content-services \
 --set alfresco-search.ingress.enabled=true \
 --set alfresco-search.ingress.basicAuth="YOUR-BASIC-AUTH" \
 --set alfresco-search.ingress.whitelist_ips="YOUR_IPS" \
@@ -303,7 +303,7 @@ kubectl create secret tls your-cert-secret --key privkey.pem --cert fullchain.pe
 Deploy the latest version of Content Services Enterprise by running the command below (replace `YOUR-DOMAIN-NAME` with the hosted zone you created, and replace the email values accordingly). See the table of [configuration options]({% link content-services/latest/install/containers/helm.md %}#configuration-options) for the full list of available options.
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \

--- a/content-services/latest/install/containers/helm.md
+++ b/content-services/latest/install/containers/helm.md
@@ -49,7 +49,7 @@ The [Docker Compose customization guidelines]({% link content-services/latest/in
 Once you've created your custom image, you can either change the default values in the appropriate values file in the [helm/alfresco-content-services folder](https://github.com/Alfresco/acs-deployment/tree/master/helm/alfresco-content-services){:target="_blank"}, or you can override the values via the `--set` command-line option during the install:
 
 ```bash
-helm install alfresco-incubator/alfresco-content-services --set repository.image.repository="yourRegistry" --set repository.image.tag="yourTag" --set share.image.repository="yourRegistry" --set share.image.tag="yourTag"
+helm install alfresco/alfresco-content-services --set repository.image.repository="yourRegistry" --set repository.image.tag="yourTag" --set share.image.repository="yourRegistry" --set share.image.tag="yourTag"
 ```
 
 ## Helm deployment with AWS EKS
@@ -74,12 +74,11 @@ Follow the [AWS EKS Getting Started Guide](https://docs.aws.amazon.com/eks/lates
 
 As we'll be using Helm to deploy the Content Services chart, follow the [Using Helm with EKS](https://docs.aws.amazon.com/eks/latest/userguide/helm.html){:target="_blank"} instructions to set up Helm on your local machine.
 
-Helm also needs to know where to find charts. Run the following commands to add the standard Helm repository and the Alfresco incubator and stable repositories to your machine:
+Helm also needs to know where to find charts. Run the following commands to add the Nginx ingress and Alfresco repositories to your machine:
 
 ```bash
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo add alfresco-stable https://kubernetes-charts.alfresco.com/stable
-helm repo add alfresco-incubator https://kubernetes-charts.alfresco.com/incubator
+helm repo add alfresco https://kubernetes-charts.alfresco.com/stable
 ```
 
 Optionally, follow the tutorial to [deploy the Kubernetes Dashboard](https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html){:target="_blank"}  to your cluster. This can be really useful for troubleshooting issues that you may occur.
@@ -313,7 +312,7 @@ Decide whether you want to install the latest version of Content Services (Enter
 Deploy the latest version of Content Services by running the following command (replace `YOUR-DOMAIN-NAME` with the hosted zone you created earlier):
 
 ```bash
-helm install acs alfresco-incubator/alfresco-content-services \
+helm install acs alfresco/alfresco-content-services \
 --set externalPort="443" \
 --set externalProtocol="https" \
 --set externalHost="acs.YOUR-DOMAIN-NAME" \
@@ -335,7 +334,7 @@ helm install acs alfresco-incubator/alfresco-content-services \
 2. Deploy the specific version of Content Services by running the following command (replace `YOUR-DOMAIN-NAME` with the hosted zone you created earlier, and `MAJOR` & `MINOR` with the appropriate values):
 
     ```bash
-    helm install acs alfresco-incubator/alfresco-content-services \
+    helm install acs alfresco/alfresco-content-services \
     --values=MAJOR.MINOR.N_values.yaml \
     --set externalPort="443" \
     --set externalProtocol="https" \


### PR DESCRIPTION
Now we have released a final stable release of the helm charts (5.0.0) we should not be directing people towards the incubator charts anymore.