### PR TITLE
[DOCS-6325] Add Alfresco Content Connector for SAP Cloud 1.1 to ACS SP pages

### DIFF
--- a/content-services/6.2/support/index.md
+++ b/content-services/6.2/support/index.md
@@ -91,6 +91,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Connector for Salesforce 2.1 | |
 | Alfresco Content Connector for SAP applications 5.1 | |
 | Alfresco Content Connector for SAP applications 5.0 | |
+| Alfresco Content Connector for SAP Cloud 1.1 | |
 | Alfresco Content Connector for SAP Cloud 1.0 | |
 | Alfresco Collaboration Connector for Microsoft 365 1.0 | |
 | Alfresco Outlook Integration 2.7 | |
@@ -201,6 +202,7 @@ Alfresco Content Connector for Azure 1.1 | |
 | Alfresco Content Connector for Salesforce 2.1 | |
 | Alfresco Content Connector for SAP applications 5.1 | |
 | Alfresco Content Connector for SAP applications 5.0 | |
+| Alfresco Content Connector for SAP Cloud 1.1 | |
 | Alfresco Content Connector for SAP Cloud 1.0 | |
 | Alfresco Outlook Integration 2.7 | |
 | Alfresco Outlook Integration 2.6.1 | |
@@ -307,6 +309,7 @@ Alfresco Content Connector for Azure 1.1 | |
 | Alfresco Content Connector for Salesforce 2.1 | |
 | Alfresco Content Connector for SAP applications 5.1 | |
 | Alfresco Content Connector for SAP applications 5.0 | |
+| Alfresco Content Connector for SAP Cloud 1.1 | |
 | Alfresco Content Connector for SAP Cloud 1.0 | |
 | Alfresco Outlook Integration 2.7 | |
 | Alfresco Outlook Integration 2.6.1 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -82,6 +82,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Connector for Salesforce 2.3 | |
 | Alfresco Content Connector for Salesforce 2.2.1 | |
 | Alfresco Content Connector for SAP applications 5.1 | |
+| Alfresco Content Connector for SAP Cloud 1.1 | |
 | Alfresco Content Connector for SAP Cloud 1.0 | |
 | Alfresco Collaboration Connector for Microsoft 365 1.1 | |
 | Alfresco Outlook Integration 2.8 | |


### PR DESCRIPTION
This updates the Supported Platforms pages in Alfresco Content Services