### PR TITLE
[DOCS-6373] Clean up Using Alfresco Share

### DIFF
--- a/content-services/5.2/using/content/files-folders.md
+++ b/content-services/5.2/using/content/files-folders.md
@@ -4,22 +4,6 @@ title: Working with files and folders
 
 Once files are added to a site, site members can access and work with them. In addition to adding more files, members can view, download, edit, and delete files.
 
--   **[Editing files](#editing-files)**  
-There are multiple ways to edit content. These options are available whenever suitable for a file type.
--   **[Downloading files](#downloading-files)**  
-You can quickly download files from Alfresco Share so that you have a local copy.
--   **[Sharing files](#sharing-files)**  
-You can easily share an file - even with people who don't have an Alfresco Share account. Clicking the **Share** action generates a URL that you can send by email or publish using social networking websites.
--   **[Applying aspects](#applying-aspects)**  
-You can use aspects to add extra functionality, properties, or options to files. Alfresco Share provides you with a list of default aspects.
--   **[Managing file and folder permissions](#managing-file-and-folder-permissions)**  
-You can override the default site permissions for any content you add to the document library. This lets you control what site members can see and do with your content.
--   **[Becoming content owner](#becoming-content-owner)**  
-You can take ownership of files and folders from other users.
--   **[Changing the content type](#changing-the-content-type)**  
- You can change an file's content type from its default to a more specific value.
-
-
 ## Editing files {#editing-files}
 
 There are multiple ways to edit content. These options are available whenever suitable for a file type.
@@ -33,20 +17,6 @@ The **Edit in Alfresco Share** action lets you edit plain text, HTML, or XML fil
 The **Edit in Google Docs** action lets you work with files in Google Docs. The file is locked in Alfresco Share while it's being edited. It's available for supported document, presentation, and spreadsheet formats.
 
 You can also edit the properties of a file, or upload content as a new version of an existing file.
-
--   **[Editing files offline](#editing-files-offline)**  
-When you edit a file offline it's downloaded to your computer and locked in the library, so that other users can't overwrite it while you make changes offline.
--   **[Editing files in Alfresco Share](#editing-files-in-alfresco-share)**  
-You can edit plain text, HTML, and XML files directly in Alfresco Share.
--   **[Editing files in Microsoft Office](#editing-files-in-microsoft-office)**  
-You can edit Microsoft Office files directly from Alfresco Share. When you're editing a file it's locked in Share until you finish editing it.
--   **[Editing files in Google Docs](#editing-files-in-google-docs)**  
-The **Edit in Google Docs** action is available for any file that can be edited in Google Docs. Common document, presentation, and spreadsheet formats are supported.
--   **[Editing file and folder properties](#editing-file-and-folder-properties)**  
-Edit the basic details of a folder or file to change its name, description, and tags.
--   **[Uploading new versions](#uploading-new-versions)**  
-You can upload content from your computer to update a file.
-
 
 ### Editing content {#editing-content}
 
@@ -81,7 +51,7 @@ Updating your content in Alfresco Share is easy to do and you can even select wh
 9.  Click **Site Dashboard** and you'll see update notifications in the dashlets.
 
 
-This video shows the steps in the tutorial.
+
 
 
 ### Editing files offline {#editing-files-offline}
@@ -186,12 +156,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
     >**Tip:** See [Google Docs FAQs](#google-docs-faqs) for more on working with Google Docs.
 
 
-This video shows you how to edit files in Google Docs.
-
--   **[Sharing Google Docs files](#sharing-google-docs-files)**  
-You can share Google Docs files while you are editing them so multiple users can work with a document at the same time.
--   **[Google Docs FAQs](#google-docs-faqs)**  
-If you have any problems working with files in Google Docs, have a look through the list to see if there is a way to resolve your issue.
 
 
 ### Sharing Google Docs files {#sharing-google-docs-files}
@@ -374,11 +338,6 @@ This option is available in the Document Library Detailed view and on the file p
     -   Google+: Write a comment to post with the link and specify who you want to share it with. Click **Share**.
 
     > **Tip:** If an file is a Microsoft Office, PDF, or other text-based file type (not an image or video) then you can also click ![Advanced Search icon]({% link content-services/images/ico-link.png %}) on the file preview to share a link to the item, and even select to **Link to current page**.
-
-
--   **[Cancelling a shared link](#cancelling-a-shared-link)**  
- When you don’t want your publicly shared file to be available anymore, you can break the link. Once you make the link invalid, anyone who tries to access it will be unable to reach the public page.
-
 
 ### Cancelling a shared link {#cancelling-a-shared-link}
 

--- a/content-services/5.2/using/content/index.md
+++ b/content-services/5.2/using/content/index.md
@@ -10,13 +10,6 @@ The second is content items such as documents, spreadsheets, or images that are 
 
 So now that you know the differences in content types, it's time to start adding content to your site.
 
--   **[Adding content]({% link content-services/5.2/using/content/manage.md %}#adding-content)**  
-First you'll look at adding content items such as documents, spreadsheets, presentations, and images to a site.
--   **[Editing content]({% link content-services/5.2/using/content/files-folders.md %}#editing-content)**  
-Updating your content in Alfresco Share is easy to do and you can even select whether to edit in Microsoft Office, offline, or in Google Docs.
--   **[Creating content]({% link content-services/5.2/using/content/manage.md %}#creating-content)**  
-As well as uploading content, you can also create content right in Alfresco Share.
-
 ## Content
 
 A site document library is where you store and manage content, such as documents, images, and videos.
@@ -26,25 +19,6 @@ You can upload content to share and work on with other site members. Users can v
 Document library activities appear in the Site Content dashlet so you can see at a glance the content that's been added and updated.
 
 You can also store content in the My Files and Shared Files areas and in the Repository, see [Working with content outside the library](#working-with-files-outside-the-library) for more.
-
--   **[The Document Library](#the-document-library)**  
-Access the site Document Library to view and work with the content in the current site.
--   **[Adding content]({% link content-services/5.2/using/content/manage.md %}#adding-content)**  
-You build up site content by creating an organized folder structure then adding content to it.
--   **[Viewing content]({% link content-services/5.2/using/content/manage.md %}#viewing-content)**  
-To get a closer look at a file or folder without downloading it, you can view it on the file preview screen. This gives you more detail, a preview, and access to social features, actions, and version history.
--   **[Working with files and folders]({% link content-services/5.2/using/content/files-folders.md %}#working-with-files-and-folders)**  
-Once files are added to a site, site members can access and work with them. In addition to adding more files, members can view, download, edit, and delete files.
--   **[Applying rules to folders]({% link content-services/5.2/using/content/rules.md %}#applying-rules-to-folders)**  
-In the library you can define folder rules to manage your content automatically. You can come up with many creative solutions to make sure specific content processes are automated all without you having to do the work yourself.
--   **[Organizing content]({% link content-services/5.2/using/content/manage.md %}#organizing-content)**  
-With different people creating folders and adding files, you want to keep on top of it. Alfresco Share has multiple features available to help you keep content labelled, organized, and filed correctly.
--   **[Using social features]({% link content-services/5.2/using/content/manage.md %}#using-social-features)**  
-In Alfresco you can use social features to like, favorite, and comment on files and folders.
--   **[Working with files outside the library](#working-with-files-outside-the-library)**  
-While the Document Library is the focal point for working with content in Alfresco Share, there are also a few other areas available to you.
--   **[Working with replicated content]({% link content-services/5.2/using/content/files-folders.md %}#working-with-replicated-content)**  
-Alfresco Content Services administrators can configure Alfresco Content Services systems so that content is replicated across multiple repositories. Files and folders created as the result of a replication job display the **Transferred from another Repository** icon in the file list.
 
 ## The Document Library
 
@@ -69,12 +43,6 @@ Access the site Document Library to view and work with the content in the curren
     > **Note:** If you're using a Mac then it might seem that not all of the actions are available. This is because with a Mac sometimes the scrollbars are hidden. To display the scrollbars go **System Preferences** > **General** and select to always show scroll bars.
 
     In the other views, click the ![Information icon]({% link content-services/images/ico-information.png %}) information button for an item to display the item details, version, actions, and social features.
-
-
--   **[Exploring the library](#exploring-the-library)**  
-You can filter which items you see in the library using the explorer panel on the left side of the library. This can help you to locate specific items in the library.
--   **[Library view options](#library-view-options)**  
-The **Options** menu in the **Document Library** lets you customize how you view content.
 
 ## Exploring the library
 
@@ -174,13 +142,6 @@ The **My Files** and **Shared Files** areas are locations with Share, whereas th
 -   **My Files**: This is an area that only you can access. No-one else can see the files here and every user has their own, unique **My Files** area. It's great for saving draft content to, removing the need for trying to remember where you saved it on your laptop, or was it saved to your mobile...
 -   **Shared Files**: This area can be accessed by everyone in your organization. It's a great way to quickly share files with other users that's not ready to be uploaded to a site yet.
 -   **Repository**: The area lets you view all Alfresco Content Services content you have access to - all the sites, all the system files, everything is available here. You can work just as you would in a site Document Library but here you have a higher view of everything that's available. It's also very handy for Alfresco administrators who want to work with system files.
-
--   **[My Files](#my-files)**  
-**My Files** is a unique area in Alfresco Share where you can create and store content, and no other users can access it.
--   **[Shared Files](#shared-files)**  
-**Shared Files** is a unique area in Alfresco Share where you can create, store and share content, without adding it to a site Document Library.
--   **[Repository](#repository)**  
-The **Repository** displays all the Alfresco Content Services content that you have access to, including content of all sites that you're a member of.
 
 ## My Files
 

--- a/content-services/5.2/using/content/manage.md
+++ b/content-services/5.2/using/content/manage.md
@@ -18,10 +18,6 @@ You're going to add two documents that you created previously to your site.
 
     It's as simple as that. Your documents are now uploaded to the site library.
 
-
-This video shows the steps in the tutorial.
-
-
 ## Creating content {#creating-content}
 
 As well as uploading content, you can also create content right in Alfresco Share.
@@ -53,11 +49,6 @@ As well as uploading content, you can also create content right in Alfresco Shar
 6.  In Alfresco Share, click **More** then **Check In Google Doc**.
 
 7.  Now hover over the new item, click ![Edit]({% link content-services/images/ico-configure.png %}), and type a new name for the item then press ENTER.
-
-
-This video shows the steps in the tutorial.
-
-
 
 ## Using social features {#using-social-features}
 
@@ -104,16 +95,6 @@ There are two ways to add content to Alfresco Share: create new content or uploa
 
 There are different options available depending on whether you're adding files or adding folders.
 
--   [Adding folders](#adding-folders)
--   [Adding files](#adding-files)
-
--   **[Adding folders](#adding-folders)**  
-You can add folders from outside Alfresco Share and create new folders within a site.
--   **[Adding files](#adding-files)**  
-You can add both existing files from outside Alfresco Share and create new files within a site.
-
-
-
 ## Adding folders {#adding-folders}
 
 You can add folders from outside Alfresco Share and create new folders within a site.
@@ -123,15 +104,6 @@ There are three ways to add folders:
 -   Click Create in the Document Library - see [Creating folders](#creating-folders)
 -   Drag and drop folders from your computer - see [Drag and drop folders](#drag-and-drop-folders)
 -   Create folders from templates - see [Creating folders from a template](#creating-folders-from-a-template)
-
--   **[Creating folders](#creating-folders)**  
-The **Library** section of the explorer panel shows the folder structure for the current site. A new site contains just one folder named Documents. Add new folders here.
--   **[Drag and drop folders](#drag-and-drop-folders)**  
-You can drag and drop folders straight from your computer into Alfresco Share.
--   **[Creating folders from a template](#creating-folders-from-a-template)**  
-As well as creating folders from scratch, you can also create folders from templates.
-
-
 
 ## Creating folders {#creating-folders}
 
@@ -153,8 +125,6 @@ The **Library** section of the explorer panel shows the folder structure for the
 
 
 You'll see the new folder in the explorer panel.
-
-
 
 ## Drag and drop folders {#drag-and-drop-folders}
 
@@ -180,7 +150,6 @@ If empty folders exist in the folder structure then they'll also be created when
 
     If you drop files or folders into a location where there's already a file or folder with that name, then they'll be added as another file with "-1" added to their filename.
 
-
 ## Creating folders from a template {#creating-folders-from-a-template}
 
 As well as creating folders from scratch, you can also create folders from templates.
@@ -199,7 +168,6 @@ As well as creating folders from scratch, you can also create folders from templ
 
     A new folder based on the template is added to the document library. If the template contains content and subfolders these will also be replicated in the new folder.
 
-
 ## Adding files {#adding-files}
 
 You can add both existing files from outside Alfresco Share and create new files within a site.
@@ -211,17 +179,6 @@ You can also drag and drop one or more files to the library view - even to a par
 >**Tip:** In **Detailed View** you can drag and drop files into the current library level or directly onto a folder. An arrow will be displayed when the files are correctly positioned over the folder to be dropped. In all other views you can drop files into the current library level only. So if you want to drop them into a specific folder, that folder needs to be open in the library view.
 
 The **Create** menu provides options for creating different kinds of content directly in the library: plain text, HTML, and XML documents, as well as three types of Google Docs content (documents, spreadsheets, presentations). You can also create content from a template.
-
--   **[Uploading files](#uploading-files)**  
-Adding files from your computer to Alfresco Share is simple. You can upload a single file or several files at a time.
--   **[Creating files](#creating-files)**  
-With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.
--   **[Creating Google Docs files](#creating-google-docs-files)**  
-You can easily create Google Docs documents, spreadsheets, and presentations from Alfresco Share.
--   **[Creating files from a template](#creating-files-from-a-template)**  
-As well as creating files from scratch, you can also create files from templates.
-
-
 
 ## Uploading files {#uploading-files}
 
@@ -319,10 +276,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6.  In Share, click **More** then **Check In Google Doc**.
 
-
-This video shows you how to create content.
-
-
 ## Creating files from a template {#creating-files-from-a-template}
 
 As well as creating files from scratch, you can also create files from templates.
@@ -341,20 +294,9 @@ As well as creating files from scratch, you can also create files from templates
 
     A new file based on the template is added to the document library.
 
-
 ## Viewing content {#viewing-content}
 
 To get a closer look at a file or folder without downloading it, you can view it on the file preview screen. This gives you more detail, a preview, and access to social features, actions, and version history.
-
--   **[Viewing folder details](#viewing-folder-details)**  
-View the details page for a folder to conveniently see all information and actions in one place.
--   **[Viewing a file](#viewing-a-file)**  
-You can preview files by clicking on the thumbnail or name in the document library. All file details and actions are available on this one screen.
--   **[Viewing a file in a browser](#viewing-a-file-in-a-browser)**  
-While the preview feature lets you view a file in Alfresco Share, you also have the option of viewing it in your default browser.
--   **[View a file on Google Maps](#view-a-file-on-google-maps)**  
-When a file has geolocation data attached to it you can view the file location on Google Maps directly from Alfresco Share.
-
 
 ## Viewing folder details {#viewing-folder-details}
 
@@ -367,7 +309,6 @@ View the details page for a folder to conveniently see all information and actio
 2.  Click ![View Details icon]({% link content-services/images/view-folder-detail-icon.png %}) **View Details**.
 
     The Folder Details page displays all folder information, including properties and permissions. This page includes social features and folder actions.
-
 
 Click the folder in the breadcrumb trail at the top of the screen to return to the item list for that folder.
 
@@ -439,7 +380,7 @@ The actions and details are grouped in sections that you can expand and collapse
 
 ![]({% link content-services/images/hr.png %})
 
-This video shows you how to view a file.
+
 
   
 
@@ -466,40 +407,9 @@ When a file has geolocation data attached to it you can view the file location o
 
     The location attached to the file is shown in Google Maps, together with a preview of the file and a summary of the geolocation data.
 
-
-
 ## Organizing content {#organizing-content}
 
 With different people creating folders and adding files, you want to keep on top of it. Alfresco Share has multiple features available to help you keep content labelled, organized, and filed correctly.
-
--   **[Dragging and dropping content](#dragging-and-dropping-content)**  
-The drag and drop functionality lets you easily move content around the library.
--   **[Moving content](#moving-content)**  
-You can move content to relocate it to another location within the current library or to a library in a different site.
--   **[Copying content](#copying-content)**  
-You can copy content between locations, within a site or across different sites.
--   **[Creating links to content](#creating-links-to-content)**  
-You can create links to content between Alfresco locations, within a site or across different sites. This is similar to copying content, but instead of creating a new copy, you create a link to the existing file.
--   **[Unzipping content](#unzipping-content)**  
-You can unzip .zip and .acp files to add their contents to a folder in Alfresco Share.
--   **[Renaming content](#renaming-content)**  
-You can quickly rename files and folders.
--   **[Tagging and categorizing content](#tagging-and-categorizing-content)**  
-You can tag and categorize similar or related content making it easy to find the content again.
--   **[Favoriting content](#favoriting-content)**  
-Use the **Favorite** action to mark library content that you access often. This adds the file or folder to the My Favorites view in the explorer panel where you can easily find it.
--   **[Locate items and folders](#locate-items-and-folders)**  
-When you filter library content using one of the **Documents** or **Tags** explorer views, it is not possible to tell where a file or folder is within the library folder structure. The **Locate File** and **Locate Folder** actions reveal the actual location of a file or folder in the library.
--   **[Multi-selecting content](#multi-selecting-content)**  
-You can perform a single action on several pieces of content at once. You can select any number of files and folders in the same view.
--   **[Deleting content](#deleting-content)**  
-Delete content to remove it from a site library.
--   **[Recovering deleted content](#recovering-deleted-content)**  
-If you need to recover content that you've deleted, then it's easy to get it back from your trashcan.
--   **[Emptying your trashcan](#emptying-your-trashcan)**  
-When you delete content, it is moved to your trashcan. By emptying your trashcan you can permanently remove content.
-
-
 
 ## Dragging and dropping content {#dragging-and-dropping-content}
 
@@ -700,12 +610,6 @@ An example of categories, would be to have Regions as a top level category, then
 
 Categories can only be associated with library items and folders. Content needs to be enabled for categorizing before you can add it to a category, see [Managing Aspects]({% link content-services/5.2/using/content/files-folders.md %}#applying-aspects).
 
--   **[Tagging content](#tagging-content)**  
-To make content easier to find you can create and manage tags for files and folders in the document library.
--   **[Categorizing content](#categorizing-content)**  
-You can categorize files and folders to group similar content into pre-defined categories.
-
-
 ## Tagging content {#tagging-content}
 
 To make content easier to find you can create and manage tags for files and folders in the document library.
@@ -872,11 +776,6 @@ These social features are available in the file preview screen, in the Site Cont
 
 > **Note:** You can't add comments if your permission level on the site is set to Consumer. Speak to your Alfresco administrator if you need to change your permission level.
 
--   **[Managing your comments](#managing-your-comments)**  
-Adding comments to content is a convenient way of giving feedback. You can edit and delete any comments that you added.
-
-
-
 ## Managing your comments {#managing-your-comments}
 
 Adding comments to content is a convenient way of giving feedback. You can edit and delete any comments that you added.
@@ -884,14 +783,6 @@ Adding comments to content is a convenient way of giving feedback. You can edit 
 You can't add comments if your permission level on the site is set to Consumer. Speak to your Alfresco administrator if you need to change your permission level.
 
 Only site managers can edit and delete another user's comments.
-
--   **[Adding a comment](#adding-a-comment)**  
-You can add comments to folders and individual files to give other users information or notes.
--   **[Editing a comment](#editing-a-comment)**  
-You can edit a comment to change what it says.
--   **[Deleting a comment](#deleting-a-comment)**  
-
-
 
 ## Adding a comment {#adding-a-comment}
 
@@ -947,28 +838,3 @@ You can delete a comment that you created, and site managers can delete any comm
     A message prompts you to confirm the deletion of the selected comment.
 
 3.  Click **Delete**.
-
-
-
-## Configuring Google Docs using Admin Console {#configuring-google-docs-using-admin-console}
-
-The **Google Docs Console** provides the settings for enabling and controlling Google Docs Integration.
-
-1.  Open the Admin Console.
-
-2.  In the Consoles section, click **Google Docs Console**.
-
-3.  Set the properties:
-
-    |Google Docs property|Example setting|What is it?|
-    |--------------------|---------------|-----------|
-    |**googledocs.enabled**|true|Enables the Google Docs functionality.If you set this option to false, the **Edit in Google Docs** action will not be available. Documents that are currently being edited will still be available using the **Resume editing in Google Docs** action until they are saved or discarded.
-
-|
-    |**googledocs.idleThresholdSeconds**|600|Sets the idle time threshold in seconds.Additional Google users that you invite to collaborate on the document will be considered to be 'idle' after this period. The period is measured from the time when the user last made a change to the document. When saving documents back to Alfresco Content Services, or discarding changes, you must confirm that you want to disconnect any non-idle users before the action completes.
-
-|
-
-4.  Click **Save** to apply the changes you have made to the properties.
-
-    If you do not want to save the changes, click **Cancel**.

--- a/content-services/5.2/using/content/rules.md
+++ b/content-services/5.2/using/content/rules.md
@@ -26,17 +26,6 @@ Here are some examples of how you can use rules to automate repetitive tasks:
 -   All GIF files placed in the *Images* folder will be transformed to PNG files
 -   All presentation documents placed in the *Published* folder will be transformed to Flash and copied to the *Assets* folder
 
-  
-
--   **[Defining rules for a folder](#defining-rules-for-a-folder)**  
-Use folder rules to manage your files automatically. There are two ways to define rules: create your own rules or link to rules already created for a different folder.
--   **[Working with a set of rules](#working-with-a-set-of-rules)**  
-You can easily view and maintain the individual rules that makes up the rule set. You can add, edit, and delete rules, make a rule inactive, and change the run order. You can also manually run rules.
--   **[Working with linked rules](#working-with-linked-rules)**  
-When a folder has linked rules there are less editing options than when it has its own set of rules. You can either link to a different rule set or you can break the link completely.
-
-
-
 ## Defining rules for a folder {#defining-rules-for-a-folder}
 
 Use folder rules to manage your files automatically. There are two ways to define rules: create your own rules or link to rules already created for a different folder.
@@ -44,17 +33,6 @@ Use folder rules to manage your files automatically. There are two ways to defin
 When you define a rule, it only applies to new content added to the folder. Files that were in the folder before the rule was defined aren't affected by it. You can manually apply the folder rules with the **Run Rules** action.
 
 > **Note:** Even if the folder doesn't have its own rules, it could have inherited rules from a parent folder. A message on the Rules page lets you know if this is the case.
-
--   **[Creating a rule](#creating-a-rule)**  
-You can create rules for a folder, in much the same way that you might apply rules to your emails.
--   **[Rule actions](#rule-actions)**  
-When you're setting up a rule in Alfresco Share there are lots of default actions available.
--   **[Linking to an existing rule set](#linking-to-an-existing-rule-set)**  
-The **Link to Rule Set** option lets you reuse an existing rule set that's already defined for another folder.
--   **[Creating a simple workflow](#creating-a-simple-workflow)**  
-You can set up rules to trigger a simple workflow that's made up of review and approval steps. When an item enters a folder with this type of rule applied, it will have additional actions available.
-
-
 
 ## Creating a rule {#creating-a-rule}
 
@@ -101,13 +79,6 @@ You can create rules for a folder, in much the same way that you might apply rul
     -   **Run rule in background** Lets you continue working while the rule is running. You can also select an action to run if an error occurs with the rule. These actions are set up by your Alfresco administrator.
 9.  Click **Create**, or **Create and Create Another** to save this rule and start creating another.
 
-
-This video shows you how to create a rule.
-
-  
-
-
-
 ## Rule actions {#rule-actions}
 
 When you're setting up a rule in Alfresco Share there are lots of default actions available.
@@ -128,11 +99,7 @@ Actions don't apply to files in subfolders, unless the **Rule applies to subfold
 |**Link to category**|Links files or folders to a category of your choice, such as a region or classification. See [Tagging and categorizing content]({% link content-services/5.2/using/content/manage.md %}#tagging-and-categorizing-content) for more.|
 |**Add aspect**|Adds a property aspect to files, to give it additional behaviours or properties. See [About Aspects]({% link content-services/5.2/config/repository.md %}#about-aspects) for more.|
 |**Remove aspect**|Removes a property aspect from files, to remove functionality or properties. See [About Aspects]({% link content-services/5.2/config/repository.md %}#about-aspects) for more.|
-|**Add simple workflow**|Adds files to a workflow. By default there is an approval task. You can also click to add a reject task. > **Note:** You can click on **Approve** and **Reject** to rename the steps and to select a location to copy and move approved/rejected files to.
-
-See [Tasks and workflows]({% link content-services/5.2/using/content/rules.md %}#creating-a-simple-workflow) for more.
-
-|
+|**Add simple workflow**|Adds files to a workflow. By default there is an approval task. You can also click to add a reject task. > **Note:** You can click on **Approve** and **Reject** to rename the steps and to select a location to copy and move approved/rejected files to. See [Tasks and workflows](#creating-a-simple-workflow) for more.|
 |**Send email**|When files and subfolders are added you can select to send notifications by email. Click **Message** to select recipients and add the message of your choice.|
 |**Transform and copy content**|When applicable, add copies of files, in the format of your choice, to another location. For example you can generate a copy of a Word document in PDF format in a different folder.|
 |**Transform and copy image**|When applicable, add copies of image files, in the format of your choice, to another location. For example you can generate a copy of a GIF file in PNG format in a different folder.|
@@ -142,8 +109,6 @@ See [Tasks and workflows]({% link content-services/5.2/using/content/rules.md %}
 |**Increment Counter**|Automatically increments the value of a number (integer) property. This will generally only be used by Alfresco administrators.|
 |**Set property value**|Select a property and then enter a default value. Files with that property will have it changed to the entered value.|
 |**Embed properties as metadata in content**|Embeds file properties directly into the binary file as metadata. The information contained in those files can help in searching and workflows.|
-
-
 
 ## Linking to an existing rule set {#linking-to-an-existing-rule-set}
 
@@ -166,7 +131,6 @@ The **Link to Rule Set** option lets you reuse an existing rule set that's alrea
     > **Note:** You can click **View Rule Set** to view the rule details or **Change** to select a different rule to link to.
 
 5.  Click **Done**.
-
 
 ## Creating a simple workflow {#creating-a-simple-workflow}
 
@@ -236,10 +200,7 @@ For example, you could set up rules to create a simple workflow that manages con
     -   **Run rule in background** Lets you continue working while the rule is running. You can also select an action to run if an error occurs with the rule. These actions are set up by your Alfresco administrator.
 11. Click **Create**, or **Create and Create Another** to save this rule and start creating another.
 
-
 In the **Document Library** the symbol ![]({% link content-services/images/im-rules-simpleworkflow.png %}) to the left of an item indicates that a simple workflow has been applied to it. The approve and reject actions (with their defined labels) appear in the action list for these items.
-
-
 
 ## Working with a set of rules {#working-with-a-set-of-rules}
 
@@ -257,21 +218,6 @@ Selecting an individual rule in this list displays its details on the right side
 
 See [Troubleshooting rules and actions]({% link content-services/5.2/admin/troubleshoot.md %}#troubleshooting-rules-and-actions) for information about resolving problems with rules.
 
--   **[Adding to a set of rules](#adding-to-a-set-of-rules)**  
-A set of rules can include any number of individual rules, and you can add new rules to a folder as you need.
--   **[Editing a rule](#editing-a-rule)**  
-You might need to revisit your rules from time to time and make some changes to keep them current. If you don’t want to use a specific rule anymore but think you might need it again in the future, you can just disable it.
--   **[Deleting a rule](#deleting-a-rule)**  
-When a folder has a rule applied that you don't need anymore, you can delete the individual rule.
--   **[Reordering the rules in the rule set](#reordering-the-rules-in-the-rule-set)**  
-As part of managing your rule set you can pick the order in which the rules are run. If your folder has inherited rules, those are always run first in the order they're listed. Any rules marked as inactive are simply skipped.
--   **[Switching off inherited rules](#switching-off-inherited-rules)**  
-If a folder is inheriting rules from a parent folder, you can easily switch them on and off as needed.
--   **[Manually running rules](#manually-running-rules)**  
-When you create or edit a rule set, the rules aren't automatically applied to the existing folder items. You can manually run the rules at any time to apply them to all content. Only the items that meet the conditions will be affected.
-
-
-
 ## Adding to a set of rules {#adding-to-a-set-of-rules}
 
 A set of rules can include any number of individual rules, and you can add new rules to a folder as you need.
@@ -282,10 +228,7 @@ A set of rules can include any number of individual rules, and you can add new r
 
     On the New Rule page you can add a new rule to a set of rules in exactly the same way as the first time you created a rule, see [creating a rule](#creating-a-rule).
 
-
 After creating the last rule you return to the Rules page. Any new rules created are added at the end of the rule set.
-
-
 
 ## Editing a rule {#editing-a-rule}
 
@@ -303,7 +246,6 @@ You might need to revisit your rules from time to time and make some changes to 
 
 5.  Click **Save**.
 
-
 ## Deleting a rule {#deleting-a-rule}
 
 When a folder has a rule applied that you don't need anymore, you can delete the individual rule.
@@ -320,7 +262,6 @@ When a folder has a rule applied that you don't need anymore, you can delete the
 
 4.  When you're asked to confirm the deletion, click **Delete**.
 
-
 ## Reordering the rules in the rule set {#reordering-the-rules-in-the-rule-set}
 
 As part of managing your rule set you can pick the order in which the rules are run. If your folder has inherited rules, those are always run first in the order they're listed. Any rules marked as inactive are simply skipped.
@@ -332,7 +273,6 @@ As part of managing your rule set you can pick the order in which the rules are 
     > **Note:** You can't reorder linked or inherited rules here; that has to be done in the folder where they were created. Click **Reset** to return the rule set to its last saved order.
 
 3.  Click **Save**.
-
 
 ## Switching off inherited rules {#switching-off-inherited-rules}
 
@@ -348,7 +288,6 @@ Switching inherited rules on and off works at an individual folder level, and wi
 
     Any inherited rules are switched off for the folder and **Don't Inherit Rules** is shown. You can click **Don't Inherit Rules** to switch inherited rules back on for the folder.
 
-
 ## Manually running rules {#manually-running-rules}
 
 When you create or edit a rule set, the rules aren't automatically applied to the existing folder items. You can manually run the rules at any time to apply them to all content. Only the items that meet the conditions will be affected.
@@ -363,7 +302,6 @@ When you create or edit a rule set, the rules aren't automatically applied to th
     -   **Run rules for this folder and its subfolders**
     A message lets you know when the rules have run.
 
-
 ## Working with linked rules {#working-with-linked-rules}
 
 When a folder has linked rules there are less editing options than when it has its own set of rules. You can either link to a different rule set or you can break the link completely.
@@ -373,13 +311,6 @@ When you select the **Manage Rules** action for a folder with linked rules, the 
 > **Note:** The folder might also inherit rules from a parent folder. A message lets you know if this is the case.
 
 Changes to the rule set have to be done in the folder where the rules were originally defined. It's easy to get to the Rules page for the source folder: just click **View Rule Set**.
-
--   **[Linking to a different rule set](#linking-to-a-different-rule-set)**  
-If you want to change the rules you're linked to, you can easily link to a different rule set.
--   **[Breaking the link to a rule set](#breaking-the-link-to-a-rule-set)**  
-If you don't need your rules anymore, breaking the link is just a single click away. This leaves the folder without any rules.
-
-
 
 ## Linking to a different rule set {#linking-to-a-different-rule-set}
 
@@ -401,7 +332,6 @@ If you want to change the rules you're linked to, you can easily link to a diffe
 
 5.  Click **Done**.
 
-
 ## Breaking the link to a rule set {#breaking-the-link-to-a-rule-set}
 
 If you don't need your rules anymore, breaking the link is just a single click away. This leaves the folder without any rules.
@@ -413,5 +343,3 @@ If you don't need your rules anymore, breaking the link is just a single click a
     > **Note:** This option only shows if the folder has linked rules.
 
     The link between the current folder and the linked rules is now broken.
-
-

--- a/content-services/5.2/using/dashboard.md
+++ b/content-services/5.2/using/dashboard.md
@@ -12,13 +12,6 @@ As well as adding and removing dashlets you can also customize your dashboard la
 
 Managing your profile means that you can create a personality that's visible to other Alfresco Share users.
 
--   **[Setting up your dashboard](#setting-up-your-dashboard)**  
-You can customize your dashboard so that you only see the information that you're interested in.
--   **[Updating your profile](#updating-your-profile)**  
-Alfresco Share user profiles help you to identify who a user is and what they do in your organization.
-
-
-
 ## Setting up your dashboard {#setting-up-your-dashboard}
 
 You can customize your dashboard so that you only see the information that you're interested in.
@@ -48,7 +41,6 @@ You can customize your dashboard so that you only see the information that you'r
 
 Your dashboard is now customized exactly as you want it - this isn't fixed though, you can change the dashboard whenever you like. You can click My Dashboard from anywhere in Alfresco Share to take a look at your dashboard.
 
-This video shows the steps in the tutorial.
 
   
 
@@ -74,9 +66,7 @@ When your colleagues view your profile they'll see all the details you've entere
 
 ![My Profile]({% link content-services/images/gs-my-profile.png %})
 
-This video shows the steps in the tutorial.
 
-  
 
 
 ## Your profile and dashboard {#your-profile-and-dashboard}
@@ -84,23 +74,6 @@ This video shows the steps in the tutorial.
 You can customize your user profile and dashboard however you like without affecting anyone else - you're the only person that sees your dashboard.
 
 Some of your user profile details are visible to your colleagues so it's good to keep these details up to date.
-
--   **[Customizing your dashboard](#customizing-your-dashboard)**  
-You can change the layout of your dashboard and choose from a number of dashlets to show the information you want to see.
--   **[Setting your home page](#setting-your-home-page)**  
-Your default Alfresco Share home page is your user dashboard, but you can set it to be any page in Share that you have access to.
--   **[Updating your profile](#updating-your-profile)**  
- User profiles help you to identify a user's roles and responsibilities, or even find out who's who in your organization by checking profile pictures.
--   **[Following people](#following-people)**  
-You can follow users you're interested in so that you can easily keep track of what they've been working on.
--   **[Controlling your email notifications](#controlling-your-email-notifications)**  
-Choose whether or not you want to receive notifications by email. The emails keep you up to date on events such as recent site activities.
--   **[Disabling site activity notifications](#disabling-site-activity-notifications)**  
-You can disable site activity feeds so that updates from specific sites aren't included in your email notifications or the My Activities dashlet on your dashboard.
--   **[Changing your password](#changing-your-password)**  
-Change your password for increased security.
-
-
 
 ## Customizing your dashboard {#customizing-your-dashboard}
 
@@ -134,12 +107,6 @@ If you want, add multiple copies of each dashlet and then set the filters so tha
 
     >**Tip:** On your dashboard you can resize most dashlets - just click on the bottom of a dashlet then drag up and down to resize it.
 
-
-This video shows you how to customize your dashboard.
-
-  
-
-
 ## Setting your home page {#setting-your-home-page}
 
 Your default Alfresco Share home page is your user dashboard, but you can set it to be any page in Share that you have access to.
@@ -157,11 +124,6 @@ This can save you time if most of your work is done from a specific Share locati
     You can still click your name then **User Dashboard** to go to your dashboard.
 
     > **Note:** Sometimes the home page you've selected could become unavailable, for example, if you select a site dashboard as your home page and the site is then deleted. If this happens we'll notify you that you need to select a new home page.
-
-
-This video shows you how to set your homepage.
-
-  
 
 
 ## Updating your profile {#updating-your-profile}
@@ -182,13 +144,9 @@ When you click on your name at the top of the screen a menu opens where you can 
 
 3.  Click **Home** and you can see the updated details in the **My Profile** dashlet.
 
-
 When your colleagues view your profile they'll see all the details you've entered and know exactly what you're working on.
 
 This video show you how to edit your user profile.
-
-  
-
 
 ## Following people {#following-people}
 
@@ -214,7 +172,6 @@ You can follow users you're interested in so that you can easily keep track of w
 
 5.  Click **Unfollow** to stop following someone.
 
-
 ## Controlling your email notifications {#controlling-your-email-notifications}
 
 Choose whether or not you want to receive notifications by email. The emails keep you up to date on events such as recent site activities.
@@ -230,7 +187,6 @@ Choose whether or not you want to receive notifications by email. The emails kee
 4.  Click **OK**.
 
     > **Note:** You can also enable and disable the notifications for specific sites on the My Profile **Sites** page.
-
 
 ## Disabling site activity notifications {#disabling-site-activity-notifications}
 
@@ -248,8 +204,6 @@ You can disable site activity feeds so that updates from specific sites aren't i
 
     > **Note:** The My Documents dashlet will still display details of content from the sites you've disabled feeds for.
 
-
-
 ## Changing your password {#changing-your-password}
 
 Change your password for increased security.
@@ -265,5 +219,3 @@ Change your password for increased security.
     Your password must be at least ten characters long and use a combination of uppercase and lowercase letters, numbers, and symbols.
 
 4.  Click **OK**.
-
-

--- a/content-services/5.2/using/index.md
+++ b/content-services/5.2/using/index.md
@@ -16,14 +16,6 @@ With Alfresco Outlook Integration you can save and file your emails to Alfresco 
 
 There are also some shortcuts available that your Alfresco administrator can enable so you can work with files from Windows Explorer or from your desktop.
 
--   **[Using Alfresco Content Services from Microsoft Office](#using-alfresco-content-services-from-microsoft-office)**  
-With Alfresco Office Services (AOS) you can access content directly from your Microsoft Office applications.
--   **[Using Alfresco Content Services from Microsoft Outlook](#using-alfresco-content-services-from-microsoft-outlook)**  
-With Alfresco Outlook Integration you can use email and repository management without leaving Microsoft Outlook.
--   **[Using the Windows Explorer shortcuts](#using-the-windows-explorer-shortcuts)**  
- You can work with files without actually being in the Alfresco Share interface.
-
-
 ## Using Alfresco Content Services from Microsoft Office
 
 With Alfresco Office Services (AOS) you can access content directly from your Microsoft Office applications.
@@ -34,8 +26,6 @@ You can also browse content from Windows Explorer, or map a network drive.
 
 For more information about Alfresco Office Services, see [Alfresco Office Services]({% link microsoft-office/1.1/using/index.md %}).
 
-
-
 ## Using Alfresco Content Services from Microsoft Outlook
 
 With Alfresco Outlook Integration you can use email and repository management without leaving Microsoft Outlook.
@@ -43,8 +33,6 @@ With Alfresco Outlook Integration you can use email and repository management wi
 You can directly archive emails into Alfresco Share, use the full metadata support, full search, tagging and workflow capabilities, and attach files and view archived emails in your inbox.
 
 For more information about Alfresco Outlook Integration, see [Alfresco Outlook Integration]({% link microsoft-outlook/2.4/install/index.md %}).
-
-
 
 ## Using the Windows Explorer shortcuts
 
@@ -62,17 +50,6 @@ You can use these files to add content to the repository, check documents in and
 
 > **Note:** These options only function when you are working in a Windows environment.
 
--   **[Add a file from outside Alfresco Share](#add-a-file-from-outside-alfresco-share)**  
- You can easily drag and drop content to the repository from outside Share.
--   **[Check out files from outside Alfresco Share](#check-out-files-from-outside-alfresco-share)**  
- You can use the CheckInOut.exe to check content out so that you can work on it securely.
--   **[View item details from a mapped drive](#view-item-details-from-a-mapped-drive)**  
- You can use the ShowDetails.exe to view item details and properties.
--   **[Open Alfresco Share in a browser window](#open-alfresco-share-in-a-browser-window)**  
- You can use the Share.url to open the Share in a browser window.
-
-
-
 ### Add a file from outside Alfresco Share {#add-a-file-from-outside-alfresco-share}
 
 You can easily drag and drop content to the repository from outside Share.
@@ -84,8 +61,6 @@ You can easily drag and drop content to the repository from outside Share.
 2.  Drag the file onto the location in the repository that you want to add it to.
 
     The file is added to the selected location in the repository.
-
-
 
 ### Check out files from outside Alfresco Share {#check-out-files-from-outside-alfresco-share}
 
@@ -109,8 +84,6 @@ You can use the CheckInOut.exe to check content out so that you can work on it s
 
     The (Working Copy) file is removed and any updates made while it was checked out are applied to the original file.
 
-
-
 ### View item details from a mapped drive {#view-item-details-from-a-mapped-drive}
 
 You can use the ShowDetails.exe to view item details and properties.
@@ -124,8 +97,6 @@ You can use the ShowDetails.exe to view item details and properties.
     > **Note:** There is a copy of the ShowDetails.exe at each level of the repository.
 
     A new browser window opens showing the Alfresco Share file preview, where you can see a preview of the file and its properties.
-
-
 
 ### Open Alfresco Share in a browser window {#open-alfresco-share-in-a-browser-window}
 
@@ -142,5 +113,3 @@ The Share.url is a shortcut to Share. It's available in a Windows environment if
     > **Note:** There is a copy of the Share.url at each level of the repository.
 
     Alfresco Share will open in a browser window, showing the location where you clicked on Share.url.
-
-

--- a/content-services/5.2/using/permissions.md
+++ b/content-services/5.2/using/permissions.md
@@ -24,14 +24,6 @@ If you're a member of two user groups which have different permissions then you 
 
 > **Note:** Site content can be defined as any content created or added to a site. This includes, but is not limited to, wiki pages, blog postings, library folders and items, calendar events, discussion topics, and comments on any content.
 
--   **[Dashboards permissions](#dashboards-permissions)**  
-The following sections detail the user permissions for dashboards (personal and site) and dashlets.
--   **[Content permissions](#content-permissions)**  
-The following sections detail the user permissions for content.
--   **[Member permissions](#member-permissions)**  
-The following section details the member permissions.
-
-
 ## Dashboards permissions
 
 The following sections detail the user permissions for dashboards (personal and site) and dashlets.
@@ -263,12 +255,6 @@ If you have the following permissions you can access the Site Manager through an
 -   Sites Manager is available to users in the `ALFRESCO_ADMINISTRATORS` and `SITES_ADMINISTRATORS` permissions groups.
 -   Search Manager is available to users in the `ALFRESCO_ADMINISTRATORS` and `ALFRESCO_SEARCH_ADMINISTRATORS` permissions groups.
 
--   **[Sites Manager](#sites-manager)**  
-The Sites Manager is used for maintaining sites. You have control over the visibility of all sites as well as deleting sites or making yourself a site manager.
--   **[Search Manager](#search-manager)**  
-With the Search Manager you can see details of existing search filters and create new filters.
-
-
 ### Sites Manager
 
 The Sites Manager is used for maintaining sites. You have control over the visibility of all sites as well as deleting sites or making yourself a site manager.
@@ -285,7 +271,6 @@ With the **Actions** menu, there are two options:
 You can delete any of the sites in the Site Manager list by selecting **Delete Site** from the **Actions** menu. This action deletes all site details and content.
 
 The I'm a Site Manager column shows the sites where you have the Site Manager permission. If you aren't already a manager of a site, then select **Become Site Manager** from the **Actions** menu.
-
 
 ### Search Manager
 
@@ -331,13 +316,6 @@ Most of the filter details are can be edited by hovering over them and clicking 
 
     The site(s) where the filter is available.
 
-
-  
-
--   **[Creating new search filters](#creating-new-search-filters)**  
-In the Search Manager you can quickly create your own custom filters with a wide range of options available.
-
-
 ### Creating new search filters
 
 In the Search Manager you can quickly create your own custom filters with a wide range of options available.
@@ -370,4 +348,5 @@ In the Search Manager you can quickly create your own custom filters with a wide
 
     -   **Everywhere** - shown on all sites
     -   **Selected sited** - only shown on selected sites. Click ![]({% link content-services/images/ico-add.png %}) to add a site then select it from the list and click ![]({% link content-services/images/ico-tick.png %}) to confirm. Click ![]({% link content-services/images/ico-add.png %}) to add more sites if required.
-12. Click **Save**
+
+12. Click **Save**.

--- a/content-services/5.2/using/search.md
+++ b/content-services/5.2/using/search.md
@@ -58,14 +58,14 @@ There are multiple options you can use to make your search more specific.
 
 |To search for|Enter the search criteria|This searches|
 |-------------|-------------------------|-------------|
-|the word *banana* anywhere it exists|`banana`<br><br>or<br><br>`=banana`|names, titles, descriptions, and content|
-|the exact phrase *banana peel* anywhere it exists|`banana peel`|names, titles, descriptions, and content|
-|the words *banana*, *peel*, and *slippery* where they all appear together in any order or position|`banana AND peel AND slippery`|names, titles, descriptions, and content|
-|content containing any of the words *banana*, *peel*, and *slippery*|`banana peel slippery` <br><br>or<br><br>`banana OR peel OR slippery`|names, titles, descriptions, and content|
-|the word *banana* where it is used in a title|`title:banana`|titles|
-|the word *banana* where it is used in a name|`name:banana`|names of folders and content items in the library; wiki page titles|
-|the word *banana* where it is used in the description|`description:banana`|descriptions of folders and content items in the library; descriptions of data lists|
-|the word *banana* where it is used in site content|`TEXT:banana`|wiki pages, blog postings, content items, and discussion items and replies|
+|the word *banana* anywhere it exists|`banana`<br><br>or<br><br>`=banana`|names, titles, descriptions, and content.|
+|the exact phrase *banana peel* anywhere it exists|`banana peel`|names, titles, descriptions, and content.|
+|the words *banana*, *peel*, and *slippery* where they all appear together in any order or position|`banana AND peel AND slippery`|names, titles, descriptions, and content.|
+|content containing any of the words *banana*, *peel*, and *slippery*|`banana peel slippery` <br><br>or<br><br>`banana OR peel OR slippery`|names, titles, descriptions, and content.|
+|the word *banana* where it is used in a title|`title:banana`|titles.|
+|the word *banana* where it is used in a name|`name:banana`|names of folders and content items in the library; wiki page titles.|
+|the word *banana* where it is used in the description|`description:banana`|descriptions of folders and content items in the library; descriptions of data lists.|
+|the word *banana* where it is used in site content|`TEXT:banana`|wiki pages, blog postings, content items, and discussion items and replies.|
 |content created on September 26, 2011|`created:"2011-09-26"`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
 |content created between September 26 and September 30, 2011|`created:["2011-09-26" to "2011-09-30"]`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
 |any content modified on September 26, 2011|`modified:"2011-09-26"`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|

--- a/content-services/5.2/using/search.md
+++ b/content-services/5.2/using/search.md
@@ -10,7 +10,7 @@ If you're in a site you can click **Search all content** or **Search in [sitenam
 
 There are lots of [search tips](#search-tips) available, including:
 
--   Type * to complete a word if you don't know the full word you're searching for. For example, both "**resco*" and "*alf**" will show results for *alfresco*.
+-   Type `*` to complete a word if you don't know the full word you're searching for. For example, both `**resco*` and `*alf**` will show results for *alfresco*.
 -   To search for items that contain only one of several words, use `OR` and surround your search with brackets, for example, *(big OR red)*. If you don't use brackets, search results are returned containing both *big* and *red*.
 
 The five most relevant files, sites, and people are shown, but you can click **More** to see further results.
@@ -21,21 +21,7 @@ You can either:
 
 -   Press Enter (with the cursor in the search box) to view all the [search results](#search-results) for all files found by your search.
 
-
 > **Note:** Wiki pages and blog postings are shown under along with other files. Previews aren't shown for calendar events, site-related web links, discussion topics, or data lists and list items. You need to press Enter to search for them.
-
--   **[Search results](#search-results)**  
-If you press Enter in the Search box then all the files and folders found by your search are shown.
--   **[Search tips](#search-tips)**  
-There are multiple options you can use to make your search more specific.
--   **[Using the Site Finder](#using-the-site-finder)**  
-You can search for sites using the search box on the toolbar or you can use the Site Finder to get more detailed site information.
--   **[Using the People Finder](#using-the-people-finder)**  
-You can search for people using the search box on the toolbar or you can use the People Finder to get more detailed user information.
--   **[Using the Advanced Search](#using-the-advanced-search)**  
-Use the search box in the toolbar to access the advanced search.
-
-
 
 ## Search results {#search-results}
 
@@ -56,7 +42,6 @@ You can now:
 
     You can delete a file this way but the search results won't be updated until you run a new search.
 
-
 > **Note:** Click the **Search in** menu to search in all sites or just in the site you're in.
 
 If you're a [Search Manager]({% link content-services/5.2/admin/share-admin-tools.md %}#search-manager) super user then you'll have an additional **Search Manager** option you can click where you can create new search filters.
@@ -65,44 +50,29 @@ As well as the search box on the toolbar, there are also additional advanced sea
 
 >**Tip:** If a file is a Microsoft Office, PDF, or other text-based file type (not an image or video) then you can also click ![Advanced Search icon]({% link content-services/images/advanced-search-icon.png %}) on the file preview to search for text in the file.
 
-
 ## Search tips {#search-tips}
 
 There are multiple options you can use to make your search more specific.
 
 > **Note:** File and folder names have additional search support for product names, product codes, camel case word extraction, general file naming conventions and more.
 
-|To search for...|Enter the search criteria...|This searches...|
-|----------------|----------------------------|----------------|
-|the word *banana* anywhere it exists|bananaor
-
-=banana
-
-|names, titles, descriptions, and content|
-|the exact phrase *banana peel* anywhere it exists|"banana peel"|names, titles, descriptions, and content|
-|the words *banana*, *peel*, and *slippery* where they all appear together in any order or position|banana AND peel AND slippery|names, titles, descriptions, and content|
-|content containing any of the words *banana*, *peel*, and *slippery*|banana peel slipperyor
-
-banana OR peel OR slippery|names, titles, descriptions, and content|
-|the word *banana* where it is used in a title|title:banana|titles|
-|the word *banana* where it is used in a name|name:banana|names of folders and content items in the library; wiki page titles|
-|the word *banana* where it is used in the description|description:banana|descriptions of folders and content items in the library; descriptions of data lists|
-|the word *banana* where it is used in site content|TEXT:banana|wiki pages, blog postings, content items, and discussion items and replies|
-|content created on September 26, 2011|created:"2011-09-26"|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
-|content created between September 26 and September 30, 2011|created:["2011-09-26" to "2011-09-30"]|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
-|any content modified on September 26, 2011|modified:"2011-09-26"|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
-|any content modified between September 26 and September 30, 2011|modified:["2011-09-26" to "2011-09-30"]|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
-|any content created by a specific user|creator:username> **Note:** Replace *username* with the appropriate user name.
-
-|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists.|
-|any content modified by a specific user|modifier:username> **Note:** Replace *username* with the appropriate user name.
-
-|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists.|
-|any content containing the letter sequence *use*The results returned will include references to *use*, *user*, *reuse*, etc.
-
-|TEXT:*use*|wiki pages, blog postings, library folders, content items, and discussion topics.|
-
-
+|To search for|Enter the search criteria|This searches|
+|-------------|-------------------------|-------------|
+|the word *banana* anywhere it exists|`banana`<br><br>or<br><br>`=banana`|names, titles, descriptions, and content|
+|the exact phrase *banana peel* anywhere it exists|`banana peel`|names, titles, descriptions, and content|
+|the words *banana*, *peel*, and *slippery* where they all appear together in any order or position|`banana AND peel AND slippery`|names, titles, descriptions, and content|
+|content containing any of the words *banana*, *peel*, and *slippery*|`banana peel slippery` <br><br>or<br><br>`banana OR peel OR slippery`|names, titles, descriptions, and content|
+|the word *banana* where it is used in a title|`title:banana`|titles|
+|the word *banana* where it is used in a name|`name:banana`|names of folders and content items in the library; wiki page titles|
+|the word *banana* where it is used in the description|`description:banana`|descriptions of folders and content items in the library; descriptions of data lists|
+|the word *banana* where it is used in site content|`TEXT:banana`|wiki pages, blog postings, content items, and discussion items and replies|
+|content created on September 26, 2011|`created:"2011-09-26"`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
+|content created between September 26 and September 30, 2011|`created:["2011-09-26" to "2011-09-30"]`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
+|any content modified on September 26, 2011|`modified:"2011-09-26"`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
+|any content modified between September 26 and September 30, 2011|`modified:["2011-09-26" to "2011-09-30"]`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists. You can search just by year, or go down to month and day level.|
+|any content created by a specific user|`creator:<username>`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists.|
+|any content modified by a specific user|`modifier:<username>`|wiki pages, blog postings, library folders, content items, events, links, discussion topics, and data lists.|
+|any content containing the letter sequence *use*. The results returned will include references to *use*, *user*, *reuse*, etc.|`TEXT:*use*`|wiki pages, blog postings, library folders, content items, and discussion topics.|
 
 ## Using the Site Finder {#using-the-site-finder}
 
@@ -116,13 +86,11 @@ From the search results you can navigate to a site, join or leave sites, and del
 
     >**Tip:** Leave the search box empty to display all sites you have permission to access.
 
-    The search looks for sites starting with your search criteria, so entering the search criteria awe won't find the site *Project Awesome*. If you add *, so your search criteria is *awe, then you will find the site.
+    The search looks for sites starting with your search criteria, so entering the search criteria awe won't find the site *Project Awesome*. If you add `*`, so your search criteria is `*awe`, then you will find the site.
 
 3.  Click **Search**.
 
     A list of sites matching your criteria is shown. This list includes public sites, moderated public sites, sites you created, and private sites that you belong to. To the right of a site, the actions **Join** and **Request to Join** indicate you are not a site member; the action **Leave** indicates you are a site member.
-
-
 
 ## Using the People Finder {#using-the-people-finder}
 
@@ -136,19 +104,13 @@ When you find the user you are looking for you can use the Follow/Unfollow optio
 
     You must enter at least one character. The search is not case sensitive.
 
-    The search looks for user names starting with your search criteria, so entering the search criteria 1 won't find the user User1. If you add *, so your search criteria is *1, then you will find the user.
+    The search looks for user names starting with your search criteria, so entering the search criteria 1 won't find the user User1. If you add `*`, so your search criteria is `*1`, then you will find the user.
 
     > **Note:** See the search tips provided on the People Finder page to perform more complex searches.
 
 3.  Click **Search**.
 
 4.  In the results list, click a user name to display that user's profile.
-
-
--   **[Reviewing a user profile](#reviewing-a-user-profile)**  
-When you search for a user, you can view their profile details.
-
-
 
 ## Reviewing a user profile {#reviewing-a-user-profile}
 
@@ -176,10 +138,7 @@ The profile details are organized across several pages:
 
     The number to the right of the page label indicates how many people are currently being followed by this user. If the user has marked their list as private, this page will not appear in the profile.
 
-
 > **Note:** When you view a user's profile, these pages display only the sites and content that you have permission to view.
-
-
 
 ## Using the Advanced Search {#using-the-advanced-search}
 
@@ -193,13 +152,14 @@ Use the search box in the toolbar to access the advanced search.
 
     -   **Content**: Searches for all types of content
     -   **Folders**: Searches for all folders and containers, such as library folders and data lists
+
 3.  Enter your search criteria.
 
     To search by modification date, click the calendar icon to select a date from a calendar.
 
     To search by the user who last modified the content, enter the appropriate user name in the **Modifier** field.
 
-    >**Tip:** You can type * to complete a word if you don't know the full word you're searching for. For example, both **resco* and *alf** will show results for *alfresco*..
+    >**Tip:** You can type `*` to complete a word if you don't know the full word you're searching for. For example, both `**resco*` and `*alf**` will show results for *alfresco*..
 
 4.  Click **Search**.
 
@@ -212,7 +172,6 @@ Use the search box in the toolbar to access the advanced search.
     -   Hover over a result and click **Actions** and select an option from the menu.
 
         >**Tip:** You can delete a file this way but the search results won't be updated until you run a new search.
-
 
 ## Following users {#following-users}
 
@@ -238,8 +197,4 @@ There can be many users of a system, so it is likely that there will be some use
 
 6.  Click your name at the top of the screen, then **My Profile**.
 
-
 You'll see that the top of the page shows how many people you're following.
-
-
-

--- a/content-services/5.2/using/share.md
+++ b/content-services/5.2/using/share.md
@@ -4,13 +4,6 @@ title: Using Alfresco Share
 
 Use the Getting Started guide to quickly learn the basics, and find detailed info in Using Alfresco Share.
 
--   **[Getting started with Alfresco Share](#getting-started-with-alfresco-share)**  
-For most of us, today's work environment means we spend much of our time working in teams that can extend beyond our workplace, and even our enterprise, to include partners, consultants, external agencies, and customers.
--   **[Using Alfresco Share](#using-alfresco-share)**  
-Find everything you need to know for using Alfresco Share on a daily basis.
--   **[Using Alfresco Content Services from other applications]({% link content-services/5.2/using/index.md %})**  
-There are several ways to access and use content without being in Alfresco Share.
-
 ## Getting started with Alfresco Share
 
 For most of us, today's work environment means we spend much of our time working in teams that can extend beyond our workplace, and even our enterprise, to include partners, consultants, external agencies, and customers.
@@ -26,23 +19,9 @@ This guide gives you an introduction to some of the features of Alfresco Share:
 
 You'll also be shown other little tricks and tips to help you get more out of Alfresco Share, so you can work and collaborate efficiently and effectively.
 
-The video shows an overview of the Alfresco Share features:
+There are a set of [video tutorials]({% link content-services/5.2/tutorial/video/index.md %}) related to Alfresco Share, including a [tour of the available features]({% link content-services/5.2/tutorial/video/index.md %}#tour-of-alfresco-share).
 
-> **Note:** This video contains functionality that's no longer available in Alfresco Share, i.e. Sync to Cloud.
-
--   **[Signing in](#signing-in)**  
-To start the Getting Started guide you need to sign in to Alfresco Share.
--   **[Personalizing Alfresco Share]({% link content-services/5.2/using/dashboard.md %}#personalizing-alfresco-share)**  
- Having installed Alfresco Share and signed in, the first thing you can do is to personalize Alfresco Share to your own tastes and needs.
--   **[Building a site]({% link content-services/5.2/using/sites/index.md %}#building-a-site)**  
-Now that you've personalized your own dashboard and profile, you're ready to set up a site.
--   **[Working with content]({% link content-services/5.2/using/content/index.md %})**  
-Before you begin working with content, we'll look at the two different concepts of content there are in Alfresco Share.
--   **[Being social]({% link content-services/5.2/using/sites/features.md %}#being-social)**  
- You have built a site and added some content to it. The next thing you need to do is to get other users on your site, sharing and creating their own content.
--   **[More resources](#more-resources)**  
-This is the end of the Alfresco Share Getting Started guide, and you should now be able to use Alfresco Share in ways that will improve how you work on a day to day basis.
-
+> **Note:** Some videos may contains functionality that's no longer available in Alfresco Share, i.e. Sync to Cloud.
 
 ### Signing in {#signing-in}
 
@@ -62,50 +41,15 @@ To start the Getting Started guide you need to sign in to Alfresco Share.
 
     ![Your Personal Dashboard]({% link content-services/images/gs-firstlogin.png %})
 
-
 ## Using Alfresco Share
 
 Find everything you need to know for using Alfresco Share on a daily basis.
-
--   **[Finding your way around](#finding-your-way-around)**  
-Alfresco Share content is stored in sites, and each individual site has its own dashboard made up of *dashlets*.
--   **[Your profile and dashboard]({% link content-services/5.2/using/dashboard.md %}#your-profile-and-dashboard)**  
-You can customize your user profile and dashboard however you like without affecting anyone else - you're the only person that sees your dashboard.
--   **[Sites]({% link content-services/5.2/using/sites/index.md %}#sites)**  
-A site is a area where you can share content and collaborate with other site members.
--   **[Content]({% link content-services/5.2/using/content/index.md %}#content)**  
-A site document library is where you store and manage content, such as documents, images, and videos.
--   **[Tasks and workflows]({% link content-services/5.2/using/tasks.md %}#tasks-and-workflows)**  
-Tasks and workflows help you keep track of the things you and other users need to do. You can create a standalone task or workflow, or you can attach a file to it.
--   **[Site features]({% link content-services/5.2/using/sites/features.md %}#site-features)**  
-As well as the Document Library and Site Members area, there are lots of features that can be included in a site.
--   **[Searching for content]({% link content-services/5.2/using/search.md %}#searching-for-content)**  
-You can use the search box on the toolbar to search for files, sites, and people.
--   **[Using Smart Folders]({% link content-services/5.2/using/smart-folders.md %}#using-smart-folders)**  
-A Smart Folder is a way of grouping files from different locations in Alfresco Share into a single folder, so that you can quickly find similar files.
--   **[Power users]({% link content-services/5.2/admin/share-admin-tools.md %}#power-users)**  
-Alfresco Share power users have additional options that aren't available to standard users.
--   **[User roles and permissions]({% link content-services/5.2/using/permissions.md %}#user-roles-and-permissions)**  
-A user's role determines what they can and cannot do in a site. Each role has a default set of permissions.
-
 
 ### Finding your way around {#finding-your-way-around}
 
 Alfresco Share content is stored in sites, and each individual site has its own dashboard made up of *dashlets*.
 
 You also have your own user dashboard which gives you an overview of what's happening in Alfresco Share, and a user profile which you can use to let others know what you're doing.
-
--   **[Alfresco Share toolbar](#alfresco-share-toolbar)**  
-The toolbar is designed to help you to navigate Alfresco Share and to quickly find, create, and share content.
--   **[User dashboard](#user-dashboard)**  
-Wherever you are in Alfresco Share, you can click **Home** or **User Dashboard** on your user menu to go to your dashboard.
--   **[Viewing your user profile](#viewing-your-user-profile)**  
-Your user profile includes more information than just your contact details. Here you can see at a glance who you are following, who is following you, the sites you belong to, and the content you have recently added and modified.
--   **[What version of Alfresco Share am I using?](#what-version-of-alfresco-share-am-I-using?)**  
-It's easy to check which version of Alfresco Share you're using.
--   **[Subscribing to an RSS feed](#subscribing-to-an-rss-feed)**  
-There are several places in Alfresco Share where you can subscribe to RSS feeds. These feeds let you automatically receive regular updates on various activities.
-
 
 ### Alfresco Share toolbar {#alfresco-share-toolbar}
 
@@ -156,7 +100,6 @@ It's always available at the top of the page, wherever you are in Share.
 -   **Search**
 
     Use the search box to find files, sites, and people.
-
 
 ### User dashboard {#user-dashboard}
 
@@ -233,10 +176,6 @@ You can resize most dashlets.
 To resize a dashlet click and drag on the bottom edge of the dashlet until it's the height you want. This is saved between sessions.
 
 >**Tip:** If you hover over a dashlet header then a ![Add Event icon]({% link content-services/images/help-1.png %}) icon appears. Click it for an explanation of what the dashlet does. This stays open until you close it or navigate away from the dashboard.
-
--   **[What can I do with my dashlets?](#what-can-I-do-with-my-dashlets?)**  
-As well as giving you an overview of activity and information in Alfresco Share, the dashlets also give you links to various areas of Share and let you carry out a range of actions.
-
 
 #### What can I do with my dashlets?
 
@@ -340,14 +279,6 @@ Each dashlet has a unique role:
 
 >**Tip:** Each dashlet includes help text. Position your cursor in the dashlet header to reveal the help button, then click it to display the related text. The help stays open until you close it or navigate away from the dashboard.
 
--   **[Configuring the RSS feed dashlets](#configuring-the-rss-feed-dashlets)**  
-There are two RSS feed dashlets that you can include on your personal and site dashboards: RSS Feed and Alfresco Add-ons RSS Feed. On both dashlets you can edit the default URL to display any RSS feed.
--   **[Setting up the Web View dashlet](#setting-up-the-web-view-dashlet)**  
-Set up the Web View dashlet to display websites.
--   **[Configuring the Saved Search dashlet](#configuring-the-saved-search-dashlet)**  
-Configure the Saved Search dashlet to run a specific search each time the dashboard is loaded.
-
-
 ### Configuring the RSS feed dashlets
 
 There are two RSS feed dashlets that you can include on your personal and site dashboards: RSS Feed and Alfresco Add-ons RSS Feed. On both dashlets you can edit the default URL to display any RSS feed.
@@ -361,7 +292,6 @@ There are two RSS feed dashlets that you can include on your personal and site d
 4.  Select **Open links in new window** to have the target story display in a new window.
 
 5.  Click **OK**.
-
 
 ### Setting up the Web View dashlet
 
@@ -382,7 +312,6 @@ The dashboard must be customized to display the Web View dashlet.
     > **Important:** Ensure the URL entered does not contain the JavaScript code `if(self.parent.frames.length!=0)self.parent.location=document.location;`. This or similar code causes the referenced website to open directly in the browser rather than in the Web View dashlet. This will lead to problems viewing the current dashboard (personal or site).
 
 4.  Click **OK**.
-
 
 ### Configuring the Saved Search dashlet
 
@@ -405,7 +334,6 @@ On the site dashboard, only a site manager can configure the Saved Search dashle
 5.  Select the number of results you want to display.
 
 6.  Click **OK**.
-
 
 ### Viewing your user profile {#viewing-your-user-profile}
 
@@ -451,7 +379,6 @@ Your user profile includes more information than just your contact details. Here
 
         Lets you find and recover deleted content
 
-
 ### What version of Alfresco Share am I using? {#what-version-of-alfresco-share-am-I-using}
 
 It's easy to check which version of Alfresco Share you're using.
@@ -459,7 +386,6 @@ It's easy to check which version of Alfresco Share you're using.
 1.  Click the Alfresco logo at the bottom of Alfresco Share.
 
     A box opens showing which version of Share you're working with.
-
 
 ### Subscribing to an RSS feed {#subscribing-to-an-rss-feed}
 
@@ -487,7 +413,6 @@ An RSS Feed button or icon shows you where the feeds are available.
 
     >**Tip:** RSS feeds credentials are stored by the browser you're using and not Share. As such it's recommended that you close your browser after logging out of Share and / or lock your computer while you're away from it.
 
-
 ### More resources {#more-resources}
 
 This is the end of the Alfresco Share Getting Started guide, and you should now be able to use Alfresco Share in ways that will improve how you work on a day to day basis.
@@ -505,6 +430,3 @@ This is just the beginnings of what you can achieve with Alfresco Share; we'd re
 -   Read the [(Using Alfresco Share)](#using-alfresco-share) documentation on other features
 -   Watch the Alfresco Share 'How To' videos [('How To' videos)]({% link content-services/5.2/tutorial/index.md %})
 -   Use other site components such as discussion forums[(Discussion forums)]({% link content-services/5.2/using/sites/features.md %}#the-discussion-forum), blogs[(Blogs)]({% link content-services/5.2/using/sites/features.md %}#the-blog), and data lists [(Data lists)]({% link content-services/5.2/using/sites/features.md %}#data-lists)
-
-
-

--- a/content-services/5.2/using/sites/features.md
+++ b/content-services/5.2/using/sites/features.md
@@ -6,16 +6,6 @@ You have built a site and added some content to it. The next thing you need to d
 
 In Alfresco Share you can schedule social events using the shared site calendar, and add both internal and external users to the site. You also decide how much power they have in the site, such as whether they can just add content or actively edit content created by other users. There is also a full range of social features such as liking content and following favorite users.
 
--   **[Scheduling events](#scheduling-events)**  
-Having previously added a calendar to your site, you can now use it to schedule events for your team.
--   **[Adding users to your site]({% link content-services/5.2/using/sites/index.md %}#adding-users-to-your-site)**  
-Now that you've created a site and added content, the next step is to invite other Alfresco Share users to the site.
--   **[Using social features]({% link content-services/5.2/using/content/manage.md %}#using-social-features)**  
-When you look at the site dashboard you can see site activity and details of content that has been added or edited.
--   **[Following users]({% link content-services/5.2/using/search.md %}#following-users)**  
-There can be many users of a system, so it is likely that there will be some users whose activities will be of more importance to you. You can choose to follow these users so that you can easily keep track of what they've been doing.
-
-
 ## Scheduling events {#scheduling-events}
 
 Having previously added a calendar to your site, you can now use it to schedule events for your team.
@@ -43,23 +33,6 @@ As well as the Document Library and Site Members area, there are lots of feature
 
 Site managers can easily add and remove features by [customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site)
 
-  
-
--   **[The calendar](#the-calendar)**  
-The site calendar lets you schedule and track events related to the current site.
--   **[The wiki](#the-wiki)**  
-The wiki lets site users create pages for a collaborative wiki.
--   **[The discussion forum](#the-discussion-forum)**  
-The discussion forum lets you post user-generated content related to a site. These topics often take the form of questions or comments with threaded discussions.
--   **[The blog](#the-blog)**  
-The site blog lets you add commentary, descriptions of events, and other material related to your site.
--   **[Site links](#site-links)**  
-The links component lets site members compile a list of web links that are related to the site or that might be of interest to site users. These can be internal links pointing to site pages or external links pointing to any web address.
--   **[Data lists](#data-lists)**  
-The data lists component lets site members create and manage lists of data relevant to the site. Users can work with their own lists and can also contribute to lists created by other site members.
-
-
-
 ## The calendar {#the-calendar}
 
 The site calendar lets you schedule and track events related to the current site.
@@ -67,23 +40,6 @@ The site calendar lets you schedule and track events related to the current site
 Site members can create events that appear on the calendar for all site users to see. These events also display in the Site Calendar dashlet. You can view the calendar by day, week, or month. The Agenda view displays upcoming events.
 
 > **Note:** See [Customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site) for how to switch the calendar on and off for a site.
-
--   **[Accessing the calendar](#accessing-the-calendar)**  
-Access the calendar to view upcoming events for the current site.
--   **[Browsing the calendar](#browsing-the-calendar)**  
-The main view defaults to a calendar displaying the current month. The explorer panel to the left provides another calendar for navigating the months without affecting the main view.
--   **[Viewing an event](#viewing-an-event)**  
-The calendar displays only the event name and time, so to view full details you must open the event. Once open you can edit or delete the event.
--   **[Adding an event](#adding-an-event)**  
-Any site member can schedule an event in the site calendar. The event appears in the calendar and the Site Calendar dashlet.
--   **[Editing event details](#editing-event-details)**  
-Edit a scheduled event to change any of the details, including the location, date, and time. You can also add and remove tags, and change the library folder associated with the event.
--   **[Changing event date and time](#changing-event-date-and-time)**  
-You can easily change the day, time, and duration of an event.
--   **[Deleting an event](#deleting-an-event)**  
-When a scheduled event is cancelled you can easily delete it to remove it from the calendar. This also removes it from the Site Calendar dashlet.
-
-
 
 ## Accessing the calendar {#accessing-the-calendar}
 
@@ -96,7 +52,6 @@ Within the calendar you can create events, as well as edit and delete any events
     > **Note:** In each site the feature names can be customized. If the site manager has done this, the link might have a name other than **Calendar**.
 
     This opens the calendar which defaults to the Month view. Any events scheduled in the current month are displayed on the calendar.
-
 
 ## Browsing the calendar {#browsing-the-calendar}
 
@@ -277,25 +232,6 @@ In both views (wiki list and page view) you can create, delete, view details for
 
 > **Note:** See [Customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site) for how to switch the wiki on and off for a site.
 
--   **[Accessing the wiki](#accessing-the-wiki)**  
-Access the wiki to view the wiki content related to the current site. In the wiki you can create, delete, rename, and edit the wiki pages. You can perform most actions from both the wiki list and the page view.
--   **[Browsing the wiki pages](#browsing-the-wiki-pages)**  
-The browsing feature in the wiki lets you filter the wiki pages so you can easily locate specific content.
--   **[Creating the wiki main page](#creating-the-wiki-main-page)**  
-When you create a new site, the site's wiki contains a main page, which is empty. You will likely choose to make this the introductory page for the site wiki.
--   **[Creating a new wiki page](#creating-a-new-wiki-page)**  
-You can create a new wiki page from both the wiki list and the page view.
--   **[Editing a wiki page](#editing-a-wiki-page)**  
-Edit a wiki page to create new content, edit existing content, and add tags.
--   **[Renaming a wiki page](#renaming-a-wiki-page)**  
-You rename a wiki page in the page view.
--   **[Deleting a wiki page](#deleting-a-wiki-page)**  
-Delete a wiki page when you no longer want it to appear in the wiki for the current site. You can perform this task from both the wiki list and the page view.
--   **[Viewing the wiki page details](#viewing-the-wiki-page-details)**  
-View wiki page details to see the version history, view the tags associated with the page, and list the wiki pages that link to the selected page. You can view the page details from both the wiki list and the page view. On this page, you can view previous versions of the page and even revert to a specific version.
-
-
-
 ## Accessing the wiki {#accessing-the-wiki}
 
 Access the wiki to view the wiki content related to the current site. In the wiki you can create, delete, rename, and edit the wiki pages. You can perform most actions from both the wiki list and the page view.
@@ -311,7 +247,6 @@ Access the wiki to view the wiki content related to the current site. In the wik
     The wiki list displays a summary of all pages in the wiki for the current site. In this view, the actions you can perform on a wiki page appear as buttons beneath the banner (only **New Page** is available in this view) and as links to the right of each page summary. You can perform most actions from both the wiki list and the page view.
 
     > **Note:** You can click **Main Page** to return to the previous view.
-
 
 ## Browsing the wiki pages {#browsing-the-wiki-pages}
 
@@ -540,23 +475,6 @@ Members of a site can create new topics and can also reply to a posting to take 
 
 > **Note:** See [Customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site) for how to switch the discussion forum on and off for a site.
 
--   **[Accessing the discussion forum](#accessing-the-discussion-forum)**  
-Access the discussion forum to view the discussion topics for the current site.
--   **[Browsing the discussion topics](#browsing-the-discussion-topics)**  
-The browsing feature in the discussions forum lets you filter the discussion topics so you can more easily navigate the content.
--   **[Viewing a topic](#viewing-a-topic)**  
-The discussion forum topics display in either a summary view or a simple list. Viewing a topic allows you to see the full contents of the discussion.
--   **[Replying to a discussion](#replying-to-a-discussion)**  
-Reply to a topic to take part in the discussion. You can reply to the original discussion topic or any replies already created for that topic. Each reply is nested to visually indicate the discussion flow.
--   **[Creating a new topic](#creating-a-new-topic)**  
-Create a new topic to start a discussion relevant to the current site. All site members will have access to this content.
--   **[Editing a topic](#editing-a-topic)**  
-Edit an existing discussion topic to modify or add to the content.
--   **[Deleting a topic](#deleting-a-topic)**  
-Delete a topic to permanently remove it from the discussions forum. This action also deletes all replies to that topic.
-
-
-
 ## Accessing the discussion forum {#accessing-the-discussion-forum}
 
 Access the discussion forum to view the discussion topics for the current site.
@@ -575,12 +493,12 @@ Within a discussion you can create new topics, as well as edit and delete topics
     -   the number of replies to the topic
     -   a sample of the content
     -   the tags associated with the topic
+
 2.  Use the **<<** and **>>** navigation buttons to move forward and backward through multiple pages of topics.
 
 3.  Click **Simple View** to display only the basic topic information: title, creation date/time, and author.
 
     Click **Detailed View** to display the summary view.
-
 
 ## Browsing the discussion topics {#browsing-the-discussion-topics}
 
@@ -605,7 +523,6 @@ The **Topics** list in the browsing pane provides the following views:
 -   **My Topics**
 
     Displays the topics created by the current user
-
 
 The **Tags** list displays the tags currently associated with one or more discussion topics. The number following the tag tells you how many discussion topics are associated with the tag.
 
@@ -660,11 +577,6 @@ Reply to a topic to take part in the discussion. You can reply to the original d
 
 
 The reply appears beneath and indented from its parent topic or reply.
-
--   **[Editing a reply](#editing-a-reply)**  
-You can edit a reply just as you edit a discussion topic.
-
-
 
 ## Editing a reply {#editing-a-reply}
 
@@ -772,22 +684,6 @@ Site members can create, edit, and add comments to blog postings. The postings c
 
 > **Note:** See [Customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site) for how to switch the blog on and off for a site.
 
--   **[Accessing the blog](#accessing-the-blog)**  
-Access the blog to view all published blog posts for the current site. You can also see your own unpublished (draft) posts.
--   **[Browsing blog posts](#browsing-blog-posts)**  
-The browsing feature in the blog lets you filter the posts so you can easily navigate the blog content.
--   **[Viewing a blog post](#viewing-a-blog-post)**  
-Browsing the blog displays the existing posts in the main view. These posts display in either a summary view or a simple list. Viewing a post lets you to see the full contents of the post.
--   **[Creating a blog post](#creating-a-blog-post)**  
-Create a new blog post to add information or a commentary related to the current site.
--   **[Editing a blog post](#editing-a-blog-post)**  
-Edit an existing blog post to modify or add to its content.
--   **[Deleting a blog post](#deleting-a-blog-post)**  
-Delete a blog post to permanently remove it from the current site's blog.
--   **[Working with comments](#working-with-comments)**  
-Adding comments to a blog post helps make the site blog interactive. While all users with access to the site can view the blog conversations, only site members can add comments.
-
-
 ## Accessing the blog {#accessing-the-blog}
 
 Access the blog to view all published blog posts for the current site. You can also see your own unpublished (draft) posts.
@@ -807,6 +703,7 @@ In the blog you can write new posts and you can edit, publish, and delete posts 
     -   a sample of the content
     -   the number of replies to the post
     -   the tags associated with the post
+
     Where the list contains more posts than can be displayed on a single page, navigation links become enabled at the top and bottom of the item list. The number in bold indicates your current page. Click a page number to display a specific page. Use the previous (<<) and next (>>) links to move forward and backward through multiple pages of posts.
 
 2.  Click **Simple View** to display only the basic blog post information: title, date/time of publishing, and author.
@@ -964,15 +861,6 @@ Adding comments to a blog post helps make the site blog interactive. While all u
 
 The number of replies added to a post is recorded and displayed for each posting. You must view a post to add, view, and manage the related comments.
 
--   **[Adding a comment to a post](#adding-a-comment-to-a-post)**  
-In the blog you can add a comment to reply to any published blog post.
--   **[Editing a comment](#editing-a-comment)**  
-Edit a blog comment to modify or add to its content.
--   **[Deleting a comment](#deleting-a-comment)**  
-Delete a comment to permanently remove it from a blog post.
-
-
-
 ## Adding a comment to a post {#adding-a-comment-to-a-post}
 
 In the blog you can add a comment to reply to any published blog post.
@@ -994,8 +882,6 @@ In the blog you can add a comment to reply to any published blog post.
     The comment displays beneath the post.
 
 6.  Click **Blog Post List** to return to the main view.
-
-
 
 ## Editing a comment {#editing-a-comment}
 
@@ -1025,7 +911,6 @@ Only a Site Manager, a Site Collaborator, and the user who created the comment c
 
 6.  Click **Blog Post List** to return to the main view.
 
-
 ## Deleting a comment {#deleting-a-comment}
 
 Delete a comment to permanently remove it from a blog post.
@@ -1050,8 +935,6 @@ Only a Site Manager, a Site Collaborator, and the user who created the comment c
 
 5.  Click **Blog Post List** to return to the main view.
 
-
-
 ## Site links {#site-links}
 
 The links component lets site members compile a list of web links that are related to the site or that might be of interest to site users. These can be internal links pointing to site pages or external links pointing to any web address.
@@ -1059,23 +942,6 @@ The links component lets site members compile a list of web links that are relat
 The comment feature allows site members to add and manage comments on the site links.
 
 > **Note:** See [Customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site) for how to switch links on and off for a site.
-
--   **[Accessing the site links](#accessing-the-site-links)**  
-Access the site links component to view the web links compiled for the current site.
--   **[Browsing the site links](#browsing-the-site-links)**  
-The explorer panel on the main view enables you to filter the links for easier navigation.
--   **[Viewing a link](#viewing-a-link)**  
-The main view of the Links feature displays the existing links for this site. You can choose a summary view or a simple list. Viewing a link enables you to see the full link details as well as any comments that have been added.
--   **[Creating a new link](#creating-a-new-link)**  
-Create a new site link to provide easy access to information that could be of interest or use to the site members. You can add any internal or external web address.
--   **[Editing a link](#editing-a-link)**  
-Edit an existing link to modify it.
--   **[Deleting a link](#deleting-a-link)**  
-Delete a link to permanently remove it from the current site. This action also deletes any comments on the link.
--   **[Adding a comment to a link](#adding-a-comment-to-a-link)**  
-In the links feature you can add a comment to a link.
-
-
 
 ## Accessing the site links {#accessing-the-site-links}
 
@@ -1095,12 +961,12 @@ In this component you can create new links, as well as edit and delete the links
     -   the user who created the link
     -   a description of the link
     -   the tags associated with the link
+
 2.  Use the **<<** and **>>** navigation buttons to move forward and backward through multiple pages of links.
 
 3.  Click **Simple View** to display only the basic link details: title and URL.
 
     Click **Detailed View** to display the summary view.
-
 
 ## Browsing the site links {#browsing-the-site-links}
 
@@ -1122,7 +988,6 @@ The **Links** list in the browsing pane provides the following options for brows
 
     Displays the links created in the past seven days
 
-
 The **Tags** list displays all tags currently associated with one or more links.
 
 **To browse the links:**
@@ -1139,8 +1004,6 @@ The **Tags** list displays all tags currently associated with one or more links.
 
 3.  Position the cursor over an item in this list to display its available actions.
 
-
-
 ## Viewing a link {#viewing-a-link}
 
 The main view of the Links feature displays the existing links for this site. You can choose a summary view or a simple list. Viewing a link enables you to see the full link details as well as any comments that have been added.
@@ -1154,7 +1017,6 @@ Although you can perform actions on a link from the main page, you might want to
     The link view displays the selected link in its entirety, along with any comments that have been added.
 
 3.  Click **Links List** to return to the main view.
-
 
 ## Creating a new link {#creating-a-new-link}
 
@@ -1182,7 +1044,6 @@ Create a new site link to provide easy access to information that could be of in
 
 7.  Click **Links List** to return to the main view.
 
-
 ## Editing a link {#editing-a-link}
 
 Edit an existing link to modify it.
@@ -1209,8 +1070,6 @@ Only a Site Manager, a Site Collaborator, and the user who created the link can 
 
 6.  Click **Links List** to return to the main view.
 
-
-
 ## Deleting a link {#deleting-a-link}
 
 Delete a link to permanently remove it from the current site. This action also deletes any comments on the link.
@@ -1229,12 +1088,7 @@ Only the Site Manager and the user who created the link can delete it.
 
 3.  Click **Delete**.
 
-
 A message indicates the selected link has been deleted.
-
--   **[Deleting multiple links](#deleting-multiple-links)**  
-In the links list you can quickly delete multiple links rather than removing them one at a time.
-
 
 ## Deleting multiple links {#deleting-multiple-links}
 
@@ -1246,6 +1100,7 @@ In the links list you can quickly delete multiple links rather than removing the
 
     -   Click the check box to left of each link you want to delete.
     -   Click **Select** at the top of the list and click **All** to select all links in the current view.
+
     Click **None** to clear the list selections. Click **Invert Selection** to toggle the check boxes to their opposite state.
 
     The appropriate check boxes appear selected in the links list.
@@ -1258,10 +1113,7 @@ In the links list you can quickly delete multiple links rather than removing the
 
 4.  Click **Delete**.
 
-
 A message indicates the selected links have been deleted.
-
-
 
 ## Adding a comment to a link {#adding-a-comment-to-a-link}
 
@@ -1282,14 +1134,6 @@ In the links feature you can add a comment to a link.
     The comment displays beneath the link.
 
 5.  Click **Links List** to return to the main view.
-
-
--   **[Editing a link comment](#editing-a-link-comment)**  
-You can edit a comment on a link to modify or add to its content.
--   **[Deleting a link comment](#deleting-a-link-comment)**  
-Delete a comment to permanently remove it from a link.
-
-
 
 ## Editing a link comment {#editing-a-link-comment}
 
@@ -1317,7 +1161,6 @@ Only a Site Manager, a site Collaborator, and the user who created the comment c
 
 5.  Click **Links List** to return to the main view.
 
-
 ## Deleting a link comment {#deleting-a-link-comment}
 
 Delete a comment to permanently remove it from a link.
@@ -1340,30 +1183,11 @@ Only a Site Manager and the user who created the comment can delete it.
 
 4.  Click **Links List** to return to the main view.
 
-
-
 ## Data lists {#data-lists}
 
 The data lists component lets site members create and manage lists of data relevant to the site. Users can work with their own lists and can also contribute to lists created by other site members.
 
 > **Note:** See [Customizing a site]({% link content-services/5.2/using/sites/index.md %}#customizing-a-site) for how to switch data lists on and off for a site.
-
--   **[Accessing the Data Lists component](#accessing-the-data-lists-component)**  
-Access the data lists component to view the lists created for the current site.
--   **[Viewing a list](#viewing-a-list)**  
-The **Lists** section of the explorer panel displays the data lists for the current site. Once you select a list to view you can apply filters to display specific list items within that list.
--   **[Creating a new list](#creating-a-new-list)**  
-Create a new list for the current site.
--   **[Editing the list details](#editing-the-list-details)**  
-Edit an existing list to modify its title and description.
--   **[Deleting a list](#deleting-a-list)**  
-Delete a list to permanently remove it from the site.
--   **[Working with list items](#working-with-list-items)**  
-Once you create a list you can populate it with list items.
--   **[Working with multiple list items](#working-with-multiple-list-items)**  
-In the data lists component you can select multiple list items to quickly and easily perform a single task on the selected items.
-
-
 
 ## Accessing the Data Lists component {#accessing-the-data-lists-component}
 
@@ -1376,7 +1200,6 @@ In this component you can create new lists, as well as edit and delete any lists
     > **Note:** In each site the feature names can be customized. If the site manager has done this, the link might have a name other than **Data Lists**.
 
     This opens the feature. The browsing pane displays a list of all existing data lists for the current site.
-
 
 ## Viewing a list {#viewing-a-list}
 
@@ -1411,8 +1234,6 @@ The **Items** list in the explorer panel provides the following options for filt
 
 3.  In the table click a column headings to sort the results by that column.
 
-
-
 ## Creating a new list {#creating-a-new-list}
 
 Create a new list for the current site.
@@ -1425,9 +1246,9 @@ Create a new list for the current site.
 
 3.  Type a **Title** (required) and **Description** (optional) for the list.
 
-    CAUTION:
-
-    You are not warned if you create lists with duplicate titles. Review the existing lists to ensure that your list name is unique.
+    > **CAUTION:**
+    >
+    > You are not warned if you create lists with duplicate titles. Review the existing lists to ensure that your list name is unique.
 
 4.  Click **Save**.
 
@@ -1436,8 +1257,6 @@ Create a new list for the current site.
 5.  Click the list name to display the list in the main view.
 
     A new list contains no list items.
-
-
 
 ## Editing the list details {#editing-the-list-details}
 
@@ -1459,8 +1278,6 @@ Only a Site Manager, a Site Collaborator, and the user who created the list can 
 
 4.  Click **Save**.
 
-
-
 ## Deleting a list {#deleting-a-list}
 
 Delete a list to permanently remove it from the site.
@@ -1475,9 +1292,7 @@ Only the Site Manager and the user who created the list can delete it.
 
 3.  Click **Delete**.
 
-
 A message indicates the selected list has been deleted.
-
 
 ## Working with list items {#working-with-list-items}
 
@@ -1486,16 +1301,6 @@ Once you create a list you can populate it with list items.
 You can add items to both your own lists and lists created by other site members. Do this by creating new items or duplicating existing list items.
 
 To maintain your lists you can also edit and delete items.
-
--   **[Creating a list item](#creating-a-list-item)**  
-Create list items in an an existing data list.
--   **[Editing a list item](#editing-a-list-item)**  
-Edit an existing list item to modify it.
--   **[Duplicating a list item](#duplicating-a-list-item)**  
-Quickly and easily create a new list item by duplicating an existing item in the same list. This is a particularly useful action if the two items have similar details.
--   **[Deleting a list item](#deleting-a-list)**  
-Delete a list item to permanently remove it from the current data list.
-
 
 ## Creating a list item {#creating-a-list-item}
 
@@ -1514,10 +1319,10 @@ Create list items in an an existing data list.
     -   Calendar icon: Click the icon to display a calendar and then select the date.
     -   **Select** button (**Assigned To** and **Assignee**): Click **Select** then search for and add the user(s).
     -   **Select** button (**Attachments**): Click **Select** then browse the library structure to locate and add the content item(s).
+
 4.  Click **Save**.
 
     The new item appears in the list.
-
 
 ## Editing a list item {#editing-a-list-item}
 
@@ -1539,8 +1344,6 @@ Only a Site Manager, a Site Collaborator, and the user who created the item can 
 
     The updated item appears in the list.
 
-
-
 ## Duplicating a list item {#duplicating-a-list-item}
 
 Quickly and easily create a new list item by duplicating an existing item in the same list. This is a particularly useful action if the two items have similar details.
@@ -1554,7 +1357,6 @@ Quickly and easily create a new list item by duplicating an existing item in the
     The new item is created. Its details are identical to the selected list item.
 
 4.  Edit the new list item as necessary.
-
 
 ## Deleting a list item {#deleting-a-list-item}
 
@@ -1572,20 +1374,11 @@ Only the Site Manager and the user who created the item can delete it.
 
 4.  Click **Delete**.
 
-
 A message indicates the selected list item has been deleted.
-
 
 ## Working with multiple list items {#working-with-multiple-list-items}
 
 In the data lists component you can select multiple list items to quickly and easily perform a single task on the selected items.
-
--   **[Selecting multiple list items](#selecting-multiple-list-items)**  
-There are two methods to select multiple list items in the current data list. You can select any number of items.
--   **[Performing actions on multiple list items](#performing-actions-on-multiple-list-items)**  
-Once you select the list items you want to work with you can select an action to perform.
-
-
 
 ## Selecting multiple list items {#selecting-multiple-list-items}
 
@@ -1595,11 +1388,10 @@ There are two methods to select multiple list items in the current data list. Yo
 
     -   Click a check box to select the associated list item.
     -   Click **Select** at the top of the data list and click **All**.
+
     Click **None** to clear the list selections. Click **Invert Selection** to toggle the check boxes to their opposite state.
 
-
 The appropriate check boxes appear selected in the data list.
-
 
 ## Performing actions on multiple list items {#performing-actions-on-multiple-list-items}
 
@@ -1619,7 +1411,6 @@ The **Selected Items** list displays the actions that you can perform on multipl
 
     Clears the check boxes of the currently selected list items
 
-
 When a data list is longer than one page you can select items on multiple pages. However, the selected action is performed only on the items on the page currently displayed.
 
 1.  Click on a data list in the Data lists explorer panel.
@@ -1633,4 +1424,3 @@ When a data list is longer than one page you can select items on multiple pages.
 4.  Click the required action.
 
     Click **Deselect All** to clear the selected items. When you select this option you cannot perform another action until you reselect the list items.
-

--- a/content-services/5.2/using/sites/index.md
+++ b/content-services/5.2/using/sites/index.md
@@ -6,14 +6,6 @@ Now that you've personalized your own dashboard and profile, you're ready to set
 
 Collaboration in Alfresco Share is based around the concept of creating sites that teams can share content in, but an Alfresco Share site is more than just a place to share and manage content. You can schedule and manage meetings and calendars, publish blogs and set up forums where you can have team discussions, and even write content online and publish it to a wiki.
 
--   **[Creating a new site](#creating-a-new-site)**  
-The first thing that you need to do is to create a site and choose its settings.
--   **[Customizing the site dashboard](#customizing-the-site-dashboard)**  
-A site dashboard displays all information and activities associated with the site. You can customize the site dashboard just as you did with your personal dashboard.
--   **[Adding features to a site](#adding-features-to-a-site)**  
-You can add features to your site such as a discussion forum, a wiki, or a blog.
-
-
 ## Creating a new site {#creating-a-new-site}
 
 The first thing that you need to do is to create a site and choose its settings.
@@ -38,13 +30,6 @@ The first thing that you need to do is to create a site and choose its settings.
 
     Now that you've created a site, you can start to customize it, in much the same way as you did with your personal dashboard.
 
-
-This video shows the steps in the tutorial.
-
-  
-
-
-
 ## Customizing the site dashboard {#customizing-the-site-dashboard}
 
 A site dashboard displays all information and activities associated with the site. You can customize the site dashboard just as you did with your personal dashboard.
@@ -60,11 +45,6 @@ A site dashboard displays all information and activities associated with the sit
 
 You can resize the dashlets on the site dashboard as required. You are now nearly ready to add content to your site, just one more step first to customize the site further.
 
-This video shows the steps in the tutorial.
-
-  
-
-
 ## Adding features to a site {#adding-features-to-a-site}
 
 You can add features to your site such as a discussion forum, a wiki, or a blog.
@@ -79,12 +59,6 @@ At the top of your site dashboard are tabs for areas of your site. By default yo
 
 
 Back on the site dashboard you can see that the wiki and calendar have been added. You now have a site set up! It's time to start adding some content...
-
-This video shows the steps in the tutorial.
-
-  
-
-
 
 ## Adding users to your site {#adding-users-to-your-site}
 
@@ -108,11 +82,6 @@ Now that you've created a site and added content, the next step is to invite oth
 
 
 An email notification is sent to each person that you invited and they can start using the site immediately.
-
-This video shows the steps in the tutorial.
-
-  
-
 
 ## Sites {#sites}
 
@@ -147,17 +116,6 @@ The manager of any site—whether public or private—can add users.
 
 You can remove yourself from a site at any time by clicking ![]({% link content-services/images/settings-icon.png %}) in the site and selecting **Leave Site**.
 
--   **[Accessing existing sites](#accessing-existing-sites)**  
-Accessing an existing site is easy.
--   **[Site dashboard](#site-dashboard)**  
-The site dashboard contains information specific to the current site, and like your user dashboard, site information is organized and displayed in dashlets.
--   **[Managing a site](#managing-a-site)**  
-Creating a site is quick and simple. You can then customize it to build a fully functional project site.
--   **[Managing site members](#managing-site-members)**  
-Site users can easily see who else is a member of the site, and site managers can edit user roles and remove a user from the site.
-
-
-
 ## Accessing existing sites {#accessing-existing-sites}
 
 Accessing an existing site is easy.
@@ -167,17 +125,6 @@ You can search for sites using the Site Finder, the search box on the toolbar, o
 If you see a link to a site anywhere in Alfresco Share, just click the link to have a look.
 
 You can see all the sites you're a member of by clicking **Sites** then **My Sites** on the Alfresco toolbar.
-
--   **[Joining a site](#joining-a-site)**  
-When you join sites you gain access to the content that's stored on them.
--   **[Leaving a site](#leaving-a-site)**  
-It's quick and easy to leave a site when you no longer want to be a member.
--   **[Entering a site](#entering-a-site)**  
-You can access a site from several places in Alfresco Share.
--   **[Moving around a site](#moving-around-a-site)**  
-The default areas available in a site are the **Site Dashboard**, **Document Library**, and the **Site Members** areas. If a site has additional site features then you'll also see a **More** menu.
-
-
 
 ## Joining a site {#joining-a-site}
 
@@ -267,13 +214,6 @@ A site manager can resize most dashlets by clicking and dragging on the bottom e
 
 >**Tip:** If you hover over a dashlet header then a ![Add Event icon]({% link content-services/images/help-1.png %}) icon appears. Click it for an explanation of what the dashlet does. This stays open until you close it or navigate away from the dashboard.
 
--   **[Choosing a site homepage](#choosing-a-site-homepage)**  
-Site dashboards are the default homepage on all Alfresco Share sites.
--   **[What can I do with the site dashlets?](#what-can-I-do-with-the-site-dashlets?)**  
-As well as giving you an overview of activity and information on Alfresco Share, the dashlets also give you links to various areas of Share and let you carry out a range of actions.
-
-
-
 ## Choosing a site homepage {#choosing-a-site-homepage}
 
 Site dashboards are the default homepage on all Alfresco Share sites.
@@ -292,12 +232,9 @@ Site managers have the option to remove the site dashboard for individual sites.
 
 4.  Click **OK** to save your changes.
 
-
 The site displays with it's new homepage.
 
 You can always add the site dashboard back later.
-
-
 
 ## What can I do with the site dashlets? {#what-can-I-do-with-the-site-dashlets}
 
@@ -320,6 +257,7 @@ Any combination of the site dashlets can appear on the dashboard:
     -   Click a member’s name to view their user profile.
     -   Click **All Members** to display all site members.
     -   Click **Add Users** to add users this site. This is available only if you are a site manager.
+
 -   **Site Content**
 
     Lists the library content that has been added or edited in the past seven days.
@@ -329,12 +267,14 @@ Any combination of the site dashlets can appear on the dashboard:
     -   Mark an item as a favorite or remove it from the Favorites list (Detailed view only).
     -   Like or unlike an item (Detailed view only).
     -   Click the **Comment** link to add a comment on an item (Detailed view only).
+
 -   **Site Activities**
 
     Tracks the most recent activities performed in this site such as content additions, edits, and deletions, as well as changes in site membership.
 
     -   Use the filter to display the activities by ownership, type, and time period. You can display only your activities, only other users’ activities, or all activities. You can also view only a specific type of activity, such as changes in membership or status updates.
     -   Click the RSS Feed icon to subscribe to the feed to automatically receive the activity updates.
+
     > **Note:** The only users notified of deletions are the user who made the deletion and the Alfresco Administrator.
 
 -   **Site Profile**
@@ -351,12 +291,14 @@ Any combination of the site dashlets can appear on the dashboard:
 
     -   Click the name of the wiki page in the dashlet header to navigate to the wiki.
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to select a different wiki page to display in the dashlet. This is available only if you are a site manager.
+
 -   **Site Links**
 
     Displays the web links compiled by site users.
 
     -   Click a link to open the related website.
     -   Click the ![]({% link content-services/images/ico-link-details.png %}) link's details icon to view the full link and any related comments.
+
 -   **Image Preview**
 
     Displays a thumbnail of all images stored in the site's library.
@@ -365,11 +307,13 @@ Any combination of the site dashlets can appear on the dashboard:
     -   Click the View Details icon to preview or work with the image in the library.
     -   Click the Download icon to download a copy of the image to your computer.
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to specify a folder. The dashlet will display the images in just that folder.
+
 -   **Site File Type Breakdown**
 
     Displays a detailed breakdown of all files stored in the site's library.
 
     -   Hover over a section of the breakdown chart to see more details.
+
 -   **Site Contributor Breakdown**
 
     Displays a breakdown of all site members contributing content to the site's library.
@@ -377,16 +321,19 @@ Any combination of the site dashlets can appear on the dashboard:
     -   Select a time period to view contributions for.
     -   Hover over a section of the breakdown chart to see more details on a specific contributor.
     -   Click on a section of the chart to open that users profile.
+
 -   **Web View**
 
     Displays a website configured by a site manager.
 
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to select a website to display.
+
 -   **Site Notice**
 
     Displays a custom message posted by a site manager
 
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to edit or change the message. This is available only if you are a site manager.
+
     >**Tip:** This dashlet title can be customized, so the dashlet will probably have a label other than **Site Notice**.
 
 -   **RSS Feed**
@@ -394,42 +341,38 @@ Any combination of the site dashlets can appear on the dashboard:
     Displays the Alfresco website feed by default.
 
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to change the RSS feed.
+
 -   **Alfresco Add-ons RSS Feed**
 
     Displays the Newest Add-ons feed from the Alfresco Add-ons website by default.
 
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to change the RSS feed.
+
 -   **Site Data Lists**
 
     Lists this site's data lists.
 
     -   Click a list to open it.
     -   Click Create Data List to create a new list for this site. This action is not available for users with the role Consumer.
+
 -   **My Discussions**
 
     Shows the most recent topics created in the site discussion forum.
 
     -   Use the filter to choose the information you want to see.
+
 -   **Site Search**
 
     Lets you search in the current site.
 
     -   Enter search criteria and click **Search** (or press ENTER).
     -   Select the maximum number of results you want to display.
+
 -   **Saved Search**
 
     Displays the results of a pre-configured search.
 
     -   Click the ![]({% link content-services/images/ico-configure.png %}) configure icon to define the search.
-
--   **[Configuring the RSS feed dashlets](#configuring-the-rss-feed-dashlets)**  
-There are two RSS feed dashlets that you can include on your personal and site dashboards: RSS Feed and Alfresco Add-ons RSS Feed. On both dashlets you can edit the default URL to display any RSS feed.
--   **[Configuring the Wiki dashlet](#configuring-the-wiki-dashlet)**  
-Configure the Wiki site dashlet to display the content of a specific wiki page.
--   **[Setting up the Site Notice dashlet](#setting-up-the-site-notice-dashlet)**  
-Setting up the Site Notice site dashlet to display a message for the site users.
-
-
 
 ## Configuring the RSS feed dashlets {#configuring-the-rss-feed-dashlets}
 
@@ -444,9 +387,6 @@ There are two RSS feed dashlets that you can include on your personal and site d
 4.  Select **Open links in new window** to have the target story display in a new window.
 
 5.  Click **OK**.
-
-
-
 
 ## Configuring the Wiki dashlet {#configuring-the-wiki-dashlet}
 
@@ -463,7 +403,6 @@ To perform this task the wiki has to have at least one page. Only a site manager
 3.  Select the page you want to display in the dashlet.
 
 4.  Click **OK**.
-
 
 ## Setting up the Site Notice dashlet {#setting-up-the-site-notice-dashlet}
 
@@ -487,28 +426,11 @@ Only a site manager can set up this dashlet.
 
 5.  Click **OK**.
 
-
-
 ## Managing a site {#managing-a-site}
 
 Creating a site is quick and simple. You can then customize it to build a fully functional project site.
 
 When you create a new site, you are automatically made the manager. This gives you full access to the site features.
-
--   **[Creating a site](#creating-a-site)**  
-You can create a site from anywhere in Alfresco Share, and are automatically made the manager of the site you create.
--   **[Customizing a site](#customizing-a-site)**  
-Once you've created a site you can customize it to add extra features.
--   **[Customizing the site dashboard](#customizing-the-site-dashboard)**  
-Like your user dashboard, site information is organized and displayed in dashlets. As a site manager you can change the site layout, choose dashlets, and configure the display order.
--   **[Editing site details](#editing-site-details)**  
-You can change the name, description, and visibility of a site after it is created.
--   **[Favoriting a site](#favoriting-a-site)**  
-You can mark a site as a favorite to add it to the Favorites list in the Sites menu. This lets you quickly access the site from anywhere in Alfresco Share. You can mark any number of sites this way.
--   **[Deleting a site](#deleting-a-site)**  
-Delete a site to move it and all of its content to your Trashcan.
-
-
 
 ## Creating a site {#creating-a-site}
 
@@ -525,6 +447,7 @@ You can create a site from anywhere in Alfresco Share, and are automatically mad
     -   **Name**: The title of the site.
     -   **URL Name**: You'll notice that the URL Name is automatically created but you can edit it if you want.
     -   **Description**: Enter a description that will help users know what the site is for.
+
 3.  If you have modules such as Records Management installed, then there will be an additional Type option. Select **Collaboration** to create a standard site.
 
 4.  Select the site visibility:
@@ -532,18 +455,12 @@ You can create a site from anywhere in Alfresco Share, and are automatically mad
     -   **Public**: All users can view a public site in their own organization, whether or not they have joined the site. Users who join the site are listed as site members and can work with the site content, depending on their assigned roles.
     -   **Moderated**: The same as a **Public** site but the site manager must approve a users request to join.
     -   **Private**: Only available to the site manager and any users added to the site.
+
     > **Note:** The visibility setting you select is displayed next to the site name when a user is in the site. See [Alfresco Share sites](#sites) for more information on site visibility settings.
 
 5.  Click **Save**.
 
-
 You'll see the dashboard for the new site which you can now customize. Sites that you create are automatically added to your **Favorites** list.
-
-This video shows you how to create a site.
-
-  
-
-
 
 ## Customizing a site {#customizing-a-site}
 
@@ -565,15 +482,9 @@ Each new site contains a library, and the site manager can [add other features](
 
 5.  Click **OK** to save your changes.
 
-
 The site dashboard displays the new theme, if one was selected. You can select the new pages by clicking **More** on the dashboard.
 
 With the site customized you can now customize the site dashboard to display information that's relevant to the site.
-
-This video shows you how to customize a site.
-
-  
-
 
 ## Customizing the site dashboard {#customizing-the-site-dashboard}
 
@@ -609,12 +520,6 @@ Like your user dashboard, site information is organized and displayed in dashlet
 
     You can resize most dashlets. Drag the bottom edge of the dashlet until it is the height you want.
 
-
-This video shows you how to customize a site dashboard.
-
-  
-
-
 ## Editing site details {#editing-site-details}
 
 You can change the name, description, and visibility of a site after it is created.
@@ -631,7 +536,6 @@ Only a site manager can edit the site details.
 
 4.  Click **OK**.
 
-
 ## Favoriting a site {#favoriting-a-site}
 
 You can mark a site as a favorite to add it to the Favorites list in the Sites menu. This lets you quickly access the site from anywhere in Alfresco Share. You can mark any number of sites this way.
@@ -641,8 +545,6 @@ You can mark a site as a favorite to add it to the Favorites list in the Sites m
     > **Note:** If a site is already a favorite you instead have the option to **Remove Current Site from Favorites**.
 
     The current site now appears in the **Favorites** list in the Sites menu and the My Sites dashlet.
-
-
 
 ## Deleting a site {#deleting-a-site}
 
@@ -659,7 +561,6 @@ Only a site manager can delete a site.
     The selected site and all its content is deleted. The site member roles are stored in case you want to restore the site. When you empty your Trashcan all site details and content including site member roles are permanently deleted.
 
     > **Note:** You can also delete sites in the **Site Finder**.
-
 
 ## Managing site members {#managing-site-members}
 
@@ -680,27 +581,6 @@ Enter a site and click **Site Members** to view or search for members of the sit
     Use this page to view users who have been invited to, or requested to join the site. You can cancel invitations here. Only site managers see the Pending page.
 
     > **Note:** From Alfresco Share version 5.1 or later, invites are only sent if your Alfresco administrator has specifically configured this option. Unless they have then users can access a site as soon as they are added by a Site Manager.
-
-
--   **[Adding users to a site](#adding-users-to-a-site)**  
-Site managers can quickly add users to a site.
--   **[Approving users to join a moderated site](#approving-users-to-join-a-moderated-site)**  
-When a user requests to join a moderated site, the request needs to be approved by a site manager.
--   **[Adding groups to a site](#adding-groups-to-a-site)**  
-Inviting users one at a time to join your site can be time consuming. To save time you can add entire user groups.
--   **[Reviewing the site members](#reviewing-the-site-members)**  
-Use the search feature to find a particular site member. You can also list all site members.
--   **[Reviewing site groups](#reviewing-site-groups)**  
-Use the search feature to find a particular site member. You can also list all site members.
--   **[Changing a site role](#changing-a-site-role)**  
-A site manager can amend a member or group role to change what they can do in a site.
--   **[Becoming a site manager](#becoming-a-site-manager)**  
-If your account is an administrator account, then you can make yourself a site manager of any site that you're a member of.
--   **[Removing a site member or site group](#removing-a-site-member-or-site-group)**  
-When you remove members or groups from a site they can no longer access it, but if the site is public they can rejoin it.
--   **[Managing pending invitations](#managing-pending-invitations)**  
-A site manager can view the outstanding invitations. You can revoke an invitation until the recipient accepts or declines it.
-
 
 ## Adding users to a site {#adding-users-to-a-site}
 
@@ -736,7 +616,6 @@ You can add any user, either internal to your organization or an external user.
 
     > **Note:** This feature is disabled if your installation doesn't support inviting new users. Talk to your system administrator about enabling this feature with the `notification.email.siteinvite` property. See [Outbound SMTP configuration properties]({% link content-services/5.2/config/email.md %}#outbound-smtp-configuration-properties) for more information.
 
-
 ## Approving users to join a moderated site {#approving-users-to-join-a-moderated-site}
 
 When a user requests to join a moderated site, the request needs to be approved by a site manager.
@@ -754,7 +633,6 @@ All managers of a site will be receive an email and be given a new approval task
 2.  Click **Approve**, or click **View** to view the approval task where you can approve, reject, and comment on the request to join.
 
     The task is cleared from your task list and the user is added to the site.
-
 
 ## Adding groups to a site {#adding-groups-to-a-site}
 
@@ -786,7 +664,6 @@ Inviting users one at a time to join your site can be time consuming. To save ti
 
     > **Note:** You can click **back to Site Groups** to return to the Search for Site Groups page without adding any groups.
 
-
 ## Reviewing the site members {#reviewing-the-site-members}
 
 Use the search feature to find a particular site member. You can also list all site members.
@@ -800,7 +677,6 @@ Use the search feature to find a particular site member. You can also list all s
     >**Tip:** Leave the search box empty to display all site members.
 
 3.  Click **Search**.
-
 
 ## Reviewing site groups {#reviewing-site-groups}
 
@@ -816,7 +692,6 @@ Use the search feature to find a particular site member. You can also list all s
 
 4.  Click **Search**.
 
-
 ## Changing a site role {#changing-a-site-role}
 
 A site manager can amend a member or group role to change what they can do in a site.
@@ -831,7 +706,6 @@ A site manager can amend a member or group role to change what they can do in a 
 
 4.  Click the current role and select a new role from the list.
 
-
 ## Becoming a site manager {#becoming-a-site-manager}
 
 If your account is an administrator account, then you can make yourself a site manager of any site that you're a member of.
@@ -840,10 +714,7 @@ If your account is an administrator account, then you can make yourself a site m
 
 1.  In a site click ![]({% link content-services/images/settings-icon.png %}) then **Become Site Manager**.
 
-
 You are now a manager of the site. You'll see that you have additional options available when you click ![]({% link content-services/images/settings-icon.png %}).
-
-
 
 ## Removing a site member or site group {#removing-a-site-member-or-site-group}
 
@@ -882,5 +753,3 @@ If you've recently upgraded to Alfresco Share 5.1 or later then you can still ma
 
     -   Click **Cancel** to revoke the user's invitation to this site.
 5.  You can click **Cancel** to revoke the user's invitation to this site.
-
-

--- a/content-services/5.2/using/smart-folders.md
+++ b/content-services/5.2/using/smart-folders.md
@@ -26,11 +26,6 @@ Take a look at the videos to learn more: [Smart Folders videos]({% link content-
 
 System administrators and business analysts can find more information here: [Configuring Smart Folders]({% link content-services/5.2/config/smart-folders/index.md %}#configuring-smart-folders) and in the tutorial: [Smart Folders tutorial]({% link content-services/5.2/tutorial/smart.md %}#smart-folders-tutorial).
 
--   **[Applying a Smart Folder Template](#applying-a-smart-folder-template)**  
-You can apply a Smart Folder structure to a physical folder by using aspects.
--   **[Smart Folders FAQs](#smart-folders-faqs)**  
-If you have any problems with Smart Folders, try these suggestions to resolve your issue.
-
 ## Applying a Smart Folder Template
 
 You can apply a Smart Folder structure to a physical folder by using aspects.
@@ -62,8 +57,8 @@ You can apply a Smart Folder structure to a physical folder by using aspects.
     -   My content modified by other users
     -   User home
     -   Tagged 'Confidential'
-    Folders contain files according to what files you have in your site. For example, if you have created audio files in the site, you will see these if you drill down to All site content/Multimedia Files/Audio content and any specific to this physical folder in This folder's content/Multimedia Files/Audio content. Any of your files that are marked as Confidential in the metadata appear in the Tagged 'Confidential' folder.
 
+    Folders contain files according to what files you have in your site. For example, if you have created audio files in the site, you will see these if you drill down to All site content/Multimedia Files/Audio content and any specific to this physical folder in This folder's content/Multimedia Files/Audio content. Any of your files that are marked as Confidential in the metadata appear in the Tagged 'Confidential' folder.
 
 ## Smart Folders FAQs
 

--- a/content-services/5.2/using/tasks.md
+++ b/content-services/5.2/using/tasks.md
@@ -16,22 +16,6 @@ You can start workflows from a number of places:
 -   Click **Tasks** on the toolbar, select any option, then click **Start Workflow**
 -   Click **Start Workflow** on the My Tasks dashlet
 
-
-
--   **[Starting a workflow](#starting-a-workflow)**  
-You can attach a workflow directly to one or more files. Starting a workflow generates a workflow task such as a review.
--   **[Viewing workflows you started](#viewing-workflows-you-started)**  
-You can view the full details of all workflows that you have started.
--   **[Cancelling an active workflow](#cancelling-an-active-workflow)**  
-You can cancel an active workflow if you find you don't need it anymore. This deletes all tasks related to the workflow.
--   **[Deleting a completed workflow](#deleting-a-completed-workflow)**  
-Once you're finished with a workflow, you can delete it to clear it from the workflow list. This also deletes all tasks associated with the workflow.
--   **[Viewing tasks and workflows](#viewing-tasks-and-workflows)**  
-You can view the details for an individual task or for the workflow that initiated a task.
--   **[Managing tasks](#managing-tasks)**  
-Tasks assigned to you appear in two places: the My Tasks personal dashlet and the My Tasks page. Each task stays assigned to you until you complete or reassign it.
-
-
 ## Starting a workflow {#starting-a-workflow}
 
 You can attach a workflow directly to one or more files. Starting a workflow generates a workflow task such as a review.
@@ -113,6 +97,7 @@ You can attach a workflow directly to one or more files. Starting a workflow gen
         -   **View More Actions** to the right of an file in this list to display it on the file preview screen. This will cancel the task and you'll need to start again.
         -   **Remove** to delete an file from the task.
         -   **Remove All** to delete all files from the task.
+
 6.  You can select the **Send Email Notifications** check box to automatically send an email to users each time a task is assigned to them.
 
     Tasks will still appear in the users My Tasks dashlet. The email is sent to the email address listed in the user's profile. If an address is not provided, no email will be sent.
@@ -122,7 +107,6 @@ You can attach a workflow directly to one or more files. Starting a workflow gen
 7.  Click **Start Workflow**.
 
     The workflow task is created. In the file list an icon to the left of the files selected indicates that they are part of an active workflow.
-
 
 ## Viewing workflows you started {#viewing-workflows-you-started}
 
@@ -143,8 +127,8 @@ You can view the full details of all workflows that you have started.
     -   Look at completed tasks in the History section. Click a task to view its details.
     -   Click an item in the Items list to see it in the file preview screen. Click your browser’s Back button to return to the Workflow Details page.
     -   If you started the workflow you can click to **Cancel Workflow** to cancel an active workflow **Delete Workflow** to delete a completed workflow.
-3.  Click **Workflows I’ve Started** to return to the workflow list.
 
+3.  Click **Workflows I’ve Started** to return to the workflow list.
 
 ## Cancelling an active workflow {#cancelling-an-active-workflow}
 
@@ -160,7 +144,6 @@ You can cancel an active workflow if you find you don't need it anymore. This de
 
     The selected workflow is cancelled and removed from the workflow list. All tasks related to the workflow are deleted, which removes them from the Active view on the My Tasks page. They are also removed from the My Tasks dashlet.
 
-
 ## Deleting a completed workflow {#deleting-a-completed-workflow}
 
 Once you're finished with a workflow, you can delete it to clear it from the workflow list. This also deletes all tasks associated with the workflow.
@@ -175,7 +158,6 @@ Once you're finished with a workflow, you can delete it to clear it from the wor
 
     The workflow is deleted and removed from the workflow list. The tasks related to the workflow are deleted, which removes them from the Completed view on the My Tasks page. They are also removed from the My Tasks dashlet.
 
-
 ## Viewing tasks and workflows {#viewing-tasks-and-workflows}
 
 You can view the details for an individual task or for the workflow that initiated a task.
@@ -188,6 +170,7 @@ You can view the details for an individual task or for the workflow that initiat
 
     -   **View Task**: Displays the task details
     -   **View Workflow**: Displays the workflow details
+
     > **Note:** An icon (![]({% link content-services/images/im-pooled.png %})) indicates a pooled task. Pooled tasks that can be claimed are marked as **Unassigned**.
 
 3.  Click the **Task Details** and **Workflow Details** options to move between the two page views.
@@ -196,6 +179,7 @@ You can view the details for an individual task or for the workflow that initiat
 
     -   In the Items list, click an item to preview it in the library. Click your browser’s Back button to return to the Task Details page.
     -   Click **Edit** to edit the task.
+
     The Workflow Details page displays the information for the workflow that generated this task.
 
     -   Click **View Process Diagram** to display a graphical representation of the workflow. A red border highlights the current stage of the workflow. Click anywhere on the graphic to close it.
@@ -204,7 +188,6 @@ You can view the details for an individual task or for the workflow that initiat
     -   Look at completed tasks in the History section. Click a task to view it's details.
     -   Click an item in the Items list to see it in the file preview screen. Click your browser’s Back button to return to the Workflow Details page.
     -   If you started the workflow you can click to **Cancel Workflow** to cancel an active workflow.
-
 
 ## Managing tasks {#managing-tasks}
 


### PR DESCRIPTION
These updates are part of ongoing improvements to the ACS 5.2 docs:

- Remove in-page tables of contents (TOCs)
- Remove statements about video tutorials in multiple files
- Add a single link to the **Tutorials** section in `/using/share.md`
- Correct text formatting in tables and other areas