### PR TITLE
[DOCS-6691] Pipeline improvement - reduce sandbox workflow duration

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -36,6 +36,4 @@ jobs:
 
     - name: Run S3 Sync
       uses: ./.github/actions/s3_sync
-
-    - name: Run Redirects S3 Upload
-      uses: ./.github/actions/s3_upload
+      


### PR DESCRIPTION
Our build pipelines are taking longer and longer to process. This is an initial test to reduce the duration of the Sandbox workflow (for commits to a `feature-branch`). It’ll be a good test to see how long the checks take for Sandbox only, especially for multiple commits to the same branch, which take longer for each iteration.