### PR TITLE
Missing data type d:content, d:noderef

### DIFF
--- a/content-services/latest/config/models.md
+++ b/content-services/latest/config/models.md
@@ -307,6 +307,7 @@ To create a property:
 4. Click **Create** or **Create and Start Another** to save the property.
 
 The options for data types of properties are:
+TODO expecting all existing data types (d:content, d:noderef, ...)
 
 {% capture d-text %}
 


### PR DESCRIPTION
Hi,
Some data types are missing in Manage properties => Create a property => 4.
The data type d:content is not in the properties list, but is mentioned above.

Other data type must be missing, like d:noderef.
Can you add them to the documentation ? 
I just added a TODO in the MarkDown file.

Lilian