### PR TITLE
Fix typos in various pages

### DIFF
--- a/content-services/6.0/admin/audit.md
+++ b/content-services/6.0/admin/audit.md
@@ -195,7 +195,7 @@ See the source code here for details of data extractors provided out of the box 
 
 ### Data Generator
 
-Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. The are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
+Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. They are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
 
 * Authenticated Person
 * Authenticated User

--- a/content-services/6.0/admin/workflows.md
+++ b/content-services/6.0/admin/workflows.md
@@ -422,7 +422,7 @@ The following variables are set by the start task in your process definition, an
 | bpm_package | A Repository Node with aspect `bpm:workflowPackage` representing the Workflow package containing content being routed through the workflow. |
 | bpm_context | A Repository Node of type `cm:folder` representing the folder in which the workflow was started. |
 
-The are some special node objects available in the process definition, that are not part of the task model:
+There are some special node objects available in the process definition, that are not part of the task model:
 
 | Variable | Description |
 | -------- | ----------- |
@@ -484,7 +484,7 @@ Content Services ships with two default workflow models that support the default
 
 |Workflow Model|Description|
 |--------------|-----------|
-|pmModel.xml|Is the basic workflow content model|
+|bpmModel.xml|Is the basic workflow content model|
 |workflowModel.xml|Contains more detailed task types and specializes the basic task types from the BPM model|
 
 ![wf-task-model-2]({% link content-services/images/wf-task-model-2.jpg %})

--- a/content-services/6.1/admin/audit.md
+++ b/content-services/6.1/admin/audit.md
@@ -195,7 +195,7 @@ See the source code here for details of data extractors provided out of the box 
 
 ### Data Generator
 
-Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. The are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
+Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. They are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
 
 * Authenticated Person
 * Authenticated User

--- a/content-services/6.1/admin/workflows.md
+++ b/content-services/6.1/admin/workflows.md
@@ -422,7 +422,7 @@ The following variables are set by the start task in your process definition, an
 | bpm_package | A Repository Node with aspect `bpm:workflowPackage` representing the Workflow package containing content being routed through the workflow. |
 | bpm_context | A Repository Node of type `cm:folder` representing the folder in which the workflow was started. |
 
-The are some special node objects available in the process definition, that are not part of the task model:
+There are some special node objects available in the process definition, that are not part of the task model:
 
 | Variable | Description |
 | -------- | ----------- |
@@ -484,7 +484,7 @@ Content Services ships with two default workflow models that support the default
 
 |Workflow Model|Description|
 |--------------|-----------|
-|pmModel.xml|Is the basic workflow content model|
+|bpmModel.xml|Is the basic workflow content model|
 |workflowModel.xml|Contains more detailed task types and specializes the basic task types from the BPM model|
 
 ![wf-task-model-2]({% link content-services/images/wf-task-model-2.jpg %})

--- a/content-services/6.2/admin/audit.md
+++ b/content-services/6.2/admin/audit.md
@@ -195,7 +195,7 @@ See the source code here for details of data extractors provided out of the box 
 
 ### Data Generator
 
-Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. The are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
+Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. They are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
 
 * Authenticated Person
 * Authenticated User

--- a/content-services/6.2/admin/workflows.md
+++ b/content-services/6.2/admin/workflows.md
@@ -422,7 +422,7 @@ The following variables are set by the start task in your process definition, an
 | bpm_package | A Repository Node with aspect `bpm:workflowPackage` representing the Workflow package containing content being routed through the workflow. |
 | bpm_context | A Repository Node of type `cm:folder` representing the folder in which the workflow was started. |
 
-The are some special node objects available in the process definition, that are not part of the task model:
+There are some special node objects available in the process definition, that are not part of the task model:
 
 | Variable | Description |
 | -------- | ----------- |
@@ -484,7 +484,7 @@ Content Services ships with two default workflow models that support the default
 
 |Workflow Model|Description|
 |--------------|-----------|
-|pmModel.xml|Is the basic workflow content model|
+|bpmModel.xml|Is the basic workflow content model|
 |workflowModel.xml|Contains more detailed task types and specializes the basic task types from the BPM model|
 
 ![wf-task-model-2]({% link content-services/images/wf-task-model-2.jpg %})

--- a/content-services/community/admin/audit.md
+++ b/content-services/community/admin/audit.md
@@ -195,7 +195,7 @@ See the source code here for details of data extractors provided out of the box 
 
 ### Data Generator
 
-Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. The are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
+Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. They are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
 
 * Authenticated Person
 * Authenticated User

--- a/content-services/community/admin/workflows.md
+++ b/content-services/community/admin/workflows.md
@@ -373,7 +373,7 @@ The following variables are set by the start task in your process definition, an
 | bpm_package | A Repository Node with aspect `bpm:workflowPackage` representing the Workflow package containing content being routed through the workflow. |
 | bpm_context | A Repository Node of type `cm:folder` representing the folder in which the workflow was started. |
 
-The are some special node objects available in the process definition, that are not part of the task model:
+There are some special node objects available in the process definition, that are not part of the task model:
 
 | Variable | Description |
 | -------- | ----------- |

--- a/content-services/latest/admin/audit.md
+++ b/content-services/latest/admin/audit.md
@@ -195,7 +195,7 @@ See the source code here for details of data extractors provided out of the box 
 
 ### Data Generator
 
-Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. The are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
+Unlike Data Extractors, which require an input (typically a node ref) to work with, Data Generators do not require an input. They are activated when an inbound mapped path is present, but they're not dependent on the value on that path. They can generate data purely from the system state and thread context. Out of the box data generators include:
 
 * Authenticated Person
 * Authenticated User

--- a/content-services/latest/admin/workflows.md
+++ b/content-services/latest/admin/workflows.md
@@ -422,7 +422,7 @@ The following variables are set by the start task in your process definition, an
 | bpm_package | A Repository Node with aspect `bpm:workflowPackage` representing the Workflow package containing content being routed through the workflow. |
 | bpm_context | A Repository Node of type `cm:folder` representing the folder in which the workflow was started. |
 
-The are some special node objects available in the process definition, that are not part of the task model:
+There are some special node objects available in the process definition, that are not part of the task model:
 
 | Variable | Description |
 | -------- | ----------- |
@@ -484,7 +484,7 @@ Content Services ships with two default workflow models that support the default
 
 |Workflow Model|Description|
 |--------------|-----------|
-|pmModel.xml|Is the basic workflow content model|
+|bpmModel.xml|Is the basic workflow content model|
 |workflowModel.xml|Contains more detailed task types and specializes the basic task types from the BPM model|
 
 ![wf-task-model-2]({% link content-services/images/wf-task-model-2.jpg %})


### PR DESCRIPTION
Following on from PR #225 (which corrects the Community `/admin/workflows.md` page), this PR fixes the same typos in other ACS versions plus a few more pages.