### PR TITLE
[DOCS-6361] Add Alfresco Outlook Integration 2.8.1 docs 

### DIFF
--- a/microsoft-outlook/2.7/config/index.md
+++ b/microsoft-outlook/2.7/config/index.md
@@ -944,7 +944,7 @@ Use this file to set up attributes and metadata settings.
         <connection url="http://127.0.0.1:8080/" shareUrl="share" alfrescoUrl="alfresco" login="admin" password="7DkTRpO8sfo=" checkCertificate="true" checkVersion="true" authentication="basic" webApp="2" shareAlterUrl="" settingsCheckInterval="480" />
         <logging minLevel="info" />
         <storage archiveOption="0" storeFiles="true" storeLink="true" storeMsg="false" compress="true" />
-        <feature autoPaging="false" highlightTexts="false" tokenAlterMode="false" messageIcon="false" />
+        <feature autoPaging="false" tokenAlterMode="false" messageIcon="false" />
         <explorer-search-properties />
         <search-properties />
       </outlook>

--- a/microsoft-outlook/latest/config/index.md
+++ b/microsoft-outlook/latest/config/index.md
@@ -677,7 +677,7 @@ See examples of how to use these search settings below.
     <match type="aspect" pattern="cm:versionable">
         <target useTags="true" useText="true">
             <property name="cm:title"/>
-                <hr/>
+            <hr/>
             <property name="cm:description">
                 <ui multiline="true"/>
             </property>
@@ -685,7 +685,37 @@ See examples of how to use these search settings below.
     </match>
     ```
 
-7. Click **Apply** to save your changes and restart Microsoft Outlook.
+7. To use wildcards, add the asterisk character in the folder path, for example:
+
+    ```xml
+    <match pattern="/app:company_home/st:sites/*/cm:myexample-1-site-standard-search" >
+        <target useTags="true" useText="true">
+            <property name="cm:title"/>
+            <hr/>
+            <property name="cm:description">
+                <ui multiline="true"/>
+            </property>
+        </target>
+    </match>
+    ```
+
+    Starting from Outlook Integration 2.8.1, this rule allows you to assign the search configuration to every `myexample-1-site-standard-search` located under any `st:sites`, and with any number of folders between `st:sites` and `myexample-1-site-standard-search`.
+
+    Here is another example to show how the asterisk can be used in multiple locations:
+
+    ```xml
+    <match pattern="/app:company_home/st:sites/*/cm:testfolder/*/cm:myexample-1-site-standard-search">
+    ```
+
+    You can also use the asterisk wildcard in this way:
+
+    ```xml
+    <match pattern="/app:company_home/st:sites/cm:test*/cm:myexample-1-site-standard-search">
+    ```
+
+    > **Note:** An exact match of the pattern without a wildcard takes priority over the wildcard pattern.
+
+8. Click **Apply** to save your changes and restart Microsoft Outlook.
 
     The template changes are applied.
 

--- a/microsoft-outlook/latest/config/index.md
+++ b/microsoft-outlook/latest/config/index.md
@@ -1029,7 +1029,7 @@ Use this file to set up attributes and metadata settings.
         <connection url="http://127.0.0.1:8080/" shareUrl="share" alfrescoUrl="alfresco" login="admin" password="7DkTRpO8sfo=" checkCertificate="true" checkVersion="true" authentication="basic" webApp="2" shareAlterUrl="" settingsCheckInterval="480" />
         <logging minLevel="info" />
         <storage archiveOption="0" storeFiles="true" storeLink="true" storeMsg="false" compress="true" />
-        <feature autoPaging="false" highlightTexts="false" tokenAlterMode="false" messageIcon="false" />
+        <feature autoPaging="false" tokenAlterMode="false" messageIcon="false" />
         <explorer-search-properties />
         <search-properties />
       </outlook>

--- a/microsoft-outlook/latest/install/index.md
+++ b/microsoft-outlook/latest/install/index.md
@@ -34,7 +34,7 @@ You can download the Outlook Integration software from the [Alfresco Support Por
 
 ## Prerequisites
 
-There are a number of software requirements for installing Outlook Integration.
+There are a number of software requirements for installing Outlook Integration. See [Supported Platforms]({% link microsoft-outlook/latest/support/index.md %}) for more information.
 
 You need one of each of the following components:
 
@@ -58,7 +58,22 @@ You can use one of the following Outlook releases:
 
 ### Alfresco requirements
 
-* Alfresco Content Services 6.2.2 or later. See [Supported Platforms]({% link microsoft-outlook/latest/support/index.md %}) for more information.
+* Alfresco Content Services 6.2.2 or later.
+
+#### Alfresco Search Services 2.0 and above
+
+If you're using Alfresco Search Services or Alfresco Search and Insight Engine 2.0 and above in combination with Outlook Integration 2.8.1 and above, you must add the `messageId` property to the `shared.properties` file for SOLR. See the [Alfresco indexing recommendations]({% link search-services/latest/config/indexing.md %}#cross-locale) to locate this file.
+
+Add the following lines to the configuration:
+
+```bash
+alfresco.cross.locale.property.#={http://www.alfresco.org/model/imap/1.0}messageId
+alfresco.cross.locale.property.#={http://www.westernacher.com/alfresco/models/wpsmail-v2}messageId
+```
+
+where `#` is an ascending index number that hasn't been used.
+
+> **Note:** This change requires a SOLR restart, but no reindex.
 
 ### Java requirements
 

--- a/microsoft-outlook/latest/support/index.md
+++ b/microsoft-outlook/latest/support/index.md
@@ -6,8 +6,9 @@ The following are the supported platforms for Outlook Integration 2.8:
 
 | Version | Notes |
 | ------- | ----- |
-| Alfresco Content Services 6.2.2 | |
+| Alfresco Content Services 7.1.x | |
 | Alfresco Content Services 7.0.x | |
+| Alfresco Content Services 6.2.2 | |
 | | |
 | **Application servers** | |
 | Apache Tomcat | Check the supported Tomcat version based on your Content Services version |


### PR DESCRIPTION
This branch will be merged to `master` once the release has been approved for GA release

Specific changes for Outlook Integration 2.8.1:

- #368 
- #369 - applies to both Search Services or Search and Insight Engine 
- #375 
- #390 

Maintenance only:

- #366 
