### PR TITLE
Fix hazelcast jar reference

### DIFF
--- a/content-services/latest/admin/cluster.md
+++ b/content-services/latest/admin/cluster.md
@@ -187,11 +187,11 @@ To enable the Hazelcast cluster messaging, edit this section on each Share Tomca
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                 http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
                 http://www.hazelcast.com/schema/spring
-                http://www.hazelcast.com/schema/spring/hazelcast-spring-2.4.xsd">
+                http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
    <!--
         Hazelcast distributed messaging configuration - Share web-tier cluster config
         - see http://www.hazelcast.com/docs.jsp
-        - and specifically http://docs.hazelcast.org/docs/2.4/manual/html-single/#SpringIntegration
+        - and specifically http://docs.hazelcast.org/docs/3.12/manual/html-single/#SpringIntegration
    -->
    <!-- Configure cluster to use either Multicast or direct TCP-IP messaging - multicast is default -->
    <!-- Optionally specify network interfaces - server machines likely to have more than one interface -->


### PR DESCRIPTION
Fix hazelcast jar references from 2.4 (used on Alfresco 6.1) to the new version 3.12 (used on Alfresco 7.1). In case a server do not have internet, the fact that the wrong version number is specified will prevent Alfresco from starting. With the correct version (found inside the hazelcast-spring jar file), Alfresco can start without internet.