### PR TITLE
[DOCS-6703] Docs should point to correct version number

### DIFF
--- a/content-services/latest/index.md
+++ b/content-services/latest/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alfresco Content Services
+title: Alfresco Content Services 7.2
 ---
 
 Alfresco Content Services 7.2 (or ACS) offers full-featured Enterprise Content Management (ECM) for organizations that require enterprise-grade scalability, performance, and 24x7 support for business-critical content and compliance. It delivers a wide range of use cases such as content and governance services, contextual search and insight, the ability to easily integrate with other applications. At the core of Content Services is a repository supported by a server that persists content, metadata, associations, and full text indexes.


### PR DESCRIPTION
Hi,

I've posted this documention suggestion on the official alfresco discord server and as told by @aborroy  I'm therefore opening this ticket:

----

In my acs ansible tasks or in other source code I'm writing for the customer, I'm always referencing to the official documentation pages. 
For example, for an ACS 6.2 ansible task, I'm referencing to
https://docs.alfresco.com/content-services/6.2/install/zip/tomcat/#install-alfresco-wars

For the current ACS 7.2 version I can only reference to:
https://docs.alfresco.com/content-services/latest/install/zip/tomcat/#install-alfresco-wars

What I would like to reference in my sourcecode is:
https://docs.alfresco.com/content-services/7.2/install/zip/tomcat/#install-alfresco-wars
so I don't have to adjust my commits once the next ACS version 7.3 is out...

This Issue is not only related to ACS, it's a general topic for all alfresco services documentations.
Is it somehow possible to upload/reference the latest documentation as well for the specific version number?


I've also realized alfresco itself runs into this issue with all it's release notes!

For Example:
Release Notes form ACS 7.1 sadly does not point to its correct documentation:
https://docs.alfresco.com/content-services/7.1/
![image](https://user-images.githubusercontent.com/43071828/162197894-35749e67-7415-4ac6-9a49-28fe5efa3c08.png)

Release Notes from ACS 7.0 sadly does not point to its correct documentation:
https://docs.alfresco.com/content-services/7.0/
![image](https://user-images.githubusercontent.com/43071828/162198214-727554bb-fcc2-4f93-b500-35747e00a19a.png)

and so on....

