### PR TITLE
[MNT-22706] Fix value for applying recommended patch

### DIFF
--- a/content-services/7.0/upgrade/index.md
+++ b/content-services/7.0/upgrade/index.md
@@ -254,11 +254,12 @@ The `dir.root` directory is defined in the `alfresco-global.properties` file. By
     Remember to specify the relevant JDBC driver into your application server's classpath.
 
 ## Apply optional performance database patch
->**Note.** This patch can take hours to run on larger systems.
+
+>**Note:** This patch can take hours to run on larger systems.
 
 Alfresco Content Services 7.0 contains a recommended database patch, which adds two indexes to the `alf_node` table and three to `alf_transaction`. This patch is optional, but recommended for larger implementations as it can have a big positive performance impact. These indexes are not automatically applied during upgrade, as the amount of time needed to create them might be considerable. They should be run manually after the upgrade process completes.
 
-To apply the patch, an admin should set the following Alfresco global property to `true`:
+To apply the patch, an admin should set the following Alfresco global property to `false`:
 
 ```text
 system.new-node-transaction-indexes.ignored=false

--- a/content-services/7.1/upgrade/index.md
+++ b/content-services/7.1/upgrade/index.md
@@ -255,14 +255,15 @@ The `dir.root` directory is defined in the `alfresco-global.properties` file. By
     Remember to specify the relevant JDBC driver into your application server's classpath.
 
 ## Apply optional performance database patch
->**Note.** This patch can take hours to run on larger systems.
+
+>**Note:** This patch can take hours to run on larger systems.
 
 Content Services 7.0 contains a recommended database patch, which adds two indexes to the `alf_node` table and three to 
 `alf_transaction`. This patch is optional, but recommended for larger implementations as it can have a big positive 
 performance impact. These indexes are not automatically applied during upgrade, as the amount of time needed to create 
 them might be considerable. They should be run manually after the upgrade process completes.
 
-To apply the patch, an admin should set the following Alfresco global property to `true`:
+To apply the patch, an admin should set the following Alfresco global property to `false`:
 
 ```text
 system.new-node-transaction-indexes.ignored=false

--- a/content-services/latest/upgrade/index.md
+++ b/content-services/latest/upgrade/index.md
@@ -257,7 +257,8 @@ The `dir.root` directory is defined in the `alfresco-global.properties` file. By
     Remember to specify the relevant JDBC driver into your application server's classpath.
 
 ## Apply optional performance database patch
->**Note.** This patch can take hours to run on larger systems.
+
+>**Note:** This patch can take hours to run on larger systems.
 
 Content Services 7.0 contains a recommended database patch, which adds two indexes to the `alf_node` table and 
 three to `alf_transaction`. This patch is optional, but recommended for larger implementations as it can have a big 


### PR DESCRIPTION
This update completes the fix suggested in PR #475 and also requested in MNT-22706: 

> To apply the patch, an admin should set the following Alfresco global property to `false`:
> `system.new-node-transaction-indexes.ignored=false`