### PR TITLE
[DOCS-6350] docker references update

### DIFF
--- a/process-services/1.10/install/container.md
+++ b/process-services/1.10/install/container.md
@@ -18,11 +18,11 @@ The Docker images for Process Services are available on [Docker Hub](https://hub
 To download the images from Docker Hub, use the following commands:
 
 ```bash
-docker pull alfresco/process-services:1.10.0
+docker pull alfresco/process-services:1.10.x
 ```
 
 ```bash
-docker pull alfresco/process-services-admin:1.10.0
+docker pull alfresco/process-services-admin:1.10.x
 ```
 
 >**Note:** If a tag isn't supplied then the latest version will be downloaded.

--- a/process-services/1.11/install/container.md
+++ b/process-services/1.11/install/container.md
@@ -18,11 +18,11 @@ The Docker images for Process Services are available on [Docker Hub](https://hub
 To download the images from Docker Hub, use the following commands:
 
 ```bash
-docker pull alfresco/process-services:1.11.0
+docker pull alfresco/process-services:1.11.x
 ```
 
 ```bash
-docker pull alfresco/process-services-admin:1.11.0
+docker pull alfresco/process-services-admin:1.11.x
 ```
 
 >**Note:** If a tag isn't supplied then the latest version will be downloaded.

--- a/process-services/1.9/install/container.md
+++ b/process-services/1.9/install/container.md
@@ -14,11 +14,11 @@ The Docker images for Process Services are available on [Docker Hub](https://hub
 To download the images from Docker Hub, use the following commands:
 
 ```bash
-docker pull alfresco/process-services:1.9.0
+docker pull alfresco/process-services:1.9.x
 ```
 
 ```bash
-docker pull alfresco/process-services-admin:1.9.0
+docker pull alfresco/process-services-admin:1.9.x
 ```
 
 >**Note:** If a tag isn't supplied then the latest version will be downloaded.

--- a/process-services/latest/install/container.md
+++ b/process-services/latest/install/container.md
@@ -18,11 +18,11 @@ The Docker images for Process Services are available on [Docker Hub](https://hub
 To download the images from Docker Hub, use the following commands:
 
 ```bash
-docker pull alfresco/process-services:2.0.0
+docker pull alfresco/process-services:2.0.x
 ```
 
 ```bash
-docker pull alfresco/process-services-admin:2.0.0
+docker pull alfresco/process-services-admin:2.0.x
 ```
 
 >**Note:** If a tag isn't supplied then the latest version will be downloaded.


### PR DESCRIPTION
 docker references updates used .x instead of a number at request of PM.,