### PR TITLE
Update security.md

### DIFF
--- a/content-services/6.2/admin/security.md
+++ b/content-services/6.2/admin/security.md
@@ -1442,7 +1442,7 @@ The CSRF filter can be configured in the `web-client-security-config.xml` file, 
 ```text
 # CSRF filter overrides
 csrf.filter.enabled=true
-csrf.filter.referer=https://mydomain.com/*.
+csrf.filter.referer=https://mydomain.com/.*
 csrf.filter.referer.always=false
 csrf.filter.origin=https://mydomain.com
 csrf.filter.origin.always=false


### PR DESCRIPTION
fixed typo which leads to wrong regex in csrf.filter.referer config
wrong:
`
csrf.filter.referer=https://mydomain.com/*.
`

correct:
` 
csrf.filter.referer=https://mydomain.com/.*
`