### PR TITLE
AuthNegotiateDelegateWhitelist is deprecated

### DIFF
--- a/content-services/6.2/admin/auth-sync.md
+++ b/content-services/6.2/admin/auth-sync.md
@@ -1233,15 +1233,15 @@ This task can be performed by the enterprise system administrator or the Alfresc
 
 When using Chrome on Windows to access Share, if the command-line switch is not present, the permitted list consists of those servers in the Local Machine or Local Intranet security zone. This is the behavior in Internet Explorer. For example, when the host in the URL includes a "`.`" character, it is outside the Local Intranet security zone. Treating servers that bypass proxies as being in the Intranet zone is currently not supported.
 
-On Windows, HTTP authentication is achieved by adding the Kerberos delegation server whitelist policy, `AuthNegotiateDelegateWhitelist`. Note that the `AuthNegotiateDelegateWhitelist` policy:
+On Windows, HTTP authentication is achieved by adding the Kerberos delegation server allowlist policy, `AuthNegotiateDelegateAllowlist`. Note that the `AuthNegotiateDelegateAllowlist` policy:
 
 * Specifies the servers that Chrome may delegate to
-* Has a Windows registry location of `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome\AuthNegotiateDelegateWhitelist`
+* Has a Windows registry location of `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome\AuthNegotiateDelegateAllowlist`
 * Has separate multiple server names with commas
 * Allows wildcards (*)
 * If you do not set this policy, Chrome does not delegate user credentials, even if a server is detected as Intranet
 
-To set the `AuthNegotiateDelegateWhitelist` policy, follow these steps:
+To set the `AuthNegotiateDelegateAllowlist` policy, follow these steps:
 
 1. Download the Administrative policy template from [http://dl.google.com/dl/edgedl/chrome/policy/policy_templates.zip](http://dl.google.com/dl/edgedl/chrome/policy/policy_templates.zip).
 2. Use the command line, `gpedit.msc` to open the local group policy management.
@@ -1250,9 +1250,9 @@ To set the `AuthNegotiateDelegateWhitelist` policy, follow these steps:
 5. Click **Add/Remove Templates**.
 6. Click the **Add** button.
 7. Select `windows/adm/en-US/chrome.adm` from the `policy_templates.zip` download.
-8. In the **Local Computer Policy Editor** console tree, navigate to **Local Computer Policy > Computer Configuration > Administrative Templates > Classic Administrative Templates (ADM) > Google > Google Chrome > Policies for HTTP Authentication > Kerberos delegation server whitelist**.
-9. On the **Kerberos delegation server whitelist** window, click **Enabled**.
-10. Specify your Share server name(s) as value in **Kerberos delegation server whitelist**.
+8. In the **Local Computer Policy Editor** console tree, navigate to **Local Computer Policy > Computer Configuration > Administrative Templates > Classic Administrative Templates (ADM) > Google > Google Chrome > HTTP Authentication > Kerberos delegation server allowlist**.
+9. On the **Kerberos delegation server allowlist** window, click **Enabled**.
+10. Specify your Share server name(s) as value in **Kerberos delegation server allowlist**.
 11. To activate the policy, open Chrome.
 12. Type `chrome://policy` to list the settings as viewed by Chrome.
 


### PR DESCRIPTION
In Chrome Kerberos configuration.
https://cloud.google.com/docs/chrome-enterprise/policies/?policy=AuthNegotiateDelegateWhitelist
Use AuthNegotiateDelegateAllowlist instead.