### PR TITLE
[DOCS-6351] Add APS version workaround back in ``1.10``

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -397,7 +397,7 @@ defaults:
       versions:
         - 2.0 
         - 1.11
-        - 1.10
+        - "1.10"
         - 1.9
   - scope:
       path: "process-services/latest"
@@ -412,7 +412,7 @@ defaults:
   - scope:
       path: "process-services/1.10"
     values:
-      version: 1.10
+      version: "1.10"
   - scope:
       path: "process-services/1.9"
     values:

--- a/_data/toc/process-services.yaml
+++ b/_data/toc/process-services.yaml
@@ -63,6 +63,8 @@
           path: '/process-services/latest/develop/dev-ext/'
         - title: 'ReST API'
           path: '/process-services/latest/develop/rest-api/'
+
+# Alfresco Process Services 1.11
 - version: 1.11
   pages:
     - title: 'Introduction'
@@ -129,7 +131,7 @@
           path: '/process-services/1.11/develop/rest-api/'
 
 # Alfresco Process Services 1.10
-- version: 1.10
+- version: '1.10'
   pages:
     - title: 'Introduction'
       path: '/process-services/1.10/'
@@ -259,4 +261,3 @@
           path: '/process-services/1.9/develop/dev-ext/'
         - title: 'ReST API'
           path: '/process-services/1.9/develop/rest-api/'
-


### PR DESCRIPTION
I removed ``1.10`` from the config file which stopped the 1.10 branch from publishing correctly.
I've added it back in now.

(Fixes config changes in PR #278)