### PR TITLE
[DOCS-6620] Remove references to source code access in DTE docs

### DIFF
--- a/content-services/5.2/install/index.md
+++ b/content-services/5.2/install/index.md
@@ -6072,8 +6072,6 @@ Use this information to install the Document Transformation Engine SDK.
         -   OCR
         -   Resizing an image, which is necessary to produce thumbnails
         -   PDF/A as a target format
-    > **Note:** The Document Transformation Engine SDK source code is available on request. Contact [Customer Support](https://support.alfresco.com){:target="_blank"} for the SDK source code.
-
 
 
 ##### Installing GhostScript and pdf2swf {#installing-ghostscript-and-pdf2swf}

--- a/transformation-engine/2.2/install/sdk.md
+++ b/transformation-engine/2.2/install/sdk.md
@@ -6,8 +6,6 @@ Use this information to install the Document Transformation Engine SDK.
 
 Download the Document Transformation Engine SDK from the [Alfresco Support Portal](http://support.alfresco.com){:target="_blank"}.This is an executable jar file with all dependencies that works as a command line client. The executable class is `com.westernacher.transformationserver.demo.DemoClient`.
 
-> **Note:** The Document Transformation Engine SDK source code is available on request. Contact [Customer Support](https://support.alfresco.com){:target="_blank"} for the SDK source code.
-
 To invoke the Document Transformation Engine SDK jar file, use the following syntax:
 
 ```java


### PR DESCRIPTION
This is a continuation of PR #544 with updates to older versions of the DTE docs