### PR TITLE
Fix Customer Support Portal URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
             <p><b>Support resources</b></p>
             <ul>
                 <li><a href="/support/latest/" target="_blank">Support Handbook</a></li>
-                <li><a href="https://myalfresco.force.com/support/SiteLogin" target="_blank">Customer Support Portal</a></li>
+                <li><a href="https://support.alfresco.com/" target="_blank">Customer Support Portal</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Change URL for the Support Portal to one that correctly redirects to the Hyland Community portal