### PR TITLE
Add critical system property to enable mutual TLS

### DIFF
--- a/search-services/1.4/install/options.md
+++ b/search-services/1.4/install/options.md
@@ -67,18 +67,20 @@ This task assumes you have:
         set SOLR_SSL_TRUST_STORE_PASSWORD=password
         set SOLR_SSL_NEED_CLIENT_AUTH=true
         set SOLR_SSL_WANT_CLIENT_AUTH=false
+        set SOLR_OPTS=%SOLR_OPTS% -Dalfresco.secureComms=https
         ```
 
         (Linux) update the `alfresco-search-services/solr.in.sh` file:
 
         ```bash
-       SOLR_SSL_KEY_STORE=<SOLR_HOME>/keystore/ssl.repo.client.keystore
-       SOLR_SSL_KEY_STORE_PASSWORD=password
-       SOLR_SSL_TRUST_STORE=<SOLR_HOME>/keystore/ssl.repo.client.truststore
-       SOLR_SSL_TRUST_STORE_PASSWORD=password 
-       SOLR_SSL_NEED_CLIENT_AUTH=true 
-       SOLR_SSL_WANT_CLIENT_AUTH=false
-       ```
+        SOLR_SSL_KEY_STORE=<SOLR_HOME>/keystore/ssl.repo.client.keystore
+        SOLR_SSL_KEY_STORE_PASSWORD=password
+        SOLR_SSL_TRUST_STORE=<SOLR_HOME>/keystore/ssl.repo.client.truststore
+        SOLR_SSL_TRUST_STORE_PASSWORD=password 
+        SOLR_SSL_NEED_CLIENT_AUTH=true 
+        SOLR_SSL_WANT_CLIENT_AUTH=false
+        SOLR_OPTS="$SOLR_OPTS -Dalfresco.secureComms=https"
+        ```
 
     5. Set the `SOLR_PORT` environment variable:
 


### PR DESCRIPTION
The following section is not adequately written to describe how 'solrcore.properties' are overridden by external means, i.e. JNDI, Java system properties and environment variables. This change demonstrate how to do it in Java system property. Without this critical setting, the Solr will try and fail to connect to Alfresco via http (not https) or receive an HTTP 403 Forbidden error if Alfresco still listens to port 8080.

https://docs.alfresco.com/search-services/1.4/config/#alfrescosecurecomms