### PR TITLE
[DOCS-6381] Remove highlightTexts parameter in sample config

### DIFF
--- a/microsoft-outlook/2.7/config/index.md
+++ b/microsoft-outlook/2.7/config/index.md
@@ -944,7 +944,7 @@ Use this file to set up attributes and metadata settings.
         <connection url="http://127.0.0.1:8080/" shareUrl="share" alfrescoUrl="alfresco" login="admin" password="7DkTRpO8sfo=" checkCertificate="true" checkVersion="true" authentication="basic" webApp="2" shareAlterUrl="" settingsCheckInterval="480" />
         <logging minLevel="info" />
         <storage archiveOption="0" storeFiles="true" storeLink="true" storeMsg="false" compress="true" />
-        <feature autoPaging="false" highlightTexts="false" tokenAlterMode="false" messageIcon="false" />
+        <feature autoPaging="false" tokenAlterMode="false" messageIcon="false" />
         <explorer-search-properties />
         <search-properties />
       </outlook>

--- a/microsoft-outlook/latest/config/index.md
+++ b/microsoft-outlook/latest/config/index.md
@@ -1029,7 +1029,7 @@ Use this file to set up attributes and metadata settings.
         <connection url="http://127.0.0.1:8080/" shareUrl="share" alfrescoUrl="alfresco" login="admin" password="7DkTRpO8sfo=" checkCertificate="true" checkVersion="true" authentication="basic" webApp="2" shareAlterUrl="" settingsCheckInterval="480" />
         <logging minLevel="info" />
         <storage archiveOption="0" storeFiles="true" storeLink="true" storeMsg="false" compress="true" />
-        <feature autoPaging="false" highlightTexts="false" tokenAlterMode="false" messageIcon="false" />
+        <feature autoPaging="false" tokenAlterMode="false" messageIcon="false" />
         <explorer-search-properties />
         <search-properties />
       </outlook>


### PR DESCRIPTION
Removes the `highlightTexts` parameter in the sample configuration since it's no longer used. 
Applies to Alfresco Outlook Integration version 2.7 and above.