### PR TITLE
[DOCS-6612] Moved solr shard prop config from general solr config to alfresco acs config

### DIFF
--- a/insight-engine/1.4/config/properties.md
+++ b/insight-engine/1.4/config/properties.md
@@ -54,7 +54,6 @@ The `solrcore.properties` configuration file is the property configuration file 
 |enable.alfresco.tracking|This property instructs Solr if it should index Alfresco Content Services content in the associated repository store or not, for example `true`.|
 |max.field.length|This property specifies the maximum number of tokens to include for each field. By default, all tokens are added, for example `2147483647`.|
 |maxScheduledTransactions|This optional parameter controls the maximum transactions to schedule for reindexing in the admin fix tool. If the admin fix action specifies a value for `maxScheduledTransactions` then the request parameter that is used in the solrcore.properties configuration file is ignored.|
-|search.solrShardRegistry.dbidRangeRefreshTimeoutInSeconds|This property controls the frequency of synchronisation of the shard information between multiple ACS instances for `DBID_Range` sharding, for example `30`. **Note:** This property is only used when you are using `DBID_Range` sharding with multiple ACS instances.|
 |solr.authorityCache.autowarmCount|This property configures the Solr result cache, for example `0`.|
 |solr.authorityCache.initialSize|This property configures the caches used in authority filter generation, for example `64`.|
 |solr.authorityCache.size|This property configures the caches used in authority filter generation, for example `64`.|

--- a/insight-engine/1.4/config/sharding/create.md
+++ b/insight-engine/1.4/config/sharding/create.md
@@ -368,6 +368,7 @@ search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000
 |search.solrShardRegistry.purgeOnInit|If true, this property removes persisted shard state from the database when the subsystem starts for example, true|
 |search.solrShardRegistry.shardInstanceTimeoutInSeconds|Specifies that if a shard has not made a tracking request within this time, it will not be used for query. **Note:** When tracking large change sets or rebuilding your indexes, increase the shard timeout. For example, change the value of this property to 3200 or 7200 seconds|
 |search.solrShardRegistry.maxAllowedReplicaTxCountDifference|Specifies that if any shard is more than this number of transactions behind the leading instance, it will not be used, for example 1000 transactions|
+|search.solrShardRegistry.dbidRangeRefreshTimeoutInSeconds|This property controls the frequency of synchronisation of the shard information between multiple ACS instances for [DB_ID_RANGE]({% link insight-engine/1.4/config/sharding/index.md %}#sharding-methods-db-id-range)` sharding, for example `30`. <br/><br/>**Note:** This property is only used when you are using `DB_ID_RANGE` sharding with multiple ACS instances.|
 
 If there is more than one index for a store, the most up to date index (the one that has indexed most transactions) will be used. For each shard, an instance is chosen at random from all the shards that are actively tracking and within 1000 transactions of the lead instance.
 

--- a/insight-engine/1.4/config/sharding/index.md
+++ b/insight-engine/1.4/config/sharding/index.md
@@ -97,7 +97,7 @@ shard.instance=<shard.instance>
 shard.count=<shard.count>
 ```
 
-### DBID range (DB_ID_RANGE)
+### DBID range (DB_ID_RANGE)  {#sharding-methods-db-id-range}
 
 This method is available in Search and Insight Engine 1.1 and later versions. This routes documents within specific DBID ranges to specific shards. It adds new shards to the cluster without requiring a reindex.
 

--- a/insight-engine/latest/config/properties.md
+++ b/insight-engine/latest/config/properties.md
@@ -58,7 +58,6 @@ The `solrcore.properties` configuration file is the property configuration file 
 |enable.alfresco.tracking|This property instructs Solr if it should index Alfresco Content Services content in the associated repository store or not, for example `true`.|
 |max.field.length|This property specifies the maximum number of tokens to include for each field. By default, all tokens are added, for example `2147483647`.|
 |maxScheduledTransactions|This optional parameter controls the maximum transactions to schedule for reindexing in the admin fix tool. If the admin fix action specifies a value for `maxScheduledTransactions` then the request parameter that is used in the solrcore.properties configuration file is ignored.|
-|search.solrShardRegistry.dbidRangeRefreshTimeoutInSeconds|This property controls the frequency of synchronisation of the shard information between multiple ACS instances for `DBID_Range` sharding, for example `30`. **Note:** This property is only used when you are using `DBID_Range` sharding with multiple ACS instances.|
 |solr.authorityCache.autowarmCount|This property configures the Solr result cache, for example `0`.|
 |solr.authorityCache.initialSize|This property configures the caches used in authority filter generation, for example `64`.|
 |solr.authorityCache.size|This property configures the caches used in authority filter generation, for example `64`.|

--- a/insight-engine/latest/config/sharding/create.md
+++ b/insight-engine/latest/config/sharding/create.md
@@ -368,6 +368,7 @@ search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000
 |search.solrShardRegistry.purgeOnInit|If true, this property removes persisted shard state from the database when the subsystem starts for example, true|
 |search.solrShardRegistry.shardInstanceTimeoutInSeconds|Specifies that if a shard has not made a tracking request within this time, it will not be used for query. **Note:** When tracking large change sets or rebuilding your indexes, increase the shard timeout. For example, change the value of this property to 3200 or 7200 seconds|
 |search.solrShardRegistry.maxAllowedReplicaTxCountDifference|Specifies that if any shard is more than this number of transactions behind the leading instance, it will not be used, for example 1000 transactions|
+|search.solrShardRegistry.dbidRangeRefreshTimeoutInSeconds|This property controls the frequency of synchronisation of the shard information between multiple ACS instances for [DB_ID_RANGE]({% link insight-engine/latest/config/sharding/index.md %}#sharding-methods-db-id-range) sharding, for example `30`. <br/><br/>**Note:** This property is only used when you are using `DB_ID_RANGE` sharding with multiple ACS instances.|
 
 If there is more than one index for a store, the most up to date index (the one that has indexed most transactions) will be used. For each shard, an instance is chosen at random from all the shards that are actively tracking and within 1000 transactions of the lead instance.
 

--- a/insight-engine/latest/config/sharding/index.md
+++ b/insight-engine/latest/config/sharding/index.md
@@ -97,7 +97,7 @@ shard.instance=<shard.instance>
 shard.count=<shard.count>
 ```
 
-### DBID range (DB_ID_RANGE)
+### DBID range (DB_ID_RANGE) {#sharding-methods-db-id-range}
 
 This method is available in Search and Insight Engine 1.1 and later versions. This routes documents within specific DBID ranges to specific shards. It adds new shards to the cluster without requiring a reindex.
 


### PR DESCRIPTION
This is fix for the following PR: Move solr related prop to acs alfresco-global.properties #168