### PR TITLE
[DOCS-6308] Display currently selected version on product landing pages

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -40,12 +40,16 @@
           <div class="column column-content">
             <button class="button is-rounded" id="table-of-contents" onclick="tocToggler()">Table of contents</button>
             <div class="content">
-              <!-- If it is the landing page for a product, then print out the currently selected version for the product. -->
-              <!-- A page is considered to be the landing page if the path to it is <product id>/<product version>/index.md -->
-              <!-- Any longer path is considered a sub page, which should not have the product version printed out -->
+              <!-- For each landing page, print out the selected version for the product (unless it's a Community version). -->
+              <!-- A landing page has a path with format: <product-name>/<product-version>/index.md -->
+              <!-- A longer path is considered a sub page, which should not have the version printed out. -->
               {% assign pathElements = page.path | split: "/"%}
               {% if pathElements.size == 3 %}
+              {% unless page.version == 'community' %}
               <h1>{{page.title}} {{page.version}}</h1>
+              {% else %}
+              <h1>{{page.title}}</h1>
+              {% endunless %}
               {% else %}
               <h1>{{page.title}}</h1>
               {% endif %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -40,14 +40,15 @@
           <div class="column column-content">
             <button class="button is-rounded" id="table-of-contents" onclick="tocToggler()">Table of contents</button>
             <div class="content">
-                <h1>{{page.title}}</h1>
-                <!-- If it is the landing page for a product, then print out the currently selected version for the product. -->
-                <!-- A page is considered to be the landing page if the path to it is <product id>/<product version>/index.md -->
-                <!-- Any longer path is considered a sub page, which should not have the product version printed out -->
-                {% assign pathElements = page.path | split: "/"%}
-                {% if pathElements.size == 3 %}
-                <p><b>Version: {{page.version}}</b></p>
-                {% endif %}
+              <!-- If it is the landing page for a product, then print out the currently selected version for the product. -->
+              <!-- A page is considered to be the landing page if the path to it is <product id>/<product version>/index.md -->
+              <!-- Any longer path is considered a sub page, which should not have the product version printed out -->
+              {% assign pathElements = page.path | split: "/"%}
+              {% if pathElements.size == 3 %}
+              <h1>{{page.title}} {{page.version}}</h1>
+              {% else %}
+              <h1>{{page.title}}</h1>
+              {% endif %}
               <article>
                 {{content}}
               </article>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -8,7 +8,6 @@
   {% assign version = path[2]%}
 
   <body>
-    
     {% if site.analytics != nil %}
     {% include analytics_body.html %}
     {% endif %}
@@ -42,6 +41,13 @@
             <button class="button is-rounded" id="table-of-contents" onclick="tocToggler()">Table of contents</button>
             <div class="content">
                 <h1>{{page.title}}</h1>
+                <!-- If it is the landing page for a product, then print out the currently selected version for the product. -->
+                <!-- A page is considered to be the landing page if the path to it is <product id>/<product version>/index.md -->
+                <!-- Any longer path is considered a sub page, which should not have the product version printed out -->
+                {% assign pathElements = page.path | split: "/"%}
+                {% if pathElements.size == 3 %}
+                <p><b>Version: {{page.version}}</b></p>
+                {% endif %}
               <article>
                 {{content}}
               </article>

--- a/microsoft-office/1.1/index.md
+++ b/microsoft-office/1.1/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alfresco Office Services 1.1
+title: Alfresco Office Services
 ---
 
 Alfresco Office Services (AOS) allows you to access Alfresco directly from your Microsoft Office applications.

--- a/microsoft-office/1.2/index.md
+++ b/microsoft-office/1.2/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alfresco Office Services 1.2
+title: Alfresco Office Services
 ---
 
 Alfresco Office Services (AOS) allows you to access Alfresco directly from your Microsoft Office applications.

--- a/microsoft-office/1.3/index.md
+++ b/microsoft-office/1.3/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alfresco Office Services 1.3
+title: Alfresco Office Services
 ---
 
 Alfresco Office Services (AOS) allows you to access Alfresco directly from your Microsoft Office applications.

--- a/microsoft-office/latest/index.md
+++ b/microsoft-office/latest/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alfresco Office Services 1.4
+title: Alfresco Office Services
 ---
 
 Alfresco Office Services (AOS) allows you to access Alfresco directly from your Microsoft Office applications.


### PR DESCRIPTION
Note that some the products don't display a version drop-down selector in the Docs site, but have version "1.0" in the product title. In these cases, the content always reflects the latest release of that product:

- Alfresco Process Automation 1.0
- Alfresco Mobile Workspace 1.0
- Alfresco Content Services for Mobile 1.0
- Alfresco Support Handbook 1.0