### PR TITLE
[DOCS-6476] Correct keys.md

### DIFF
--- a/search-services/latest/config/keys.md
+++ b/search-services/latest/config/keys.md
@@ -145,12 +145,14 @@ Before continuing, make sure that you've already completed the steps in [Generat
         # ssl encryption
         encryption.ssl.keystore.location=${dir.keystore}/ssl.keystore
         encryption.ssl.keystore.type=JCEKS
-        encryption.ssl.keystore.keyMetaData.location=encryption.ssl.truststore.location=${dir.keystore}/ssl.truststore
+        encryption.ssl.keystore.keyMetaData.location=
+        encryption.ssl.truststore.location=${dir.keystore}/ssl.truststore
         encryption.ssl.truststore.type=JCEKS
         encryption.ssl.truststore.keyMetaData.location=
         # secret key keystore configuration
         encryption.keystore.location=${dir.keystore}/keystore
-        encryption.keystore.keyMetaData.location=encryption.keystore.type=JCEKS
+        encryption.keystore.keyMetaData.location=
+        encryption.keystore.type=JCEKS
         solr.host=localhost
         solr.port=8983
         solr.port.ssl=8983


### PR DESCRIPTION
Fix a typo for SSL configuration in the Search Services documentation. This applies similar changes to  PR #433.