### PR TITLE
[DOCS-6309] Remove Media Management from ACS 7 integrations list

### DIFF
--- a/content-services/latest/install/zip/additions.md
+++ b/content-services/latest/install/zip/additions.md
@@ -55,7 +55,6 @@ Use this information to review the components or modules that integrate Content 
 | Desktop Sync | |
 | Transform Service | |
 | Document Transformation Engine | Paid add-on module |
-| Media Management | Paid add-on module and requires additional software |
 | Search and Insight Engine | Paid add-on module |
 | Search Services | |
 | Federation Services | |


### PR DESCRIPTION
Remove "Media Management" from _Installing integrations_ section to match the Supported platforms page.