### PR TITLE
[DOCS-6328] Fix version numbers in Support Handbook pages

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -45,7 +45,7 @@
               <!-- A longer path is considered a sub page, which should not have the version printed out. -->
               {% assign pathElements = page.path | split: "/"%}
               {% if pathElements.size == 3 %}
-              {% unless page.version == 'community' or page.path contains 'support' %}
+              {% unless page.version == 'community' or page.path contains 'support' or page.path contains 'process-automation' or page.path contains 'mobile-workspace' or page.path contains 'content-mobile' %}
               <h1>{{page.title}} {{page.version}}</h1>
               {% else %}
               <h1>{{page.title}}</h1>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -45,7 +45,7 @@
               <!-- A longer path is considered a sub page, which should not have the version printed out. -->
               {% assign pathElements = page.path | split: "/"%}
               {% if pathElements.size == 3 %}
-              {% unless page.version == 'community' %}
+              {% unless page.version == 'community' or page.path contains 'support' %}
               <h1>{{page.title}} {{page.version}}</h1>
               {% else %}
               <h1>{{page.title}}</h1>


### PR DESCRIPTION
Following on from #297, exclude the version number from the Support Handbook.

For some reason, we seem to have inherited extra version number injections in several subpages in the Support handbook. This PR now excludes the version number from the Support Handbook landing page and fixes the "extras" in the subpages. It also removes the version numbers from the following landing pages:

- Alfresco Process Automation
- Alfresco Mobile Workspace
- Alfresco Content Services for Mobile
