### PR TITLE
DOCS-6211 - ATS 1.4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -515,6 +515,7 @@ defaults:
       toc: "transform-service"
       support: true
       versions:
+        - 1.4
         - 1.3
         - 1.2
         - 1.1
@@ -522,8 +523,12 @@ defaults:
   - scope:
       path: "transform-service/latest"
     values:
-      version: 1.3
+      version: 1.4
       latest: true
+  - scope:
+      path: "transform-service/1.3"
+    values:
+      version: 1.3
   - scope:
       path: "transform-service/1.2"
     values:

--- a/_data/toc/transform-service.yaml
+++ b/_data/toc/transform-service.yaml
@@ -1,5 +1,5 @@
-# Transform Service 1.3
-- version: 1.3
+# Transform Service 1.4
+- version: 1.4
   pages:
     - title: 'Introduction'
       path: '/transform-service/latest/'
@@ -19,6 +19,27 @@
               path: '/transform-service/latest/config/engine/'
     - title: 'Administer'
       path: '/transform-service/latest/admin/'
+# Transform Service 1.3
+- version: 1.3
+  pages:
+    - title: 'Introduction'
+      path: '/transform-service/1.3/'
+    - title: 'Install'
+      path: '/transform-service/1.3/install/'
+    - title: 'Configure'
+      pages:
+        - title: 'Overview'
+          path: '/transform-service/1.3/config/'
+        - title: 'Extend'
+          pages:
+            - title: 'Overview'
+              path: '/transform-service/1.3/config/extend/'
+            - title: 'Configure Transformers'
+              path: '/transform-service/1.3/config/transformers/'
+            - title: 'Create custom T-Engine'
+              path: '/transform-service/1.3/config/engine/'
+    - title: 'Administer'
+      path: '/transform-service/1.3/admin/'
 # Transform Service 1.2
 - version: 1.2
   pages:

--- a/content-services/6.2/install/containers/docker-compose.md
+++ b/content-services/6.2/install/containers/docker-compose.md
@@ -265,6 +265,10 @@ The Docker Compose file provides some default configuration. This section lists 
 | JAVA_TOOL_OPTIONS | Adding this environment variable, allows to set sensitive values (like passwords) that are not passed as arguments to the Java Process. |
 | JAVA_OPTS | A set of properties that are picked up by the JVM inside the container. Any Content Services property can be passed to the container using the format `-Dproperty=value` (e.g. `-Ddb.driver=org.postgresql.Driver`). |
 
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/6.2/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services.
+
 ### Alfresco Share (share)
 
 | Property | Description |

--- a/content-services/6.2/install/containers/helm.md
+++ b/content-services/6.2/install/containers/helm.md
@@ -68,6 +68,10 @@ The Enterprise configuration will deploy the following system:
 * You've read the [main Helm README](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md){:target="_blank"} page
 * You are proficient in AWS and Kubernetes
 
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/6.2/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services.
+
 ### Set up an EKS cluster
 
 Follow the [AWS EKS Getting Started Guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html){:target="_blank"} to create a cluster and prepare your local machine to connect to the cluster. Use the **Managed nodes - Linux** option and specify a `--node-type` of at least `m5.xlarge`.

--- a/content-services/6.2/install/containers/index.md
+++ b/content-services/6.2/install/containers/index.md
@@ -140,6 +140,53 @@ Note that the [VERSIONS.md](https://github.com/Alfresco/acs-packaging/blob/maste
 
 You can review the requirements for your chosen deployment method below.
 
+### IPTC Content Model bootstrapping (OPTIONAL) {#iptc-model-bootstrap}
+If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction, then you need to 
+bootstrap the IPTC Content Model manually into Content Services.
+
+The files for this content model can be downloaded from the 
+[Alfresco Transform Core GitHub project](https://github.com/Alfresco/alfresco-transform-core/tree/master/models){:target="_blank"}.
+You need both the Content Model XML and the associated i18n property files for different languages.
+
+#### Docker Compose IPTC Content Model bootstrapping
+Place the IPTC Content Model files in a subfolder from where the `docker-compose.yml` file is located.
+Such as in the following example:
+
+```bash
+- docker-compose.yml
+- models
+  - iptc
+    - iptc-model.properties
+    ...
+  - iptc-model-context.xml
+```
+
+Then update the `docker-compose.yml` file with the model:
+
+```xml
+...
+services:
+    alfresco:
+        image: ...
+        mem_limit: 1700m
+        environment:
+            JAVA_TOOL_OPTIONS: "
+            ...
+                "
+            JAVA_OPTS: "
+            ...                
+            "
+        volumes:
+            - ./models/iptc-model-context.xml:/usr/local/tomcat/shared/classes/alfresco/extension/iptc-model-context.xml
+            - ./models/iptc:/usr/local/tomcat/shared/classes/alfresco/extension/models/iptc     
+```
+
+You are adding the 3 last lines setting up volume mappings.
+
+#### Helm IPTC Content Model bootstrapping
+Before installing with Helm charts you need to [produce a custom Repository Docker image]({% link content-services/6.2/install/containers/customize.md %}) 
+with the IPTC Content Model. Then update the Helm charts to use this image.
+
 ### Helm charts
 
 To deploy Content Services using Helm charts, you need to install the following software:

--- a/content-services/6.2/install/zip/index.md
+++ b/content-services/6.2/install/zip/index.md
@@ -5,6 +5,7 @@ title: Install with zip
 This page describes how to manually install Content Services using the distribution zip.
 
 For a description of the system paths used within this documentation, see [System path conventions]({% link content-services/6.2/admin/index.md %}#system-paths-convention).
+
 ## Prerequisites
 
 To install Content Services using the distribution zip (which also contains the WAR files), make sure that the required software is available on your system:
@@ -17,6 +18,10 @@ To install Content Services using the distribution zip (which also contains the 
 * ImageMagick
 
 For a list of supported components and versions, refer to the `VERSIONS.md` file in the distribution zip.
+
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/6.2/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services. If you follow the link you will find the necessary content model files.
 
 ## Install overview
 

--- a/content-services/6.2/support/index.md
+++ b/content-services/6.2/support/index.md
@@ -68,6 +68,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.3 | |
 | Alfresco Desktop Sync 1.6 | |
+| Alfresco Transform Service 1.4 | |
 | Alfresco Transform Service 1.3 | |
 | Alfresco Document Transformation Engine 2.2.2 | |
 | Alfresco Media Management 1.4.3 | |

--- a/content-services/latest/install/ansible.md
+++ b/content-services/latest/install/ansible.md
@@ -26,6 +26,10 @@ There are two types of installations - local and remote:
 
 If you're using the Content Services (Enterprise), then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services. If you follow the link you will find the necessary content model files.
+
 ## Target O/S
 
 The playbooks have been tested using Ansible 2.9.16 (or later) on target hosts with the following operating systems:

--- a/content-services/latest/install/containers/docker-compose.md
+++ b/content-services/latest/install/containers/docker-compose.md
@@ -268,6 +268,10 @@ The Docker Compose file provides some default configuration. This section lists 
 | JAVA_TOOL_OPTIONS | Adding this environment variable, allows to set sensitive values (like passwords) that are not passed as arguments to the Java Process. |
 | JAVA_OPTS | A set of properties that are picked up by the JVM inside the container. Any Content Services property can be passed to the container using the format `-Dproperty=value` (e.g. `-Ddb.driver=org.postgresql.Driver`). |
 
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services.
+
 ### Alfresco Share (share)
 
 | Property | Description |

--- a/content-services/latest/install/containers/helm.md
+++ b/content-services/latest/install/containers/helm.md
@@ -71,6 +71,10 @@ The Enterprise configuration will deploy the following system:
 * You've read the [main Helm README](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md){:target="_blank"} page
 * You are proficient in AWS and Kubernetes
 
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services.
+
 ### Set up an EKS cluster
 
 Follow the [AWS EKS Getting Started Guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html){:target="_blank"} to create a cluster and prepare your local machine to connect to the cluster. Use the **Managed nodes - Linux** option and specify a `--node-type` of at least `m5.xlarge`.

--- a/content-services/latest/install/containers/index.md
+++ b/content-services/latest/install/containers/index.md
@@ -138,6 +138,53 @@ Note that the [VERSIONS.md](https://github.com/Alfresco/acs-packaging/blob/maste
 
 You can review the requirements for your chosen deployment method below.
 
+### IPTC Content Model bootstrapping (OPTIONAL) {#iptc-model-bootstrap}
+If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction, then you need to
+bootstrap the IPTC Content Model manually into Content Services.
+
+The files for this content model can be downloaded from the
+[Alfresco Transform Core GitHub project](https://github.com/Alfresco/alfresco-transform-core/tree/master/models){:target="_blank"}.
+You need both the Content Model XML and the associated i18n property files for different languages.
+
+#### Docker Compose IPTC Content Model bootstrapping
+Place the IPTC Content Model files in a subfolder from where the `docker-compose.yml` file is located.
+Such as in the following example:
+
+```bash
+- docker-compose.yml
+- models
+  - iptc
+    - iptc-model.properties
+    ...
+  - iptc-model-context.xml
+```
+
+Then update the `docker-compose.yml` file with the model:
+
+```xml
+...
+services:
+    alfresco:
+        image: ...
+        mem_limit: 1700m
+        environment:
+            JAVA_TOOL_OPTIONS: "
+            ...
+                "
+            JAVA_OPTS: "
+            ...                
+            "
+        volumes:
+            - ./models/iptc-model-context.xml:/usr/local/tomcat/shared/classes/alfresco/extension/iptc-model-context.xml
+            - ./models/iptc:/usr/local/tomcat/shared/classes/alfresco/extension/models/iptc     
+```
+
+You are adding the 3 last lines setting up volume mappings.
+
+#### Helm IPTC Content Model bootstrapping
+Before installing with Helm charts you need to [produce a custom Repository Docker image]({% link content-services/latest/install/containers/customize.md %})
+with the IPTC Content Model. Then update the Helm charts to use this image.
+
 ### Helm charts
 
 To deploy Content Services using Helm charts, you need to install the following software:

--- a/content-services/latest/install/zip/index.md
+++ b/content-services/latest/install/zip/index.md
@@ -16,8 +16,6 @@ To install Content Services using the distribution zip (which also contains the 
 * Application server: Apache Tomcat
 * Database: PostgreSQL or MySQL
 * Message broker: ActiveMQ
-* LibreOffice
-* ImageMagick
 
 For a list of other supported components and versions, refer to the `VERSIONS.md` file in the distribution zip.
 

--- a/content-services/latest/install/zip/index.md
+++ b/content-services/latest/install/zip/index.md
@@ -19,6 +19,10 @@ To install Content Services using the distribution zip (which also contains the 
 
 For a list of other supported components and versions, refer to the `VERSIONS.md` file in the distribution zip.
 
+>**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
+then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
+into Content Services. If you follow the link you will find the necessary content model files.
+
 ## Install overview
 
 Use this section to get an overview of the main stages for installing Content Services using the distribution zip. It's designed for users who just need a simple checklist to follow.

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -71,6 +71,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.4 | |
 | Alfresco Desktop Sync 1.7 | |
+| Alfresco Transform Service 1.4 | |
 | Alfresco Transform Service 1.3.2 | |
 | Alfresco Search and Insight Engine 2.0 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0 | |

--- a/transform-service/1.2/install/index.md
+++ b/transform-service/1.2/install/index.md
@@ -415,16 +415,12 @@ The Transform Service distribution zip file includes all the files required to p
     sfs.url=http://localhost:8099
     sfs.endpoint=${sfs.url}/alfresco/api/-default-/private/sfs/versions/1/file
 
-    # Transform Router property:
+    # Transform Router properties:
+    transform.service.enabled=true
     transform.service.url=http://localhost:8095/
 
     # Transform Core properties:
     localTransform.core-aio.url=http://transform-core-aio:8090/
-    alfresco-pdf-renderer.url=http://transform-core-aio:8090/
-    jodconverter.url=http://transform-core-aio:8090/
-    img.url=http://transform-core-aio:8090/
-    tika.url=http://transform-core-aio:8090/
-    transform.misc.url=http://transform-core-aio:8090/
     ```
 
     This overrides the default properties provided by Content Services.

--- a/transform-service/1.3/admin/index.md
+++ b/transform-service/1.3/admin/index.md
@@ -1,0 +1,133 @@
+---
+title: Administer Transform Service
+---
+
+The following section describes the Transform Service components, and also explain the flow of information between the repository and these components during the transformation process.
+
+## Transform Service components
+
+The Transform Service handles the essential transforms, such as Microsoft Office documents, images, and PDFs. These include PNG for thumbnails, PDF and JPEG for downloads and previews.
+
+The main components of the Transform Service are:
+
+* **Content Repository (ACS)**: This is the repository where documents and other content resides. The repository produces and consumes events destined for the message broker (such as ActiveMQ or Amazon MQ). It also reads and writes documents to the shared file store.
+* **ActiveMQ**: This is the message broker (either a self-managed ActiveMQ instance or Amazon MQ), where the repository and the Transform Router send image transform requests and responses. These JSON-based messages are then passed to the Transform Router.
+* **Transform Router**: The Transform Router allows simple (single-step) and pipeline (multi-step) transforms that are passed to the Transform Engines. The Transform Router (and the Transform Engines) run as independently scalable Docker containers.
+* **Transform Engines**: The Transform Engines transform files referenced by the repository and retrieved from the shared file store. Here are some example transformations for each Transform Engine (this is not an exhaustive list):
+  * LibreOffice (e.g. docx to pdf)
+  * ImageMagick (e.g. resize)
+  * Alfresco PDF Renderer (e.g. pdf to png)
+  * Tika (e.g. docx to plain text)
+  * Misc. (not included in diagram)
+* **Shared File Store**: This is used as temporary storage for the original source file (stored by the repository), intermediate files for multi-step transforms, and the final transformed target file. The target file is retrieved by the repository after it's been processed by one or more of the Transform Engines.
+
+The following diagram shows a simple representation of the Transform Service components:
+
+![Transform service components Overview]({% link transform-service/images/ats-1.3.2-components.png %})
+
+Note that from Transform Service version 1.3.2 the metadata extraction that usually takes part in the core repository 
+legacy transform engines has now been lifted out into the separate transform engine processes. This enables scaling 
+of the metadata extraction.
+
+This shows an example implementation of how you can deploy into AWS, using a number of managed services:
+
+* Amazon EKS - Elastic Container Service for Kubernetes
+* Amazon MQ - Managed message broker service for [Apache ActiveMQ](https://activemq.apache.org/){:target="_blank"}
+* Amazon EFS - Amazon Elastic File System
+
+You can replace the AWS services (EKS, MQ, and EFS) with a self-managed Kubernetes cluster, ActiveMQ (configured with failover), and a shared file store, such as NFS.
+
+> **Note:** For more detailed representations of the Alfresco Content Services deployment (including the Transform Service), see the GitHub [Docker Compose](https://github.com/Alfresco/acs-deployment/tree/master/docs/docker-compose){:target="_blank"} and [Helm](https://github.com/Alfresco/acs-deployment/tree/master/docs/helm){:target="_blank"} documentation.
+
+The advantage of using Docker containers is that they provide a consistent environment for development and production. They allow applications to run using microservice architecture. This means you can upgrade an individual service with limited impact on other services.
+
+## Docker images overview
+
+A typical containerized deployment of Transform Service looks as follows:
+
+![Docker Compose Deployment Overview]({% link transform-service/images/ats-1.3.2-containerized-deployment.png %})
+
+Note that from Transform Service version 1.3 all the transform engines are contained in one component called 
+Transform Core All-In-One (AIO) Engine. Only for large deployments are the Transform Engines deployed separately.
+
+Some of the Docker images that are used by the Transform Service are uploaded to a private registry, **Quay.io**. Enterprise customers can contact [Alfresco Support](https://support.alfresco.com/){:target="_blank"} to request Quay.io account credentials to pull the private (Enterprise-only) Docker images:
+
+* `quay.io/alfresco/alfresco-transform-router`
+
+The other images are available in DockerHub:
+
+* `alfresco/alfresco-transform-core-aio`
+* `alfresco/alfresco-pdf-renderer`
+* `alfresco/alfresco-imagemagick`
+* `alfresco/alfresco-libreoffice`
+* `alfresco/alfresco-tika`
+* `alfresco/alfresco-shared-file-store`
+* `alfresco/alfresco-transform-misc`
+
+For information about deploying and configuring the Transform Service, see [Install Transform Service]({% link transform-service/1.3/install/index.md %}).
+
+## Troubleshoot Transform Services
+
+Use this information to help monitor and troubleshoot the Transform Service.
+
+### How do I monitor the Transform Engines (e.g. LibreOffice) and the Transform Router
+
+There are two options for monitoring each component:
+
+* View the logs via the Kubernetes dashboard.
+* Access the `/metrics` and the `/prometheus` endpoint, which expose information about the running processes.
+
+### What do I do if LibreOffice hangs
+
+If LibreOffice hangs, the health endpoint will fail to respond, and the container/pod will automatically reboot. This applies to all five Docker transformers. The Content Services Helm deployment uses two replicas for each component of the Transform Service by default (except for the shared file store) in order to provide scalability and fault tolerance.
+
+### What debug logging is available for the Transform Service
+
+All the key operations are logged, as well as the different entry and exit points for all kind of processes and actions.
+
+### What do I do if Tika runs out of memory
+
+Similar to LibreOffice, the Tika container/pod should automatically restart since OOM is an error. If the automatic restart fails, the pods can be restarted from the Kubernetes dashboard.
+
+### How do I monitor ActiveMQ / Amazon MQ
+
+* Access the ActiveMQ Admin Console (Web Console) at `<amazon-mq-host>`.
+* The micrometer implementation also monitors the size of the queue.
+
+### Are any metrics sent to/via HeartBeat
+
+No. HeartBeat hasn't been integrated yet.
+
+### Where are the temporary files located for individual and multi-step transforms
+
+The individual transform, or Transform Engine, cleans up its own temporary files within the running container. For multi-step transforms, the intermediate files will eventually be cleaned up by the Shared File Store.
+
+### Is any monitoring/metrics system available
+
+Yes:
+
+* All the Transform Service components use micrometer.
+* The Prometheus service that's deployed ingests data from the Transform Router.
+
+### If a transform fails when uploading a complex XLSX document, what happens
+
+The Transform Service will attempt to retry the transform a few times (this is configurable). Otherwise, a failed transform is returned to the repository, so no preview or thumbnail will be available. The repository will no longer retry.
+
+### Can you share the Transform Service with multiple repositories
+
+This release will only support a single Content Services repository instance. For example, if you have two or more separate Content Services deployments (whether clustered or not), then each one will need to its own Transform Service instance.
+
+## Error handling in Transform Router
+
+Use this information to review the possible responses from the Transform Router (T-Router) if a problem occurs.
+
+The Transform Service is designed to be easy to set-up and debug. However, when a problem occurs, the T-Router tries to respond with a failed Transform Reply (T-Reply). Here are a few examples:
+
+|T-Reply|Possible T-Reply response|
+|-------|-------------------------|
+|400 BAD REQUEST|T-Request with an `invalid JSON` is received|
+|400 BAD REQUEST|T-Request with `invalid/missing values` is received|
+|400 BAD REQUEST|T-Request with an `unsupported transformation` is received|
+|500 INTERNAL SERVER ERROR|Transformation `fails in the T-Engine`|
+|500 INTERNAL SERVER ERROR|When any other `unexpected exception in the T-Router` is thrown|
+|no reply|When a `Java Error` (*Throwable*, but not *Exception*) occurs in the T-Router, the problem is only logged.|

--- a/transform-service/1.3/config/engine.md
+++ b/transform-service/1.3/config/engine.md
@@ -1,0 +1,237 @@
+---
+title: Create custom T-Engine
+---
+
+Alfresco Content Services provides a number of content transforms, but also allows you to add custom transforms. This section describes how to create custom transforms.
+
+The deployment and development of a T-Engine transformer is simpler than in previous versions of Content Services.
+
+* Transformers no longer need to be applied as AMPs/JARs on top of the repository.
+* New versions may be deployed separately without restarting the repository.
+* As a standalone Spring Boot application, development and test cycles are reduced.
+* A base Spring Boot application is provided with hook points to extend it with custom transform code.
+* The base also includes the creation of a Docker image for your Spring Boot application. Even if you don't intend to deploy with Docker, this may still be of interest, as the configuration of any tools or libraries used in the transform need only be done once rather than for every development or ad-hoc test environment.
+
+## Develop new T-Engine
+
+When developing new Local Transformers, it's a good idea to increase the polling frequency of the various locations that contain custom Pipeline, Rendition, Mimetype Definitions, and also of the Transform Service:
+
+```bash
+mimetype.config.cronExpression=0 0/1 * * * ?
+rendition.config.cronExpression=2 0/1 * * * ?
+local.transform.service.cronExpression=4 0/1 * * * ?
+transform.service.cronExpression=6 0/1 * * * ?
+```
+
+Use this information to create a simple Hello World transformer and test it.
+
+In this example, you'll develop, configure and run custom transformers running within a T-Engine.
+
+The code for this example is in the [alfresco-helloworld-transformer](https://github.com/Alfresco/alfresco-helloworld-transformer/tree/master/alfresco-helloworld-transformer-engine){:target="_blank"} project in GitHub. This T-Engine contains a single transformer. However, T-Engines may contain many transformers in a single T-Engine. The transformer takes a source text file containing a name and produces an HTML file with the message:
+
+```html
+Hello `<name>`
+```
+
+To demonstrate how to use Renditions, it also takes a transform option that specifies which language to use.
+
+> **Note:** It is assumed that you're familiar with Spring Boot, Maven, and Docker technologies.
+
+## Develop and debug T-Engines
+
+T-Engines are Dockerized Spring Boot applications. They are set up as Maven projects built on top of [alfresco-transformer-base](https://github.com/Alfresco/alfresco-transform-core/tree/master/alfresco-transformer-base){:target="_blank"}, which is a sub-project of Alfresco Transform Core. The Alfresco Transformer Base brings in Spring Boot capabilities, as well as base classes, which assist in the creation of new T-Engines.
+
+### Project setup
+
+In order to configure a custom T-Engine as a Spring Boot application in a Docker image, we need to add some configuration. The quickest way to get started is to base your project on [alfresco-helloworld-transformer](https://github.com/Alfresco/alfresco-helloworld-transformer/tree/master/alfresco-helloworld-transformer-engine){:target="_blank"}, as it is fully configured, ready to be built and run, and contains relatively little extra code. It is also possible to start from a blank Maven project with the same folder structure. The key files in this project are:
+
+* **pom.xml** The POM file defines Alfresco Transform Core as the parent and adds required dependencies. It also configures plugins for building the Spring Boot application and generating the Docker image. It is likely you will need to change the artifact name and add extra dependencies.
+
+* **Application.java** The Application class defines an entry point for the Spring Boot application.
+
+* **Dockerfile** The Dockerfile is needed by the `docker-maven-plugin` configured in the `pom.xml` to generate a Docker image. It defines a simple Docker image with our Spring Boot application fat jar copied in, specifies default user information, and exposes port 8090.
+
+## T-Engine configuration
+
+For the repository configuration, see how to [Configure a T-Engine as a Local Transform](https://github.com/Alfresco/acs-packaging/blob/release/6.2.N/docs/custom-transforms-and-renditions.md#configure-a-t-engine-as-a-local-transform){:target="_blank"}.
+
+T-Engines must provide a `/transform/config` end point for clients to determine what is supported. This is simply achieved by editing a JSON file.
+
+The following [engine_config.json](https://github.com/Alfresco/alfresco-helloworld-transformer/blob/master/alfresco-helloworld-transformer-engine/src/main/resources/engine_config.json){:target="_blank"} is taken from the Hello World example, but there are other examples such as the one used by the [Tika T-Engine](https://github.com/Alfresco/alfresco-transform-core/blob/master/alfresco-docker-tika/src/main/resources/engine_config.json){:target="_blank"}.
+
+```json
+{
+  "transformOptions":
+  {
+    "helloWorldOptions":
+    [
+      {"value": {"name": "language"}}
+    ]
+  },
+  "transformers":
+  [
+    {
+      "transformerName": "helloWorld",
+      "supportedSourceAndTargetList":
+      [
+        {"sourceMediaType": "text/plain",  "maxSourceSizeBytes": 50, "targetMediaType": "text/html"  }
+      ],
+      "transformOptions":
+      [
+        "helloWorldOptions"
+      ]
+    }
+  ]
+}
+```
+
+* **transformOptions** provides a list of transform options that may be referenced for use in different transformers. This way, common options don't need to be repeated for each transformer. They can even be shared between T-Engines. In this example, there is only one group of options called `helloWorldOptions`, which has just one option - the `language`. Unless an option has a `"required": true` field, it's considered to be optional. If you look at the [Tika T-Engine](https://github.com/Alfresco/alfresco-transform-core/blob/master/alfresco-docker-tika/src/main/resources/engine_config.json){:target="_blank"} file, you can see that options may also be grouped. You don't need to specify `sourceMimetype`, `targetMimetype`, `sourceExtension` or `targetExtension` as options, since these are automatically added.
+
+* **transformers** is a list of transformer definitions. Each transformer definition should have a unique `transformerName`, specify a `supportedSourceAndTargetList` and indicate which options it supports. In this example configuration, there is only one transformer called `Hello World` and it accepts `helloWorldOptions`. A transformer may specify references to 0 or more `transformOptions`.
+
+* **supportedSourceAndTargetList** is simply a list of source and target Media Types that may be transformed, with an optional `maxSourceSizeBytes` value. In this example configuration, there is only one from text to HTML and we have limited the source file size, to avoid transforming files that clearly don't contain names.
+
+### The Controller Class
+
+T-Engines generally extend an `AbstractTransformerController` and provide implementations of the following methods. Take a look at the [HelloWorldController.java](https://github.com/Alfresco/alfresco-helloworld-transformer/blob/master/alfresco-helloworld-transformer-engine/src/main/java/org/alfresco/transformer/HelloWorldController.java){:target="_blank"} example.
+
+* **transform**
+
+```java
+@PostMapping(value="/transform", consumes=MULTIPART_FORM_DATA_VALUE)
+publicResponseEntity<Resource> transform(HttpServletRequest request,
+@RequestParam("file") MultipartFile sourceMultipartFile,
+@RequestParam(value="targetExtension") String targetExtension,
+@RequestParam(value="language") String language)
+```
+
+The `/transform` endpoint handles the repository requests to Local Transforms over `http`. Generally it will:
+
+* prepare source and target files on disk using the supplied MultipartFile and targetExtension. The Transformer Base will handle the removal of these files.
+* perform the transform
+* send the result back
+
+Method parameters:
+
+* **sourceMultipartFile** - The file to be transformed from the transform request. This is always provided.
+* **targetExtension** - The target extension of the transformed file to be returned in the response. This is always provided.
+* **language** - This is the custom transform option defined for the example T-Engine.
+
+The `transform` method's signature will vary depending on the T-Engine's configuration. The example T-Engine is configured to take a single `language` transform option, but the number of the `transform` method's parameters will have to match the transform options defined in [engine\_config.json](https://github.com/Alfresco/alfresco-helloworld-transformer/blob/master/alfresco-helloworld-transformer-engine/src/main/resources/engine_config.json){:target="_blank"}.
+
+* **ProcessTransform**
+
+```java
+public void processTransform(File sourceFile, File targetFile, Map<String, String> transformOptions, Long timeout)
+```
+
+This method handles requests from the Transform Service via a message queue. As it performs the same transform as the `transform` method, they tend to both call a common method to perform the actual transform.
+
+* **getProbeTestTransform**
+
+```java
+public ProbeTestTransform getProbeTestTransform()
+```
+
+This method provides a way to define a test transform for [T-Engine Probes](https://github.com/Alfresco/alfresco-transform-core/blob/master/docs/Probes.md){:target="_blank"}. For example, a test transform of a small file included in the Docker image.
+
+## Run hello world T-Engine standalone
+
+Use this information to run the example Hello World transform engine (T-Engine).
+
+1. Clone the [alfresco-helloworld-transformer](https://github.com/Alfresco/alfresco-helloworld-transformer/tree/master/alfresco-helloworld-transformer-engine){:target="_blank"} project.
+
+2. Navigate to the `alfresco-helloworld-transformer-engine` folder.
+
+3. Build the T-Engine:
+
+    ```bash
+    mvn clean install -Plocal
+    ```
+
+4. Start the T-Engine:
+
+    ```bash
+    docker run -d -p 8090:8090 --name alfresco-helloworld-transformer alfresco/alfresco-helloworld-transformer:latest
+    ```
+
+5. Create a test file named `source_file.txt` with the following content:
+
+    ```bash
+    T-Engines
+    ```
+
+6. Open your browser and go to `http://localhost:8090/`.
+
+    For convenience, the Hello World T-Engine provides an HTML form to POST requests to the `/transform` endpoint.
+
+7. In the HTML Form, choose `source_file.txt`.
+
+8. Specify a language, where the supported languages are: English, Spanish, German.
+
+9. Click `Transform` and then view the downloaded file.
+
+T-Engines provide a `/log` endpoint out of the box. This shows information about transformations performed by the T-Engine. In addition, the T-Engine server logs can be accessed using the Docker `logs` command. For example:
+
+```bash
+docker logs alfresco-helloworld-transformer
+```
+
+See the [Docker documentation](https://docs.docker.com/engine/reference/commandline/logs/){:target="_blank"} for more.
+
+## Configure custom T-Engine
+
+Use this information to configure a custom transform engine (T-Engine).
+
+1. Define an HTTP URL and JMS queue name for the T-Engine.
+
+    For example, you can configure custom T-Engines through environment variables:
+
+    ```bash
+    export TRANSFORMER_URL_<CUSTOM_ENGINE_NAME>="http://custom-engine-host:8090"
+    export TRANSFORMER_QUEUE_<CUSTOM_ENGINE_NAME>="custom-engine-queue"
+    ```
+
+2. (Optional) Configure multi-step (pipeline) transformers:
+
+   1. Specify the mounting location of the pipeline definition file, `custom-pipeline-file.json`.
+
+        For example:
+
+        ```bash
+        /local/path/to/custom-pipeline-file.json:/mounting/location/of/custom-pipeline-file.json
+        ```
+
+   2. Specify the location through an environment variable.
+
+        For example:
+
+        ```bash
+        export TRANSFORMER_ROUTES_ADDITIONAL_<name>="/mounting/location/of/custom-pipeline-file.json"
+        ```
+
+    > **Note:** The `<name>` suffix doesn't need to match any labels - it just differentiates multiple additional route files. However, the T-Engine name can be used as it may help to make debugging easier.
+
+3. Create a JSON file that contains additional pipeline transformers.
+
+    For example:
+
+    ```json
+    {
+      "transformers": [
+        {
+            "transformerName": "pdfToImageViaPng",
+            "transformerPipeline" : [
+              {"transformerName": "pdfrenderer",      "targetMediaType": "image/png"},
+              {"transformerName": "imagemagick"}
+            ],
+            "supportedSourceAndTargetList": [
+            ],
+            "transformOptions": [
+              "pdfRendererOptions",
+              "imageMagickOptions"
+            ]
+        }
+      ]
+    }
+    ```

--- a/transform-service/1.3/config/extend.md
+++ b/transform-service/1.3/config/extend.md
@@ -1,0 +1,71 @@
+---
+title: Extend Transform Service
+---
+
+Use this information to extend the functionality of the Transform Service by adding and configuring custom transform engines (T-Engines).
+
+The Transform Service handles communication with all its own T-Engines, and builds up its own combined configuration JSON which is requested by the repository periodically.
+
+```bash
+transform.service.cronExpression=4 30 0/1 * * ?
+transform.service.initialAndOnError.cronExpression=0/10 * * * * ?
+```
+
+Custom transform engines (T-Engines) are added by specifying their HTTP URL and JMS queue name.
+
+The transform router (T-Router) uses the T-Engine names to register new engines via properties. The names must be unique and consistent for each engine for both of its properties (URL and queue).
+
+Examples of such names are: `IMAGEMAGICK`, `LIBREOFFICE`, `PDF_RENDERER`, `TIKA`, `TRANSFORMER1`, `CUSTOM_ENGINE`, `CUSTOM_RED_ENGINE`.
+
+> **Note:** The T-Engine names are case-insensitive.
+
+To configure a custom T-Engine:
+
+* Provide its URL and queue name. Custom T-Engines can be configured through environment variables:
+
+```bash
+export TRANSFORMER_URL_<CUSTOM_ENGINE_NAME>="http://custom-engine-host:8090"
+export TRANSFORMER_QUEUE_<CUSTOM_ENGINE_NAME>="custom-engine-queue"
+```
+
+* (Optional) Define pipeline (multi-step) transformers.
+
+    1. If the mounting location of the pipeline definition file is:
+
+        ```bash
+        /local/path/to/custom-pipeline-file.json:/mounting/location/of/custom-pipeline-file.json
+        ```
+
+    2. Specify the location through an environment variable:
+
+        ```bash
+        export TRANSFORMER_ROUTES_ADDITIONAL_<name>="/mounting/location/of/custom-pipeline-file.json"
+        ```
+
+        > **Note:** The `<name>` suffix doesn't need to match any labels - it just differentiates multiple additional route files. However, the engine name can be used as it may help to make debugging easier.
+
+    3. Define additional pipeline transformers, for example:
+
+        ```json
+        {
+            "transformers": [
+                {
+                    "transformerName": "pdfToImageViaPng",
+                    "transformerPipeline" : [
+                        {
+                            "transformerName": "pdfrenderer",
+                            "targetMediaType": "image/png"
+                        },
+                        {
+                            "transformerName": "imagemagick"
+                        }
+                    ],
+                    "supportedSourceAndTargetList": [],
+                    "transformOptions": [
+                        "pdfRendererOptions",
+                        "imageMagickOptions"
+                    ]
+                }
+            ]
+        }
+        ```

--- a/transform-service/1.3/config/index.md
+++ b/transform-service/1.3/config/index.md
@@ -1,0 +1,38 @@
+---
+title: Configure Transform Service
+nav: false
+---
+
+Use this information to configure Transform Service.
+
+## Transform Service vs. Local and Legacy Transforms
+
+Here is a summary of the changes in the transforms introduced in Alfresco Content Services 7.
+
+The Transform Service and Local transformers where introduced in Alfresco Content Services 6 to help offload the 
+transformation of content to a separate process. The Legacy transforms were deprecated. In Alfresco Content Services 7, 
+the out of the box Legacy transformers and transformation framework have been removed. This helps provide greater clarity 
+around installation and administration of transformations and technically a more scalable, reliable and secure environment.
+
+The Transform Service performs transformations for Content Services in Docker containers to provide greater scalability. 
+Requests to the Transform Service are placed in a queue and processed asynchronously. Security is also improved by better isolation.
+
+**Local Transforms** run in separate processes to the repository known as Transform Engines (or T-Engines for short).
+
+You can turn on (enable) and off (disable) Local and Transform Service transforms independently of each other 
+by settings in `alfresco-global.properties`. In the Content Services deployment, the Transform Service is disabled for the 
+zip distribution but enabled for Docker Compose and Helm deployments by default. The repository will try to transform 
+content using the Transform Service if possible and if not it will fall back to a Local Transform.
+
+```bash
+transform.service.enabled=true
+local.transform.service.enabled=true
+```
+
+Setting the enabled state to `false` will disable all of the transforms performed by that particular service. It's 
+possible to disable individual Local Transforms by setting the corresponding T-Engine URL property 
+`localTransform.<engineName>.url` value to an empty string.
+
+```bash
+localTransform.<engineName>.url=
+```

--- a/transform-service/1.3/config/transformers.md
+++ b/transform-service/1.3/config/transformers.md
@@ -1,0 +1,187 @@
+---
+title: Configure Transformers
+---
+
+The Transform Router (T-Router) configures engine transformers automatically by retrieving the engine transform configurations from each configured Transform Engine (i.e T-Engine). The engine transform configurations provide the transformer configuration, including the supported transformers and their transform options.
+
+For more information on the format of the transform configuration and instructions on how to create a transform configuration files for a custom engine, see [Creating a T-Engine](https://github.com/Alfresco/acs-packaging/blob/release/6.2.N/docs/creating-a-t-engine.md){:target="_blank"}.
+
+T-Engines are added to the T-Router by adding the engine's URL and JMS queue name used by each and every engine. See next section for the URL and JMS queue name property format.
+
+The T-Router supports 2 types of transformers:
+
+* **Single-step transformer**: This maps T-Requests to a single T-Engine, which can directly transform the `source media type` to the `target media type` with the provided `transform options` and `source file size`.
+
+  For example: `image/png` to `image/png` is handled by the `IMAGEMAGICK` transformer.
+
+* **Pipeline transformer**: This maps T-Requests to a sequence of intermediate T-Request steps, which are handled by multiple `T-Engines`. These transformers handle situations where there is no single engine that can directly transform one media type to another, but that can be achieved through intermediate media types and transformations.
+
+  For example: `application/msword` to `image/png` can't be directly performed by one single engine, but it can be handled by `LIBREOFFICE` (which would generate `application/pdf`) and then `PDF_RENDERER`.
+
+Single-step transformers map to a transformer, which in turn maps to an engine. Each engine can have multiple transformers defined in its configuration. The single-step transformers are configured automatically from engine transform configuration files.
+
+Pipeline transforms map to a pipeline transformer, which in turn maps to a series of single-step transformers. These are defined through configuration files in the T-Router. This is described in the later section about pipelines.
+
+## Add T-Engines to T-Router
+
+The T-Router uses T-Engine names to register new engines via properties. The names must be unique and consistent for each engine, for both of its properties (url and queue). Examples of such name are: `IMAGEMAGICK`, `LIBREOFFICE`, `PDF_RENDERER`, `TIKA`, `TRANSFORMER1`, `CUSTOM_ENGINE`, `CUSTOM_RED_ENGINE`, etc.. The T-Engine names are case-insensitive.
+
+Engine configuration is part of the T-Router SpringBoot `application.yaml` configuration:
+
+```yaml
+transformer:
+  url:
+    imagemagick: http://imagemagick-host:8091
+    pdf_renderer: http://pdf-renderer-host:8090
+  queue:
+    imagemagick: org.alfresco.transform.engine.imagemagick.acs
+    pdf_renderer: org.alfresco.transform.engine.alfresco-pdf-renderer.acs
+  engine:
+    protocol: ${TRANSFORMER_ENGINE_PROTOCOL:jms}  # this value can be one of the following (http, jms)
+```
+
+These properties can be overridden by environment variables on the T-Router container:
+
+```bash
+export TRANSFORMER_URL_IMAGEMAGICK="http://host1"
+export TRANSFORMER_QUEUE_IMAGEMAGICK="queue66"
+
+export TRANSFORMER_URL_PDF_RENDERER="http://host2:8099"
+export TRANSFORMER_QUEUE_PDF_RENDERER="queue-red-black"
+
+export TRANSFORMER_ENGINE_PROTOCOL="http"
+```
+
+Additional custom engines can be configured through environment variables as well:
+
+```bash
+export TRANSFORMER_URL_CUSTOM_RED_ENGINE="http://red-engine-host:8090"
+export TRANSFORMER_QUEUE_CUSTOM_RED_ENGINE="red-engine-queue"
+```
+
+The HTTP URL is for retrieving the engine config, and for transform requests in HTTP mode. The queue is used for transform requests in JMS mode, transform config is not retrieved in this way.
+
+All registered engines are queried via their HTTP URL for transform config on T-Router startup. This allows for auto configuration of engine transformers, and generates a transform config for the T-Router. The T-Router transform config consists of aggregated transform configs from all engines plus all available pipeline transformers. It can be checked using the `/transform/config` endpoint. During the registration process, the engine names provided in the properties are mapped to the corresponding transformers supported by the particular engine and to the corresponding JMS queue.
+
+## T-Router pipeline configuration
+
+This section assumes that you're familiar with transformer concepts used in Alfresco Content Services and now in the Transform Service. A good place to start is the [Content Services](https://github.com/Alfresco/acs-packaging/blob/release/6.2.N/docs/custom-transforms-and-renditions.md){:target="_blank"} GitHub documentation, as the concepts and transformer configuration are identical.
+
+Here's a very brief overview.
+
+Each T-Engine may contain multiple transformers, as exposed via its `/transform/config` endpoint. Each transformer has a list of supported transforms, which consist of:
+
+* source and target media types (similar to mimetype)
+* maximum supported source file size
+* priority
+
+The priority is used in resolving conflicts or to deliberately override existing transforms, where everything else is equal. Each transformer can also have a set of options, for example, an image processing transformer might have options for the target image parameters (resolution, aspect ratio, etc.). All of this information determines the transformer for each incoming request. Pipeline transformers can be defined in terms of other pipeline transformers. Pipelines examples are provided later.
+
+## Out of the box pipeline transformer definitions
+
+The T-Router supports pipeline transformers, allowing it to perform transformations in a sequence of requests to various engines. This functionality is identical in definition to Content Services pipeline transformers (starting from Alfresco Transform Service 1.3.0). For more information on these pipelines, see the Content Services GitHub documentation on [Configuring a custom transform pipeline](https://github.com/Alfresco/acs-packaging/blob/release/6.2.N/docs/custom-transforms-and-renditions.md#configure-a-custom-transform-pipeline){:target="_blank"} as the T-Router pipeline transformers are defined using the same format. Due to this commonality, pipelines defined in Content Services can be moved to Transform Service directly. However, it's worth mentioning that most of the pipeline definitions provided out of the box are identical to the pipeline definitions in Content Services.
+
+The pipeline configuration file provided is bundled in the standard T-Router artifact/Docker image (the top resource being `transformer-pipelines.json`).
+
+The default file is specified through the SpringBoot property `transformer-routes-path`, which can be overridden by the `TRANSFORMER_ROUTES_PATH` environment variable.
+
+> **Note:** It is not recommended to override the default routes file, unless none of the pipelines are applicable for the use case. Instead, you can specify additional transforms defined in the provided `transformer-pipelines.json` file.
+
+Here's one of the pipeline transformers that provides additional transforms defined in the provided `transformer-pipelines.json` file:
+
+```json
+{
+    "transformers": [
+        {
+            "transformerName": "pdfToImageViaPng",
+            "transformerPipeline": [
+                {
+                    "transformerName": "pdfrenderer",
+                    "targetMediaType": "image/png"
+                },
+                {
+                    "transformerName": "imagemagick"
+                }
+            ],
+            "supportedSourceAndTargetList": [],
+            "transformOptions": [
+                "pdfRendererOptions",
+                "imageMagickOptions"
+            ]
+        }
+    ]
+}
+```
+
+The above definition will introduce a new transformer, specifically a pipeline transformer called `pdfToImageViaPng`. The pipeline transformer is made up of two single-step transformers, `pdfrenderer` and `imagemagick`. If the **supportedSourceAndTargetList** is left blank, then the T-Router will complete the supported list automatically. The supported list can be restricted to specific sources and targets by explicitly defining them, just like a single-step transformer in an engine would. Priorities can be used to override conflicting transforms provided by other transformers.
+
+> **Note:** Pipeline transformers become available only if all of the involved single-step transformers are available. The application logs will report any missing pipeline transformers on startup and config refresh.
+
+## Add new pipeline transformer definitions
+
+Additional transformers can be defined in new JSON or YAML files and specified through environment variables with the `TRANSFORMER_ROUTES_ADDITIONAL_` prefix:
+
+```bash
+export TRANSFORMER_ROUTES_ADDITIONAL_<name>="/path/to/the/additional/route/file.yaml"
+```
+
+> **Note:** The `<name>` suffix can be a random string. It doesn't need to match any other labels - it just differentiates multiple additional route files.
+
+Here's example content of an additional pipeline in JSON format (same as the `transformer-pipelines.json`) provided. The environment variable `TRANSFORMER_ROUTES_ADDITIONAL_OFFICE_TO_IMAGE="/additional.json"`, and the `additional.json` file could be:
+
+```json
+{
+    "transformers": [
+        {
+            "transformerName": "pdfToImageViaPng",
+            "transformerPipeline": [
+                {
+                    "transformerName": "pdfrenderer",
+                    "targetMediaType": "image/png"
+                },
+                {
+                    "transformerName": "imagemagick"
+                }
+            ],
+            "supportedSourceAndTargetList": [],
+            "transformOptions": [
+                "pdfRendererOptions",
+                "imageMagickOptions"
+            ]
+        }
+    ]
+}
+```
+
+Here's example content of an additional pipeline in YAML format. This is the same pipeline as in the JSON example. The environment variable `TRANSFORMER_ROUTES_ADDITIONAL_AI_ROUTES="/additional.json"`, and the `additional.json` content could be:
+
+```yaml
+routes:
+   - transformerName: pdfToImageViaPng
+     transformerPipeline:
+     - transformerName: pdfrenderer
+       targetMediaType: image/png
+     - transformerName: imagemagick
+     supportedSourceAndTargetList: []
+     transformOptions:
+     - pdfRendererOptions
+     - imageMagickOptions
+```
+
+Regardless of the format used, the custom pipeline definition files must be mounted on the T-Router container file-system.
+
+Multiple additional pipeline files can be specified. Ideally, for each new custom engine a separate custom pipeline file should be added.
+
+In case of clashes between transformers and their supported transforms:
+
+* If two transformers support the same source and target media type, the transformer with the higher priority is used (i.e. a lower numeric value is considered higher priority).
+
+* If the same transform is specified in multiple transformers with the same transform options, priority and maxSourceFileSize, then one of the transformers will be chosen at random.
+
+## Transform option filtering
+
+Each transformer can reference transform option names which it claims to support, but a pipeline transformer might reference options for multiple transformers as inherited from its single-step transformers. In order to send the correct options to the correct transformer, the options are filtered for each transform request to a T-Engine.
+
+If the applicable transformer is a single-step transformer, the request is sent to the relevant T-Engine, with the request transform options filtered based on the transformer's supported transform options list.
+
+If the applicable transformer is a pipeline transformer, then T-Router will filter transform options from the request for each intermediate step with respect to the current step's transformer.

--- a/transform-service/1.3/index.md
+++ b/transform-service/1.3/index.md
@@ -1,0 +1,21 @@
+---
+title: Alfresco Transform Service
+---
+
+The Alfresco Transform Service provides a secure, scalable, reliable, and extensible mechanism for converting files from their current format into other formats.
+
+Transform Service provides a single all-in-one Transform Core Engine (T-Engine) that performs all the core transforms. This replaces the five separate T-Engines for all but the largest deployments, where it's still advisable to separate out the different types of transforms into their own images. Note that the all-in-one T-Engine is the default option for the Docker Compose deployment and installation using the distribution zip, however Helm deployments continue to use the five separate T-Engines in order to provide balanced throughput and scalability improvements. This release also provides two main options for deployment: using containerized deployment or using the distribution zip.
+
+The extraction of metadata is performed in the T-Engines. Prior to Alfresco Content Services 7, it was performed inside the content repository. 
+
+The key capabilities of the Transform Service include the ability to:
+
+* Scale the transformation capabilities independently of the content repository.
+* Make use of the exposed transformation capabilities for all subsystems of the repository.
+* Provide a greater level of reliability and fault tolerance by using persistent queues.
+* Develop custom (i.e. out of process) transformers to enable the migration of any existing transform customizations.
+* Scale the metadata extraction independently of the content repository.
+
+> **Important:** The Transform Service is deployed as part of the Alfresco Content Services deployment for containerized deployments only. See [What's deployed in Content Services]({% link content-services/latest/install/containers/index.md %}#whats-deployed-in-content-services) for the list of components.
+
+> **Important:** If you're installing Content Services using the distribution zip, you can install the Transform Service using an additional distribution zip.

--- a/transform-service/1.3/install/index.md
+++ b/transform-service/1.3/install/index.md
@@ -63,21 +63,119 @@ This is recommended for evaluations only (i.e. test and development environments
 
 See [Install with Docker Compose]({% link transform-service/1.3/install/index.md %}#install-with-docker-compose) for more details.
 
-### Non-containerized deployment
+### Non-containerized deployment {#prereq-non-containerized-deploy}
+Before installing Transform Services from the distribution ZIP file, [install Alfresco Content Services using distribution ZIP]({% link content-services/latest/install/zip/index.md %}).
+This will also install the message broker ActiveMQ, which is used by Transform Services.
 
-Before you can use the Transform Service zip, you need to install the software requirements listed.
+In a non-containerized environment you need to install the following software before installing Transform Services:
 
-Follow the linked pages in the Content Services documentation, starting from [Install using distribution zip]({% link content-services/latest/install/zip/index.md %}).
+* LibreOffice: see [Install LibreOffice](#install-libreoffice)
+* ImageMagick: see [Install ImageMagick](#install-imagemagick)
+* alfresco-pdf-renderer: see [Install alfresco-pdf renderer](#install-pdf-renderer)
 
-#### Software requirements (zip)
+You can install the third-party software used by Transform Services independently.
 
-* Content Services: see [Supported Platforms]({% link transform-service/1.3/support/index.md %}) for the supported versions.
-* Messaging broker: see [Configure ActiveMQ]({% link content-services/latest/config/activemq.md %})
-* ImageMagick: see [Install ImageMagick]({% link content-services/latest/install/zip/additions.md %}#install-imagemagick)
-* LibreOffice: see [Install LibreOffice]({% link content-services/latest/install/zip/additions.md %}#install-libreoffice)
-* alfresco-pdf-renderer: see [Install alfresco-pdf renderer]({% link content-services/latest/install/zip/additions.md %}#install-alfresco-pdf-renderer)
+#### Install LibreOffice {#install-libreoffice}
+In Transform Services, you can transform a document from one format to another, for example, a text file to a PDF file.
+To access these transformation facilities, you must install LibreOffice.
 
-See [Install with zip]({% link transform-service/1.3/install/index.md %}#install-with-zip) for more details.
+1. Browse to the LibreOffice download site: [LibreOffice download site](https://www.libreoffice.org/download/download/){:target="_blank"}
+2. Download the latest (stable) version of LibreOffice for your platform.
+3. When prompted, specify a download destination.
+4. Browse to the location of your downloaded file, and install the application.
+5. Change the installation directory to:
+    * (Windows) `c:\Alfresco\LibreOffice`
+    * (Linux) `/opt/alfresco/LibreOffice`
+      If you're installing LibreOffice on Linux, you also need a number of libraries to be installed. See [Install Linux libraries](#install-linux-libraries) for more.
+
+##### Install Linux libraries {#install-linux-libraries}
+Use this information to install Linux libraries manually on supported Linux distributions, such as Ubuntu, SUSE and Red Hat.
+
+LibreOffice requires the following libraries to be installed on your system:
+* libfontconfig
+* libICE
+* libSM
+* libXrender
+* libXext
+* libXinerama
+* libcups
+* libGLU
+* libcairo2
+* libgl1-mesa-glx
+
+If the required libraries are missing, you'll get a warning message. You can install them using your preferred package
+manager from the command line. Note that the file names for the Linux libraries may vary by distribution.
+
+For Red Hat Enterprise Linux/CentOS, you can run:
+
+```bash
+cd <libre-install-dir>/LibreOffice_*.*.*.*_Linux_x86-64_rpm/RPMS/
+```
+
+```bash
+sudo yum localinstall *rpm
+```
+
+For Ubuntu:
+
+```bash
+cd <libre-install-dir>/LibreOffice_*.*.*.*_Linux_x86-64_rpm/RPMS/
+```
+
+```bash
+sudo dpkg -i *deb
+```
+
+If LibreOffice doesn't start up normally with Transform Services, test it manually, for example, by running this startup script:
+
+```bash
+start ex. {installdir}/libreoffice/scripts/libreoffice_ctl.sh start
+status ex. {installdir}/libreoffice/scripts/libreoffice_ctl.sh status
+```
+
+If you receive errors that indicate that a library is missing, work with your system administrator to add the
+missing library or its equivalent from your configured repositories.
+
+#### Install ImageMagick {#install-imagemagick}
+To enable image manipulation in Transform Services, you must install and configure ImageMagick. Transform Services uses
+ImageMagick to manipulate images for previewing.
+
+1. Check if ImageMagick is already installed on your system.
+   Use the ImageMagick convert command to check that you have the right software installed on your machine. This command is usually located in `/usr/bin`: `install Image`.
+2. If the ImageMagick software isn't available on your system, download and install the appropriate package for your platform.
+   To download ImageMagick, browse to [ImageMagick download website](https://www.imagemagick.org/script/download.php){:target="_blank"}.
+   > **Note:** In next steps, you'll make changes to the Content Services configuration files to enable the manually installed ImageMagick application. These steps can only be performed after Content Services has been installed.
+
+The following table lists example of how to set the paths to different things when starting Transform Core AIO later on:
+
+|Property|Description|
+   |--------|-----------|
+|img.root| Windows: `img.root=C:\\ImageMagick`<br>Linux: `img.root=/ImageMagick`<br><br>**Note:** Don't include a slash (`/`) at the end of the path, i.e. `/ImageMagick/`.|
+|img.dyn|Windows: `img.dyn=${img.root}\\lib` <br>Linux: `img.dyn=${img.root}/lib`|
+|img.exe|Windows: `img.exe=${img.root}\\convert.exe` <br>Linux: `img.exe=${img.root}/bin/convert`|
+|img.coders|Windows: `img.coders=${img.root}\\modules\\coders` <br>Linux: `img.coders=${img.root}/modules/coders`|
+|img.config|Windows: `img.config=${img.root}\\config` <br>Linux: `img.config=${img.root}/config`|
+|img.url|Windows: `img.url=${img.root}\\url` <br>Linux: `img.url=${img.root}/url`|
+
+> **Note:** Test that you're able to convert a PDF using the command: `convert filename.pdf[0] filename.png`
+
+#### Install alfresco-pdf-renderer {#install-pdf-renderer}
+Transform Services uses `alfresco-pdf-renderer` for creating document thumbnails and previews. Use this information to
+install `alfresco-pdf-renderer` on your system.
+
+>**Note:** The `alfresco-pdf-renderer` executable file is platform-specific.
+
+The `alfresco-pdf-renderer` binaries are available in the Alfresco Content Services distribution zip.
+
+* For Windows:
+    * Extract the file `alfresco-pdf-renderer/alfresco-pdf-renderer-1.0-win64.tgz` to a location of your choice.
+    * Browse to the location of your saved file and extract the archive.
+    * Note down the exe path: `<alfresco-pdf-renderer_installation_dir>/alfresco-pdf-renderer`
+
+* For Linux:
+    * Extract the file `alfresco-pdf-renderer/alfresco-pdf-renderer-1.0-linux.tgz` to a location of your choice.
+    * Browse to the location of your saved file and extract the archive.
+    * Note down the exe path: `<alfresco-pdf-renderer_installation_dir>/alfresco-pdf-renderer`
 
 ## Install with Helm charts
 
@@ -326,10 +424,12 @@ Use this information to verify that the system started correctly, and to clean u
 See the [Docker documentation](https://docs.docker.com/){:target="_blank"} for more on getting started with Docker and using Docker.
 
 ## Install with zip
+Use these instructions to install Transform Service using the distribution zip and connect it to an instance of
+Alfresco Content Services.
 
-Use these instructions to install Transform Service using the distribution zip to an instance of Content Services.
-
-The Transform Service distribution zip file includes all the files required to provide the Transform Service capabilities. Ensure that you've installed the prerequisites before continuing, for more see [Install Transform Service]({% link transform-service/1.3/install/index.md %}).
+The Transform Services distribution zip file includes all the files required to provide the transformation and
+metadata extraction capabilities. Ensure that you've installed the [prerequisites](#prereq-non-containerized-deploy)
+before continuing.
 
 1. Browse to the [Alfresco Support Portal](https://support.alfresco.com/){:target="_blank"} and download `alfresco-transform-service-distribution-1.3.x.zip`.
 
@@ -416,16 +516,12 @@ The Transform Service distribution zip file includes all the files required to p
     sfs.url=http://localhost:8099
     sfs.endpoint=${sfs.url}/alfresco/api/-default-/private/sfs/versions/1/file
 
-    # Transform Router property:
+    # Transform Router properties:
+    transform.service.enabled=true
     transform.service.url=http://localhost:8095/
 
     # Transform Core properties:
     localTransform.core-aio.url=http://transform-core-aio:8090/
-    alfresco-pdf-renderer.url=http://transform-core-aio:8090/
-    jodconverter.url=http://transform-core-aio:8090/
-    img.url=http://transform-core-aio:8090/
-    tika.url=http://transform-core-aio:8090/
-    transform.misc.url=http://transform-core-aio:8090/
     ```
 
     This overrides the default properties provided by Content Services.

--- a/transform-service/1.3/install/index.md
+++ b/transform-service/1.3/install/index.md
@@ -1,0 +1,453 @@
+---
+title: Install Transform Service
+---
+
+This release provides two main options for deployment: using the distribution zip, or using containerized deployment.
+
+The Transform Service zip can be applied when installing Alfresco Content Services using the distribution zip.
+
+The Transform Service is also deployed as part of the Content Services containerized deployment using Docker images that are packaged in Helm charts. These charts are a deployment template that can be used as the basis for your specific deployment needs.
+
+> **Note:** Deployment of Transform Service with Content Services on AWS, such as Amazon EKS (Elastic Kubernetes Service), is recommended only for customers with a good knowledge of Content Services, and strong competencies in AWS and containerized deployment.
+
+The following diagram shows how Content Services and the components of the Transform Service interact when deployed using Docker Compose.
+
+![Docker Compose Deployment Overview]({% link transform-service/images/docker-compose-components.png %})
+
+The following diagram shows how Content Services and the components of the Transform Service interact when deployed using Helm charts.
+
+![ACS Helm Deployment Overview]({% link transform-service/images/helm-components.png %})
+
+## Prerequisites
+
+There are a number of software requirements for installing Transform Service.
+
+The Transform Service is only deployed as part of Content Services for containerized deployments.
+
+However, this is not the case if you're installing Content Services using the distribution zip. See [Supported platforms]({% link transform-service/1.3/support/index.md %}) for more information.
+
+### Containerized deployments
+
+The images downloaded directly from [Docker Hub](https://hub.docker.com/u/alfresco/){:target="_blank"}, or [Quay.io](https://quay.io/){:target="_blank"} are for a limited trial of the Enterprise version of Content Services that goes into read-only mode after 2 days. For a longer (30-day) trial, get the Alfresco Content Services [Download Trial](https://www.alfresco.com/platform/content-services-ecm/trial/download){:target="_blank"}.
+
+> **Note:** A [Quay.io](https://quay.io/) account is needed to pull the Docker images that are needed for the Transform Service:
+>
+> * `alfresco/alfresco-transform-router`
+
+The other images are available in DockerHub:
+
+* `alfresco/alfresco-shared-file-store`
+* `alfresco/alfresco-transform-core-aio`
+
+#### Software requirements (Helm)
+
+To use the Content Services deployment (including the Transform Service), you need to install the following software:
+
+* [AWS CLI](https://github.com/aws/aws-cli#installation){:target="_blank"} - the command line interface for Amazon Web Services.
+* [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/){:target="_blank"} - the command line tool for Kubernetes.
+* [Helm](https://github.com/helm/helm#install){:target="_blank"} - the tool for installing and managing Kubernetes applications.
+  * There are Helm charts that allow you to deploy Content Services with Transform Service in a Kubernetes cluster, for example, on AWS.
+
+See [Install with Helm charts]({% link transform-service/1.3/install/index.md %}#install-with-helm-charts) for more details.
+
+#### Software requirements (Docker)
+
+This is recommended for evaluations only (i.e. test and development environments).
+
+* [Docker](https://docs.docker.com/install/){:target="_blank"} (latest stable version)
+  * This allows you to run Docker images and `docker-compose` on a single computer.
+* [Docker Compose](https://docs.docker.com/compose/install/){:target="_blank"}
+  * Docker Compose is included as part of some Docker installers. If it's not part of your installation, then install it separately after you've installed Docker.
+
+> **Note:** Check the prerequisites for your operating system, both for Docker and Docker Compose.
+
+See [Install with Docker Compose]({% link transform-service/1.3/install/index.md %}#install-with-docker-compose) for more details.
+
+### Non-containerized deployment
+
+Before you can use the Transform Service zip, you need to install the software requirements listed.
+
+Follow the linked pages in the Content Services documentation, starting from [Install using distribution zip]({% link content-services/latest/install/zip/index.md %}).
+
+#### Software requirements (zip)
+
+* Content Services: see [Supported Platforms]({% link transform-service/1.3/support/index.md %}) for the supported versions.
+* Messaging broker: see [Configure ActiveMQ]({% link content-services/latest/config/activemq.md %})
+* ImageMagick: see [Install ImageMagick]({% link content-services/latest/install/zip/additions.md %}#install-imagemagick)
+* LibreOffice: see [Install LibreOffice]({% link content-services/latest/install/zip/additions.md %}#install-libreoffice)
+* alfresco-pdf-renderer: see [Install alfresco-pdf renderer]({% link content-services/latest/install/zip/additions.md %}#install-alfresco-pdf-renderer)
+
+See [Install with zip]({% link transform-service/1.3/install/index.md %}#install-with-zip) for more details.
+
+## Install with Helm charts
+
+Use this information to deploy Content Services (including the Transform Service) using Helm charts by running a Kubernetes cluster on Amazon Web Services (AWS). These charts are a deployment template which can be used as the basis for your specific deployment needs.
+
+The Helm charts are provided as a reference that can be used to build deployments in AWS. If you're a System administrator, ensure that data persistence, backups, log storage, and other system-level functions have been configured to meet your needs.
+
+You'll need your [Quay.io](https://quay.io){:target="_blank"} account credentials to access the Docker images. If you don't already have these credentials, contact [Alfresco Support](https://support.alfresco.com/){:target="_blank"}.
+
+Here is a summary of the steps required:
+
+1. Set up your Kubernetes cluster on AWS.
+2. Install the Kubernetes Dashboard to manage your Kubernetes cluster.
+3. Set up Content Services on the Kubernetes cluster, including creating file storage.
+4. To access the images in [Quay.io](https://quay.io/){:target="_blank"}, you'll need to generate a pull secret and apply it to your cluster.
+5. Deploy Content Services.
+
+    > **Note:** Remember to pass the name of the secret as an extra `--set` argument in the `helm install` command.
+
+6. Check the status of your deployment.
+
+See the [Alfresco/acs-deployment](https://github.com/Alfresco/acs-deployment/){:target="_blank"} GitHub project documentation for the prerequisites and detailed setup:
+
+* [Deploying with Helm charts on AWS using EKS](https://github.com/Alfresco/acs-deployment/blob/support/SP/4.N/docs/helm-deployment-aws_eks.md){:target="_blank"}
+
+## Install with Docker Compose
+
+Use this information to quickly start up Content Services (including Transform Service) using Docker Compose. Due to the limited capabilities of Docker Compose, this deployment method is only recommended for development and test environments.
+
+To check which branch tag corresponds to a specific Content Services release, review the [release versions](https://github.com/Alfresco/acs-deployment/blob/support/SP/4.N/docs/helm-chart-releases.md){:target="_blank"} page in GitHub. Choose a version from the left column that corresponds to the required Content Services version you want to deploy.
+
+   > **Note:** Check the prerequisites for your operating system, both for Docker and Docker Compose, using the links provided.
+
+1. Clone the project locally, and then change directory to the project folder:
+
+   ```bash
+    git clone --branch x.y.z https://github.com/Alfresco/acs-deployment.git
+    cd acs-deployment/docker-compose
+    ```
+
+    > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to deploy. For example, if you want Content Services 7.0.0, then select tag `5.0.0`.
+
+    > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
+
+2. Log in to Quay.io using your credentials:
+
+    ```bash
+    docker login https://quay.io
+    ```
+
+    You'll need your [Quay.io](https://quay.io){:target="_blank"} account credentials to access the Docker images. If you don't already have these credentials, contact [Alfresco Support](https://support.alfresco.com/){:target="_blank"}.
+
+3. Deploy Content Services, including the repository, Share, Postgres database, Search Services, and Transform Service:
+
+    ```bash
+    docker-compose up
+    ```
+
+    This downloads the images, fetches all the dependencies, creates each container, and then starts the system:
+
+    ```bash
+    Creating network "docker-compose_default" with the default driver
+    Creating docker-compose_digital-workspace_1 ... done
+    Creating docker-compose_solr6_1             ... done
+    Creating docker-compose_shared-file-store_1 ... done
+    Creating docker-compose_sync-service_1      ... done
+    Creating docker-compose_alfresco_1          ... done
+    Creating docker-compose_share_1             ... done
+    Creating docker-compose_postgres_1          ... done
+    Creating docker-compose_activemq_1          ... done
+    Creating docker-compose_proxy_1              ... done
+    Creating docker-compose_transform-router_1   ... done
+    Creating docker-compose_transform-core-aio_1 ... done
+    Attaching to docker-compose_digital-workspace_1, docker-compose_shared-file-store_1, docker-compose_alfresco_1,
+    ```
+
+    As an alternative, you can also start the containers in the background by running `docker-compose up -d`.
+
+4. Wait for the logs to show messages:
+
+    ```bash
+    alfresco_1 | 2020-07-06 11:50:46,808  WARN ... The Alfresco Content Services license will expire in 2 days.
+    alfresco_1 | 2020-07-06 11:50:50,938  INFO ... Starting 'Transformers' subsystem, ID: [Transformers, default]
+    alfresco_1 | 2020-07-06 11:50:50,371  INFO ... Startup of 'Transformers' subsystem, ID: [Transformers, default] complete
+    ```
+
+    If you encounter errors whilst the system is starting up:
+
+    * Stop the session (by using `CONTROL+C`).
+    * Remove the container using `--rmi all`. This option also removes the images created by docker-compose up, and the images used by any service. You can use this, for example, if any containers fail and you need to remove them.
+    * Try allocating more memory resources, as advised in `docker-compose.yml`. For example, in Docker, change the memory setting in **Preferences** (or **Settings**) > **Advanced** > **Memory**, to at least 8GB. Make sure you restart Docker and wait for the process to finish before continuing.
+    * Go back to step 5 in the initial Docker Compose instructions to start the deployment again.
+
+    > **Note:** You'll need a machine with at least 13GB of memory to distribute among the Docker containers.
+
+5. Open your browser and check everything starts up correctly:
+
+    | Service | Endpoint |
+    | ------- | -------- |
+    | Administration and REST APIs | `http://localhost:8080/alfresco` |
+    | Share | `http://localhost:8080/share` |
+    | Digital Workspace | `http://localhost:8080/workspace` |
+    | Search Services administration | `http://localhost:8083/solr` |
+    | Transform Router configuration | `http://localhost:8095/transform/config` |
+    | ActiveMQ Admin Web Console | `http://localhost:8161/admin` |
+
+6. Log in as the `admin` user. Enter the default administrator password `admin`.
+
+You can use a number of commands to check that the system started correctly, see below.
+
+See the [Alfresco/acs-deployment](https://github.com/Alfresco/acs-deployment/tree/support/SP/4.N) GitHub project documentation for the prerequisites and detailed setup: [Deploying using Docker Compose](https://github.com/Alfresco/acs-deployment/blob/support/SP/4.N/docs/docker-compose-deployment.md){:target="_blank"}.
+
+### Check system start up
+
+Use this information to verify that the system started correctly, and to clean up the deployment.
+
+1. Open a new terminal window.
+
+2. Change directory to the `docker-compose` folder that you created in the deployment steps.
+
+3. Verify that all the services started correctly.
+
+    1. List the images and additional details:
+
+        ```bash
+        docker-compose images
+        ```
+
+        You should see a list of the services defined in your `docker-compose.yaml` file:
+
+        ```bash
+        Container                             Repository                                     Tag         Image Id       Size  
+        ------------------------------------------------------------------------------------------------------------------------
+        docker-compose_activemq_1             alfresco/alfresco-activemq                     5.15.8      80350f7a9820   545.9 MB
+        docker-compose_alfresco_1             quay.io/alfresco/alfresco-content-repository   7.0.0       835dbb204129   1.076 GB
+        docker-compose_digital-workspace_1    quay.io/alfresco/alfresco-digital-workspace    2.0.0-adw   b360030b24f9   35.65 MB
+        docker-compose_postgres_1             postgres                                       11.7        028e3a6bd9eb   283 MB  
+        docker-compose_proxy_1                alfresco/alfresco-acs-nginx                    3.0.1       4f0b84bc5ba0   20.42 MB
+        docker-compose_share_1                quay.io/alfresco/alfresco-share                7.0.0       059352863557   868.2 MB
+        docker-compose_shared-file-store_1    alfresco/alfresco-shared-file-store            0.10.0      56ff9f67200d   776.7 MB
+        docker-compose_solr6_1                alfresco/alfresco-search-services              2.0.1       a98e3e14aefd   1.148 GB
+        docker-compose_sync-service_1         quay.io/alfresco/service-sync                  3.4.0       ab5f9ad0ede1   801.9 MB
+        docker-compose_transform-core-aio_1   alfresco/alfresco-transform-core-aio           2.3.6       92c19ace0938   1.707 GB
+        docker-compose_transform-router_1     quay.io/alfresco/alfresco-transform-router     1.3.1       b91dd1045459   729.5 MB
+        ```
+
+    2. List the running containers:
+
+        ```bash
+        docker-compose ps
+        ```
+
+        You should see a list of the services defined in the `docker-compose.yaml` file.
+
+    3. View the log files for each service `<service-name>`, or container `<container-name>`:
+
+        ```bash
+        docker-compose logs <service-name>
+        docker container logs `<container-name>`
+        ```
+
+        For example, to check the logs for Share, run any of the following commands:
+
+        ```bash
+        docker-compose logs share
+        docker container logs docker-compose_share_1
+        ```
+
+        You can add an optional parameter `--tail=25` before `<container-name>` to display the last 25 lines of the logs for the selected container.
+
+        ```bash
+        docker container logs --tail=25 docker-compose_share_1
+        ```
+
+        Check for a success message:
+
+        ```bash
+        Successfully retrieved license information from Alfresco.
+        ```
+
+    Once you've tested the services, you can clean up the deployment by stopping the running services.
+
+4. Stop the session by using `CONTROL+C` in the same window as the running services:
+
+    ```bash
+    ^CGracefully stopping... (press Ctrl+C again to force)
+    Stopping docker-compose_transform-core-aio_1 ... done
+    Stopping docker-compose_transform-router_1   ... done
+    Stopping docker-compose_proxy_1              ... done
+    Stopping docker-compose_sync-service_1       ... done
+    Stopping docker-compose_shared-file-store_1  ... done
+    Stopping docker-compose_postgres_1           ... done
+    Stopping docker-compose_activemq_1           ... done
+    Stopping docker-compose_share_1              ... done
+    Stopping docker-compose_solr6_1              ... done
+    Stopping docker-compose_alfresco_1           ... done
+    Stopping docker-compose_digital-workspace_1  ... done
+    ```
+
+5. Alternatively, you can open a new terminal window, change directory to the `docker-compose` folder, and run:
+
+    ```bash
+    docker-compose down
+    ```
+
+    This stops the running services, as shown in the previous example, and removes them from memory:
+
+    ```bash
+    Stopping docker-compose_transform-core-aio_1 ... done
+    ...
+    Stopping docker-compose_digital-workspace_1  ... done
+    Removing docker-compose_transform-core-aio_1 ... done
+    ...
+    Removing docker-compose_digital-workspace_1  ... done
+    Removing network docker-compose_default
+    ```
+
+6. You can use a few more commands to explore the services when they're running. Change directory to `docker-compose` before running these:
+
+    1. Stop all the running containers:
+
+        ```bash
+        docker-compose stop
+        ```
+
+    2. Restart the containers (after using the `stop` command):
+
+        ```bash
+        docker-compose restart
+        ```
+
+    3. Starts the containers that were started with `docker-compose up`:
+
+        ```bash
+        docker-compose start
+        ```
+
+    4. Stop all running containers, and remove them and the network:
+
+        ```bash
+        docker-compose down [--rmi all]
+        ```
+
+        The `--rmi all` option also removes the images created by `docker-compose up`, and the images used by any service. You can use this, for example, if any containers fail and you need to remove them.
+
+See the [Docker documentation](https://docs.docker.com/){:target="_blank"} for more on getting started with Docker and using Docker.
+
+## Install with zip
+
+Use these instructions to install Transform Service using the distribution zip to an instance of Content Services.
+
+The Transform Service distribution zip file includes all the files required to provide the Transform Service capabilities. Ensure that you've installed the prerequisites before continuing, for more see [Install Transform Service]({% link transform-service/1.3/install/index.md %}).
+
+1. Browse to the [Alfresco Support Portal](https://support.alfresco.com/){:target="_blank"} and download `alfresco-transform-service-distribution-1.3.x.zip`.
+
+2. Extract the zip file into a system directory; for example, `<installLocation>/`.
+
+    In this directory you'll see the following content including three runnable JAR files:
+
+    * `alfresco-shared-file-store-controller-x.y.z.jar`
+    * `alfresco-transform-core-aio-boot-x.y.z.jar`
+    * `alfresco-transform-router-1.3.x.jar`
+    * `README.md`
+
+3. Start Active MQ.
+
+    For example, run the following command from the ActiveMQ installation directory:
+
+    ```bash
+    bin/activemq start
+    ```
+
+    For more information on installing and configuring ActiveMQ, see [Configure ActiveMQ]({% link content-services/latest/config/activemq.md %}).
+
+    Check the output to ensure that it starts successfully.
+
+    Make a note of the TCP URL, with example format `tcp://server:port`, where server is the host name of the server where ActiveMQ is installed. This is used in later steps.
+
+    Content Services uses ActiveMQ for message queuing with various products, including the Transform Service.
+
+4. Start the Shared File Store controller:
+
+    ```java
+    java -DfileStorePath=/path/to/your/AlfrescoFileStore
+     -jar alfresco-shared-file-store-controller-x.y.z.jar
+    ```
+
+    Check the output to ensure that it starts successfully.
+
+    By default, files are stored in `fileStorePath=/tmp/Alfresco`. This can be modified using the `fileStorePath` parameter as shown in the above example.
+
+    The Shared File Store allows components such as the repository, and the Transform Service to share a common place to store and retrieve files, for example, to enable transforms from an input source file to an output target file.
+
+5. Start the all-in-one Transform Core Engine Spring Boot app:
+
+    ```java
+    java -DPDFRENDERER_EXE="<alfresco-pdf-renderer_installation_dir>/alfresco-pdf-renderer"
+     -DLIBREOFFICE_HOME="<libreoffice_installation_dir>"
+     -DIMAGEMAGICK_ROOT="<imagemagick_installation_dir>"
+     -DIMAGEMAGICK_DYN="<imagemagick_installation_dir>/lib"
+     -DIMAGEMAGICK_EXE="<imagemagick_installation_dir>/bin/convert"
+     -DACTIVEMQ_URL=failover:(tcp://server:61616)?timeout=3000
+     -DFILE_STORE_URL=http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file
+     -jar alfresco-transform-core-aio-boot-x.y.z.jar
+    ```
+
+    > **Note:** You may need to change the paths depending on your operating system.
+
+    Check the output to ensure that it starts successfully.
+
+    The all-in-one core T-Engine combines the five T-Engines (i.e. LibreOffice, ImageMagick, Alfresco PDF Renderer, Tika, and Misc) into one single engine. All functionality that's available in the five T-Engines is available in the all-in-one core T-Engine. The command-line options provide the paths to the installation locations and the URL of the messaging broker.
+
+6. Start the Transform Router Spring Boot app:
+
+    ```java
+    java -DCORE_AIO_URL=http://localhost:8090
+     -DCORE_AIO_QUEUE=org.alfresco.transform.engine.aio.acs
+     -DACTIVEMQ_URL=failover:(tcp://server:61616)?timeout=3000
+     -DFILE_STORE_URL=http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file
+     -jar alfresco-transform-router-1.3.x.jar
+    ```
+
+    Check the output to ensure that it starts successfully.
+
+    The Transform Router allows simple (single-step) and pipeline (multi-step) transforms that are passed to the Transform Engines. The command-line options provide the router with the required data for T-Engines, queuing, and file-store URL.
+
+7. Set the following properties in the `<TOMCAT_HOME>/shared/classes/alfresco-global.properties` file:
+
+    ```bash
+    # ActiveMQ properties:
+    messaging.broker.url=failover:(tcp://server:61616)?timeout=3000
+    messaging.broker.username=$MQUSER
+    messaging.broker.password=$MQPASS
+
+    # Shared File Store properties:
+    sfs.url=http://localhost:8099
+    sfs.endpoint=${sfs.url}/alfresco/api/-default-/private/sfs/versions/1/file
+
+    # Transform Router property:
+    transform.service.url=http://localhost:8095/
+
+    # Transform Core properties:
+    localTransform.core-aio.url=http://transform-core-aio:8090/
+    alfresco-pdf-renderer.url=http://transform-core-aio:8090/
+    jodconverter.url=http://transform-core-aio:8090/
+    img.url=http://transform-core-aio:8090/
+    tika.url=http://transform-core-aio:8090/
+    transform.misc.url=http://transform-core-aio:8090/
+    ```
+
+    This overrides the default properties provided by Content Services.
+
+    > **Note:** Any changes to `alfresco-global.properties` require you to restart Content Services to apply the updates. See the Content Services documentation [Using alfresco-global.properties]({% link content-services/latest/config/index.md%}#using-alfresco-globalproperties) for more information.
+
+8. Check that the [configuration]({% link transform-service/1.3/config/index.md %}) is set up correctly for your environment.
+
+9. Restart Content Services.
+
+10. Ensure that the environment is up and running:
+
+    1.Check the logs for Content Services startup.
+
+    2.Monitor ActiveMQ by accessing the Web Console, e.g. `http://localhost:8161/admin/`.
+
+    3.Temporarily enable `TransformDebug` in the repository if you want to see detailed debug log entries.
+
+    4.Navigate to Digital Workspace or Share, and upload a file (such as a `.jpg`, `.png`, `.docx` etc.).
+
+* Check the logs to see the metadata and work performed for the uploaded file. These should be available in the Spring Boot apps:
+  * `alfresco-transform-router`
+  * `alfresco-transform-core-aio`
+
+Files should also be available in the specified path for the `alfresco-shared-file-store`. However, these files will only temporarily appear in the Shared File Store until explicitly deleted by the repository and/or expired and cleaned up.

--- a/transform-service/1.3/support/index.md
+++ b/transform-service/1.3/support/index.md
@@ -1,0 +1,12 @@
+---
+title: Supported Platforms
+---
+
+The following are the supported platforms and software requirements for Alfresco Transform Service 1.3:
+
+## Alfresco Content Services
+
+| Version | Notes |
+| ------- | ----- |
+| Content Services 6.2.2 | |
+| Content Services 7.0.0 | |

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -63,21 +63,152 @@ This is recommended for evaluations only (i.e. test and development environments
 
 See [Install with Docker Compose]({% link transform-service/latest/install/index.md %}#install-with-docker-compose) for more details.
 
-### Non-containerized deployment
+### Non-containerized deployment {#prereq-non-containerized-deploy}
+Before installing Transform Services from the distribution ZIP file, [install Alfresco Content Services using distribution ZIP]({% link content-services/latest/install/zip/index.md %}).
+This will also install the message broker ActiveMQ, which is used by Transform Services.
 
-Before you can use the Transform Service zip, you need to install the software requirements listed.
+In a non-containerized environment you need to install the following software before installing Transform Services:
 
-Follow the linked pages in the Content Services documentation, starting from [Install using distribution zip]({% link content-services/latest/install/zip/index.md %}).
+* LibreOffice: see [Install LibreOffice](#install-libreoffice)
+* ImageMagick: see [Install ImageMagick](#install-imagemagick)
+* alfresco-pdf-renderer: see [Install alfresco-pdf renderer](#install-pdf-renderer)
+* Exiftool: see [Install Exiftool](#install-exiftool)
 
-#### Software requirements (zip)
+You can install the third-party software used by Transform Services independently. 
 
-* Content Services: see [Supported Platforms]({% link transform-service/latest/support/index.md %}) for the supported versions.
-* Messaging broker: see [Configure ActiveMQ]({% link content-services/latest/config/activemq.md %})
-* ImageMagick: see [Install ImageMagick]({% link content-services/latest/install/zip/additions.md %}#install-imagemagick)
-* LibreOffice: see [Install LibreOffice]({% link content-services/latest/install/zip/additions.md %}#install-libreoffice)
-* alfresco-pdf-renderer: see [Install alfresco-pdf renderer]({% link content-services/latest/install/zip/additions.md %}#install-alfresco-pdf-renderer)
+#### Install LibreOffice {#install-libreoffice}
+In Transform Services, you can transform a document from one format to another, for example, a text file to a PDF file. 
+To access these transformation facilities, you must install LibreOffice. 
 
-See [Install with zip]({% link transform-service/latest/install/index.md %}#install-with-zip) for more details.
+1. Browse to the LibreOffice download site: [LibreOffice download site](https://www.libreoffice.org/download/download/){:target="_blank"}
+2. Download the latest (stable) version of LibreOffice for your platform.
+3. When prompted, specify a download destination.
+4. Browse to the location of your downloaded file, and install the application.
+5. Change the installation directory to:
+    * (Windows) `c:\Alfresco\LibreOffice`
+    * (Linux) `/opt/alfresco/LibreOffice`
+   If you're installing LibreOffice on Linux, you also need a number of libraries to be installed. See [Install Linux libraries](#install-linux-libraries) for more.
+
+##### Install Linux libraries {#install-linux-libraries}
+Use this information to install Linux libraries manually on supported Linux distributions, such as Ubuntu, SUSE and Red Hat.
+
+LibreOffice requires the following libraries to be installed on your system:
+* libfontconfig
+* libICE
+* libSM
+* libXrender
+* libXext
+* libXinerama
+* libcups
+* libGLU
+* libcairo2
+* libgl1-mesa-glx
+
+If the required libraries are missing, you'll get a warning message. You can install them using your preferred package 
+manager from the command line. Note that the file names for the Linux libraries may vary by distribution.
+
+For Red Hat Enterprise Linux/CentOS, you can run:
+
+```bash
+cd <libre-install-dir>/LibreOffice_*.*.*.*_Linux_x86-64_rpm/RPMS/
+```
+
+```bash
+sudo yum localinstall *rpm
+```
+
+For Ubuntu:
+
+```bash
+cd <libre-install-dir>/LibreOffice_*.*.*.*_Linux_x86-64_rpm/RPMS/
+```
+
+```bash
+sudo dpkg -i *deb
+```
+
+If LibreOffice doesn't start up normally with Transform Services, test it manually, for example, by running this startup script:
+
+```bash
+start ex. {installdir}/libreoffice/scripts/libreoffice_ctl.sh start
+status ex. {installdir}/libreoffice/scripts/libreoffice_ctl.sh status
+```
+
+If you receive errors that indicate that a library is missing, work with your system administrator to add the 
+missing library or its equivalent from your configured repositories.
+
+#### Install ImageMagick {#install-imagemagick}
+To enable image manipulation in Transform Services, you must install and configure ImageMagick. Transform Services uses 
+ImageMagick to manipulate images for previewing.
+
+1. Check if ImageMagick is already installed on your system.
+   Use the ImageMagick convert command to check that you have the right software installed on your machine. This command is usually located in `/usr/bin`: `install Image`.
+2. If the ImageMagick software isn't available on your system, download and install the appropriate package for your platform.
+   To download ImageMagick, browse to [ImageMagick download website](https://www.imagemagick.org/script/download.php){:target="_blank"}.
+   > **Note:** In next steps, you'll make changes to the Content Services configuration files to enable the manually installed ImageMagick application. These steps can only be performed after Content Services has been installed.
+
+The following table lists example of how to set the paths to different things when starting Transform Core AIO later on:
+
+   |Property|Description|
+   |--------|-----------|
+   |img.root| Windows: `img.root=C:\\ImageMagick`<br>Linux: `img.root=/ImageMagick`<br><br>**Note:** Don't include a slash (`/`) at the end of the path, i.e. `/ImageMagick/`.|
+   |img.dyn|Windows: `img.dyn=${img.root}\\lib` <br>Linux: `img.dyn=${img.root}/lib`|
+   |img.exe|Windows: `img.exe=${img.root}\\convert.exe` <br>Linux: `img.exe=${img.root}/bin/convert`|
+   |img.coders|Windows: `img.coders=${img.root}\\modules\\coders` <br>Linux: `img.coders=${img.root}/modules/coders`|
+   |img.config|Windows: `img.config=${img.root}\\config` <br>Linux: `img.config=${img.root}/config`|
+   |img.url|Windows: `img.url=${img.root}\\url` <br>Linux: `img.url=${img.root}/url`|
+
+> **Note:** Test that you're able to convert a PDF using the command: `convert filename.pdf[0] filename.png`
+
+#### Install alfresco-pdf-renderer {#install-pdf-renderer}
+Transform Services uses `alfresco-pdf-renderer` for creating document thumbnails and previews. Use this information to 
+install `alfresco-pdf-renderer` on your system.
+
+>**Note:** The `alfresco-pdf-renderer` executable file is platform-specific.
+
+The `alfresco-pdf-renderer` binaries are available in the Alfresco Content Services distribution zip.
+
+* For Windows:
+    * Extract the file `alfresco-pdf-renderer/alfresco-pdf-renderer-1.0-win64.tgz` to a location of your choice.
+    * Browse to the location of your saved file and extract the archive.
+    * Note down the exe path: `<alfresco-pdf-renderer_installation_dir>/alfresco-pdf-renderer`
+
+* For Linux:
+    * Extract the file `alfresco-pdf-renderer/alfresco-pdf-renderer-1.0-linux.tgz` to a location of your choice.
+    * Browse to the location of your saved file and extract the archive.
+    * Note down the exe path: `<alfresco-pdf-renderer_installation_dir>/alfresco-pdf-renderer`
+    
+#### Install ExifTool {#install-exiftool}
+Transform Services uses the [ExifTool](https://exiftool.org/){:target="_blank"} for metadata extraction. 
+
+Download version 12.25 of the ExifTool from [Alfresco Nexus Server](https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/exiftool/image-exiftool/12.25/image-exiftool-12.25.tgz){:target="_blank"}
+
+See this [ExifTool page](https://exiftool.org/install.html){:target="_blank"} for installation instructions.
+
+The steps to install are:
+
+- Download exiftool 
+- Unzip exiftool
+- Perl needs to be installed
+- ExifTool needs to then be installed globally
+
+Example from Transform Services Dockerfile:
+
+```bash
+ARG EXIFTOOL_VERSION=12.25
+ARG EXIFTOOL_FOLDER=Image-ExifTool-${EXIFTOOL_VERSION}
+ARG EXIFTOOL_URL=https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/exiftool/image-exiftool/${EXIFTOOL_VERSION}/image-exiftool-${EXIFTOOL_VERSION}.tgz
+
+RUN ...
+    curl -s -S $EXIFTOOL_URL -o ${EXIFTOOL_FOLDER}.tgz && \
+    tar xzf ${EXIFTOOL_FOLDER}.tgz && \
+    yum -y install perl && \
+    (cd ./${EXIFTOOL_FOLDER} && \
+    perl Makefile.PL && \
+    make && \
+    make test && \
+    make install) 
+```
 
 ## Install with Helm charts
 
@@ -211,17 +342,17 @@ Use this information to verify that the system started correctly, and to clean u
         ```bash
         Container                             Repository                                     Tag         Image Id       Size  
         ------------------------------------------------------------------------------------------------------------------------
-        docker-compose_activemq_1             alfresco/alfresco-activemq                     5.15.8      80350f7a9820   545.9 MB
-        docker-compose_alfresco_1             quay.io/alfresco/alfresco-content-repository   7.0.0       835dbb204129   1.076 GB
-        docker-compose_digital-workspace_1    quay.io/alfresco/alfresco-digital-workspace    2.0.0-adw   b360030b24f9   35.65 MB
-        docker-compose_postgres_1             postgres                                       11.7        028e3a6bd9eb   283 MB  
-        docker-compose_proxy_1                alfresco/alfresco-acs-nginx                    3.0.1       4f0b84bc5ba0   20.42 MB
-        docker-compose_share_1                quay.io/alfresco/alfresco-share                7.0.0       059352863557   868.2 MB
-        docker-compose_shared-file-store_1    alfresco/alfresco-shared-file-store            0.10.0      56ff9f67200d   776.7 MB
-        docker-compose_solr6_1                alfresco/alfresco-search-services              2.0.1       a98e3e14aefd   1.148 GB
-        docker-compose_sync-service_1         quay.io/alfresco/service-sync                  3.4.0       ab5f9ad0ede1   801.9 MB
-        docker-compose_transform-core-aio_1   alfresco/alfresco-transform-core-aio           2.3.6       92c19ace0938   1.707 GB
-        docker-compose_transform-router_1     quay.io/alfresco/alfresco-transform-router     1.3.1       b91dd1045459   729.5 MB
+        enterprise_activemq_1             alfresco/alfresco-activemq                     5.16.1    76a6bf63e939   716.3 MB
+        enterprise_alfresco_1             quay.io/alfresco/alfresco-content-repository   7.0.0     a5194e768856   1.484 GB
+        enterprise_digital-workspace_1    quay.io/alfresco/alfresco-digital-workspace    2.2.0     81df07ae33ac   34.23 MB
+        enterprise_postgres_1             postgres                                       13.1      407cece1abff   314.2 MB
+        enterprise_proxy_1                alfresco/alfresco-acs-nginx                    3.1.1     3a00a45550a3   21.86 MB
+        enterprise_share_1                quay.io/alfresco/alfresco-share                7.0.0     325a65fe295e   743.2 MB
+        enterprise_shared-file-store_1    quay.io/alfresco/alfresco-shared-file-store    0.14.1    54983a649f02   661.2 MB
+        enterprise_solr6_1                alfresco/alfresco-search-services              2.0.1     a98e3e14aefd   1.148 GB
+        enterprise_sync-service_1         quay.io/alfresco/service-sync                  3.4.0     7c0cee15f516   800 MB  
+        enterprise_transform-core-aio_1   alfresco/alfresco-transform-core-aio           2.4.0     71a54fd6c834   1.708 GB
+        enterprise_transform-router_1     quay.io/alfresco/alfresco-transform-router     1.4.0     a45d3ca24d65   614.7 MB
         ```
 
     2. List the running containers:
@@ -326,12 +457,14 @@ Use this information to verify that the system started correctly, and to clean u
 See the [Docker documentation](https://docs.docker.com/){:target="_blank"} for more on getting started with Docker and using Docker.
 
 ## Install with zip
+Use these instructions to install Transform Service using the distribution zip and connect it to an instance of 
+Alfresco Content Services.
 
-Use these instructions to install Transform Service using the distribution zip to an instance of Content Services.
+The Transform Services distribution zip file includes all the files required to provide the transformation and 
+metadata extraction capabilities. Ensure that you've installed the [prerequisites](#prereq-non-containerized-deploy) 
+before continuing.
 
-The Transform Service distribution zip file includes all the files required to provide the Transform Service capabilities. Ensure that you've installed the prerequisites before continuing, for more see [Install Transform Service]({% link transform-service/latest/install/index.md %}).
-
-1. Browse to the [Alfresco Support Portal](https://support.alfresco.com/){:target="_blank"} and download `alfresco-transform-service-distribution-1.3.x.zip`.
+1. Browse to the [Alfresco Support Portal](https://support.alfresco.com/){:target="_blank"} and download `alfresco-transform-service-distribution-1.4.x.zip`.
 
 2. Extract the zip file into a system directory; for example, `<installLocation>/`.
 
@@ -339,8 +472,9 @@ The Transform Service distribution zip file includes all the files required to p
 
     * `alfresco-shared-file-store-controller-x.y.z.jar`
     * `alfresco-transform-core-aio-boot-x.y.z.jar`
-    * `alfresco-transform-router-1.3.x.jar`
+    * `alfresco-transform-router-1.4.x.jar`
     * `README.md`
+    * IPTC Content Model (need to be bootstrapped into Alfresco Content Services for IPTC Metadata extraction to work)
 
 3. Start Active MQ.
 
@@ -397,7 +531,7 @@ The Transform Service distribution zip file includes all the files required to p
      -DCORE_AIO_QUEUE=org.alfresco.transform.engine.aio.acs
      -DACTIVEMQ_URL=failover:(tcp://server:61616)?timeout=3000
      -DFILE_STORE_URL=http://localhost:8099/alfresco/api/-default-/private/sfs/versions/1/file
-     -jar alfresco-transform-router-1.3.x.jar
+     -jar alfresco-transform-router-1.4.x.jar
     ```
 
     Check the output to ensure that it starts successfully.
@@ -416,25 +550,21 @@ The Transform Service distribution zip file includes all the files required to p
     sfs.url=http://localhost:8099
     sfs.endpoint=${sfs.url}/alfresco/api/-default-/private/sfs/versions/1/file
 
-    # Transform Router property:
+    # Transform Router properties:
+    transform.service.enabled=true
     transform.service.url=http://localhost:8095/
 
     # Transform Core properties:
     localTransform.core-aio.url=http://transform-core-aio:8090/
-    alfresco-pdf-renderer.url=http://transform-core-aio:8090/
-    jodconverter.url=http://transform-core-aio:8090/
-    img.url=http://transform-core-aio:8090/
-    tika.url=http://transform-core-aio:8090/
-    transform.misc.url=http://transform-core-aio:8090/
     ```
 
     This overrides the default properties provided by Content Services.
 
-    > **Note:** Any changes to `alfresco-global.properties` require you to restart Content Services to apply the updates. See the Content Services documentation [Using alfresco-global.properties]({% link content-services/latest/config/index.md%}#using-alfresco-globalproperties) for more information.
-
+    > **Note:** Any changes to `alfresco-global.properties` require you to restart Alfresco Content Services to apply the updates. See the Content Services documentation [Using alfresco-global.properties]({% link content-services/latest/config/index.md%}#using-alfresco-globalproperties) for more information.
+   
 8. Check that the [configuration]({% link transform-service/latest/config/index.md %}) is set up correctly for your environment.
 
-9. Restart Content Services.
+9. Restart Alfresco Content Services.
 
 10. Ensure that the environment is up and running:
 

--- a/transform-service/latest/support/index.md
+++ b/transform-service/latest/support/index.md
@@ -10,4 +10,3 @@ The following are the supported platforms and software requirements for Alfresco
 |-------|-----|
 |Content Services 6.2.2|IPTC content model need to be manually bootstrapped|
 |Content Services 7.0.0|IPTC content model need to be manually bootstrapped|
-|Content Services 7.1.0|IPTC content model included|

--- a/transform-service/latest/support/index.md
+++ b/transform-service/latest/support/index.md
@@ -2,11 +2,12 @@
 title: Supported Platforms
 ---
 
-The following are the supported platforms and software requirements for Alfresco Transform Service 1.3:
+The following are the supported platforms and software requirements for Alfresco Transform Service 1.4:
 
 ## Alfresco Content Services
 
-| Version | Notes |
-| ------- | ----- |
-| Content Services 6.2.2 | |
-| Content Services 7.0.0 | |
+|Version|Notes|
+|-------|-----|
+|Content Services 6.2.2|IPTC content model need to be manually bootstrapped|
+|Content Services 7.0.0|IPTC content model need to be manually bootstrapped|
+|Content Services 7.1.0|IPTC content model included|


### PR DESCRIPTION
ITS Version bump to 1.4
Fix docs for ITS 1.3 and 1.4 to include additional install instructions for libs such as imagemagick and libreoffice.
ACS 6.2 and Latest updated with info on how to bootstrap IPTC Content Model.
ACS Support page update for 6.2 and Latest with ATS 1.4