### PR TITLE
[DOCS-6371] Correct tables search enterprise

### DIFF
--- a/search-enterprise/latest/admin/index.md
+++ b/search-enterprise/latest/admin/index.md
@@ -92,7 +92,7 @@ java -jar target/alfresco-elasticsearch-reindexing-3.0.0-SNAPSHOT-app.jar \
   --alfresco.reindex.fromId=1 \
   --alfresco.reindex.toId=10000 \
   --alfresco.reindex.concurrentProcessors=2
-```
+`````
 
 ### Date Range
 


### PR DESCRIPTION
The tables in the Search Enterprise documentation need cleaning up and aligning with the rest of the documentation.