### PR TITLE
[DOCS-6418] ATS 1.4.1 version bump

### DIFF
--- a/content-services/latest/install/ansible.md
+++ b/content-services/latest/install/ansible.md
@@ -26,10 +26,6 @@ There are two types of installations - local and remote:
 
 If you're using the Content Services (Enterprise), then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
->**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
-then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
-into Content Services. If you follow the link you will find the necessary content model files.
-
 ## Target O/S
 
 The playbooks have been tested using Ansible 2.9.16 (or later) on target hosts with the following operating systems:

--- a/content-services/latest/install/containers/docker-compose.md
+++ b/content-services/latest/install/containers/docker-compose.md
@@ -268,10 +268,6 @@ The Docker Compose file provides some default configuration. This section lists 
 | JAVA_TOOL_OPTIONS | Adding this environment variable, allows to set sensitive values (like passwords) that are not passed as arguments to the Java Process. |
 | JAVA_OPTS | A set of properties that are picked up by the JVM inside the container. Any Content Services property can be passed to the container using the format `-Dproperty=value` (e.g. `-Ddb.driver=org.postgresql.Driver`). |
 
->**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
-then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
-into Content Services.
-
 ### Alfresco Share (share)
 
 | Property | Description |

--- a/content-services/latest/install/containers/helm.md
+++ b/content-services/latest/install/containers/helm.md
@@ -71,10 +71,6 @@ The Enterprise configuration will deploy the following system:
 * You've read the [main Helm README](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm/README.md){:target="_blank"} page
 * You are proficient in AWS and Kubernetes
 
->**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
-then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
-into Content Services.
-
 ### Set up an EKS cluster
 
 Follow the [AWS EKS Getting Started Guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html){:target="_blank"} to create a cluster and prepare your local machine to connect to the cluster. Use the **Managed nodes - Linux** option and specify a `--node-type` of at least `m5.xlarge`.

--- a/content-services/latest/install/containers/index.md
+++ b/content-services/latest/install/containers/index.md
@@ -138,56 +138,6 @@ Note that the [VERSIONS.md](https://github.com/Alfresco/acs-packaging/blob/maste
 
 You can review the requirements for your chosen deployment method below.
 
-### IPTC Content Model bootstrapping (OPTIONAL) {#iptc-model-bootstrap}
-
-If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction, then you need to
-bootstrap the IPTC Content Model manually into Content Services.
-
-The files for this content model can be downloaded from the
-[Alfresco Transform Core GitHub project](https://github.com/Alfresco/alfresco-transform-core/tree/master/models){:target="_blank"}.
-You need both the Content Model XML and the associated i18n property files for different languages.
-
-#### Docker Compose IPTC Content Model bootstrapping
-
-Place the IPTC Content Model files in a subfolder from where the `docker-compose.yml` file is located.
-Such as in the following example:
-
-```bash
-- docker-compose.yml
-- models
-  - iptc
-    - iptc-model.properties
-    ...
-  - iptc-model-context.xml
-```
-
-Then update the `docker-compose.yml` file with the model:
-
-```xml
-...
-services:
-    alfresco:
-        image: ...
-        mem_limit: 1700m
-        environment:
-            JAVA_TOOL_OPTIONS: "
-            ...
-                "
-            JAVA_OPTS: "
-            ...                
-            "
-        volumes:
-            - ./models/iptc-model-context.xml:/usr/local/tomcat/shared/classes/alfresco/extension/iptc-model-context.xml
-            - ./models/iptc:/usr/local/tomcat/shared/classes/alfresco/extension/models/iptc     
-```
-
-You are adding the 3 last lines setting up volume mappings.
-
-#### Helm IPTC Content Model bootstrapping
-
-Before installing with Helm charts you need to [produce a custom Repository Docker image]({% link content-services/latest/install/containers/customize.md %})
-with the IPTC Content Model. Then update the Helm charts to use this image.
-
 ### Helm charts
 
 To deploy Content Services using Helm charts, you need to install the following software:

--- a/content-services/latest/install/zip/index.md
+++ b/content-services/latest/install/zip/index.md
@@ -19,10 +19,6 @@ To install Content Services using the distribution zip (which also contains the 
 
 For a list of other supported components and versions, refer to the `VERSIONS.md` file in the distribution zip.
 
->**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
-then you need to [bootstrap the IPTC Content Model]({% link content-services/latest/install/containers/index.md %}#iptc-model-bootstrap) manually
-into Content Services. If you follow the link you will find the necessary content model files.
-
 ## Install overview
 
 Use this section to get an overview of the main stages for installing Content Services using the distribution zip. It's designed for users who just need a simple checklist to follow.

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -479,7 +479,7 @@ before continuing.
     * `alfresco-transform-core-aio-boot-x.y.z.jar`
     * `alfresco-transform-router-1.4.x.jar`
     * `README.md`
-    * IPTC Content Model (need to be bootstrapped into Alfresco Content Services for IPTC Metadata extraction to work)
+    * IPTC Content Model (need to be bootstrapped into Alfresco Content Services for IPTC Metadata extraction to work, unless you are using Alfresco Content Services version 7.1.0+. For more info see [supported platforms page]({% link transform-service/latest/support/index.md %})))
 
 3. Start Active MQ.
 

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -479,7 +479,7 @@ before continuing.
     * `alfresco-transform-core-aio-boot-x.y.z.jar`
     * `alfresco-transform-router-1.4.x.jar`
     * `README.md`
-    * IPTC Content Model (need to be bootstrapped into Alfresco Content Services for IPTC Metadata extraction to work, unless you are using Alfresco Content Services version 7.1.0+. For more info see [supported platforms page]({% link transform-service/latest/support/index.md %})))
+    * IPTC Content Model (needs to be bootstrapped into Alfresco Content Services for IPTC Metadata extraction to work, unless you are using Alfresco Content Services version 7.1.0+. See [Supported platforms]({% link transform-service/latest/support/index.md %}) for more information.
 
 3. Start Active MQ.
 

--- a/transform-service/latest/support/index.md
+++ b/transform-service/latest/support/index.md
@@ -9,8 +9,5 @@ The following are the supported platforms and software requirements for Alfresco
 |Version|Notes|
 |-------|-----|
 |Content Services 7.1.0||
-|Content Services 7.0.0|[IPTC content model need to be manually bootstrapped]({% link content-services/7.0/install/containers/index.md %}#iptc-model-bootstrap)|
-|Content Services 6.2.2|[IPTC content model need to be manually bootstrapped]({% link content-services/6.2/install/containers/index.md %}#iptc-model-bootstrap)|
-
-
-
+|Content Services 7.0.0|[IPTC content model needs to be manually bootstrapped]({% link content-services/7.0/install/containers/index.md %}#iptc-model-bootstrap)|
+|Content Services 6.2.2|[IPTC content model needs to be manually bootstrapped]({% link content-services/6.2/install/containers/index.md %}#iptc-model-bootstrap)|

--- a/transform-service/latest/support/index.md
+++ b/transform-service/latest/support/index.md
@@ -2,11 +2,15 @@
 title: Supported Platforms
 ---
 
-The following are the supported platforms and software requirements for Alfresco Transform Service 1.4:
+The following are the supported platforms and software requirements for Alfresco Transform Service 1.4.1:
 
 ## Alfresco Content Services
 
 |Version|Notes|
 |-------|-----|
-|Content Services 6.2.2|IPTC content model need to be manually bootstrapped|
+|Content Services 7.1.0||
 |Content Services 7.0.0|IPTC content model need to be manually bootstrapped|
+|Content Services 6.2.2|IPTC content model need to be manually bootstrapped|
+
+
+

--- a/transform-service/latest/support/index.md
+++ b/transform-service/latest/support/index.md
@@ -9,8 +9,8 @@ The following are the supported platforms and software requirements for Alfresco
 |Version|Notes|
 |-------|-----|
 |Content Services 7.1.0||
-|Content Services 7.0.0|IPTC content model need to be manually bootstrapped|
-|Content Services 6.2.2|IPTC content model need to be manually bootstrapped|
+|Content Services 7.0.0|[IPTC content model need to be manually bootstrapped]({% link content-services/7.0/install/containers/index.md %}#iptc-model-bootstrap)|
+|Content Services 6.2.2|[IPTC content model need to be manually bootstrapped]({% link content-services/6.2/install/containers/index.md %}#iptc-model-bootstrap)|
 
 
 


### PR DESCRIPTION
Version bump with lib updates.
Updated Supported Platforms page with links to IPTC model installs for ACS 7.0 and 6.2.
ACS 7.1 installation instructions updated: Removed IPTC model bootstrapping instructions, this model is included with ACS 7.1
