### PR TITLE
[DOCS-6190] Fix links to new content

### DIFF
--- a/_data/toc/content-services.yaml
+++ b/_data/toc/content-services.yaml
@@ -307,6 +307,8 @@
               path: '/content-services/community/install/zip/amp/'
             - title: 'Install additional software'
               path: '/content-services/community/install/zip/additions/'
+        - title: 'Install with Ansible'
+          path: '/content-services/community/install/ansible/'
         - title: 'Install using containers'
           pages:
             - title: 'Overview'

--- a/content-services/community/install/index.md
+++ b/content-services/community/install/index.md
@@ -32,9 +32,9 @@ See [Install with zip]({% link content-services/community/install/zip/index.md %
 
 Ansible playbooks provide an automated way of deploying a complete Community Edition system on "bare metal" servers, Virtual Machines, or Virtual Private Cloud instances, without the use of containers. The single playbook provided can be configured to deploy single or multi-machine instances, with a number of supported configuration options.
 
-See [Install using Ansible](#LINK-content-services/community/install/ansible.md) for basic instructions on deploying with Ansible.
+See [Install using Ansible]({% link content-services/community/install/ansible.md %}) for basic instructions on deploying with Ansible.
 
-To explore more technical information on the ACS playbook, and to access the playbook source, see [Ansible on GitHub](#LINK-https://github.com/Alfresco/alfresco-ansible-deployment){:target="_blank"}.
+To explore more technical information on the ACS playbook, and to access the playbook source, see [Ansible on GitHub](https://github.com/Alfresco/alfresco-ansible-deployment){:target="_blank"}.
 
 The ACS Ansible playbook is provided as an Open Source reference script, which customers can modify and enhance to suit their own deployment environments.
 

--- a/content-services/latest/install/ansible.md
+++ b/content-services/latest/install/ansible.md
@@ -131,7 +131,7 @@ transformers_1             : ok=81   changed=10   unreachable=0    failed=0    s
 
 For details about the webapp URLs, location of logs, configuration etc., see [useful information](#usefulinfo).
 
-To secure your installation for production see this [information](#TODO_LINK content-services/latest/admin/securing-install.md).
+If you're deploying a production system, ensure that you review the additional information provided in [Securing your installation]({% link content-services/latest/admin/securing-install.md %}).
 
 ## Remote installation
 
@@ -200,7 +200,7 @@ transformers_1             : ok=81   changed=10   unreachable=0    failed=0    s
 
 For details about the webapp URLs, location of logs, configuration etc., see [useful information](#usefulinfo).
 
-To secure your installation for production see this [information](#TODO_LINK content-services/latest/admin/securing-install.md).
+If you're deploying a production system, ensure that you review the additional information provided in [Securing your installation]({% link content-services/latest/admin/securing-install.md %}).
 
 ### Multi-machine installation
 
@@ -250,7 +250,7 @@ transformers_1             : ok=81   changed=10   unreachable=0    failed=0    s
 
 For details about the webapp URLs, location of logs, configuration etc., see [useful information](#usefulinfo).
 
-To secure your installation for production see this [information](#TODO_LINK content-services/latest/admin/securing-install.md).
+If you're deploying a production system, ensure that you review the additional information provided in [Securing your installation]({% link content-services/latest/admin/securing-install.md %}).
 
 ## Useful information {#usefulinfo}
 

--- a/content-services/latest/install/index.md
+++ b/content-services/latest/install/index.md
@@ -32,9 +32,9 @@ See [Install with zip]({% link content-services/latest/install/zip/index.md %}) 
 
 Ansible playbooks provide an automated way of deploying a complete Content Services system on "bare metal" servers, Virtual Machines, or Virtual Private Cloud instances, without the use of containers. The single playbook provided can be configured to deploy single or multi-machine instances, with a number of supported configuration options.
 
-See [Install using Ansible](#LINK-content-services/latest/install/ansible.md) for basic instructions on deploying with Ansible.
+See [Install using Ansible]({% link content-services/latest/install/ansible.md %}) for basic instructions on deploying with Ansible.
 
-To explore more technical information on the ACS playbook, and to access the playbook source, see [Ansible on GitHub](#LINK-https://github.com/Alfresco/alfresco-ansible-deployment){:target="_blank"}.
+To explore more technical information on the ACS playbook, and to access the playbook source, see [Ansible on GitHub](https://github.com/Alfresco/alfresco-ansible-deployment){:target="_blank"}.
 
 The ACS Ansible playbook is provided as an Open Source reference script, which customers can modify and enhance to suit their own deployment environments.
 
@@ -70,4 +70,4 @@ See [Upgrade Content Services]({% link content-services/latest/upgrade/index.md 
 
 ## Security
 
-If you're deploying a production system, ensure that you review the additional information provided in [Securing your installation](#LINK-content-services/latest/admin/securing-install.md).
+If you're deploying a production system, ensure that you review the additional information provided in [Securing your installation]({% link content-services/latest/admin/securing-install.md %}).

--- a/content-services/latest/upgrade/index.md
+++ b/content-services/latest/upgrade/index.md
@@ -9,7 +9,7 @@ Before performing an upgrade or applying a Service Pack, make sure you check the
 Care should be taken when upgrading from any previous releases of Content Services or Community Edition. There are some steps that should be reviewed and planned before you upgrade. Familiarize yourself with the guidance below and then plan your upgrade. In particular, ensure that the following steps are completed before you start:
 
 * Ensure that you have a functional [backup of your Alfresco repository and database]({% link content-services/latest/admin/backup-restore.md %}), before starting the upgrade process.
-* Download and run the [Alfresco Extension Inspector](#LINK-content-services/latest/develop/extension-inspector.md) to understand which customization or library items need to be reviewed or updated to support the upgrade.
+* Download and run the [Alfresco Extension Inspector]({% link content-services/latest/develop/extension-inspector.md %}) to understand which customization or library items need to be reviewed or updated to support the upgrade.
 * Review all new and deprecated features included in the Release Notes. Customers can access these from the [Support Portal](https://support.alfresco.com/){:target="_blank"}.
 * Review and implement the new [Supported platforms]({% link content-services/latest/support/index.md %}) options, and update as necessary for the new deployment. Also, check the general advice about [Supported Platforms and Languages](https://www.alfresco.com/services/subscription/supported-platforms){:target="_blank"} on our website.
 


### PR DESCRIPTION
Fixes links to the following pages:

- Install: Overview
- Install: Install using Ansible / Ansible project in GitHub
- Admin: Securing your installation

Updates paragraph that links to new page for 'Securing your installation'

TODO: 'Deployment Support Policy’ link - this will be fixed once this branch is merged to master