### PR TITLE
[DOCS-6711] Added warning note that sys: namespace is not allowed in ReST API calls for ACS 7.1 and 7.2

### DIFF
--- a/content-services/7.1/develop/rest-api-guide/folders-files.md
+++ b/content-services/7.1/develop/rest-api-guide/folders-files.md
@@ -2064,6 +2064,8 @@ Update the properties, also referred to as metadata, for a folder or file.
 * [How to remove aspects](#removeaspectsnode) 
 * [How to get and set permissions](#setpermissionsnode)
 
+>**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
+
 Quite often you want to update some metadata for a folder or file. It can for example be as part of a business process 
 that is used to process content, and at different places in the flow, folders and files should be updated to reflect the 
 processing state. The ReST API implements partial update via PUT. Although technically this is not RESTful it was decided 
@@ -2205,6 +2207,20 @@ Adding aspects to a folder or file is a bit more complicated than just updating 
 
 * [How to update metadata](#updatemetadatanode)  
 * [How to remove aspects](#removeaspectsnode) 
+
+>**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
+> 
+> For example, if you try and add the `sys:hidden` aspect to a node, the following error is returned: 
+> 
+>```{
+> “error”: {
+>   “errorKey”: “framework.exception.ApiDefault”,
+>   “statusCode”: 400,
+>   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>   “descriptionURL”: “https://api-explorer.alfresco.com”
+>  }
+>}```
 
 When you set a property on a file via the update node call the associated aspect will be applied automatically for you, 
 if it’s not already set on the node. Let’s take the out-of-the-box `cm:effectivity` aspect for example, it has two properties 
@@ -2419,6 +2435,20 @@ Removing aspects from a folder or file is a bit more complicated than just updat
 
 * [How to update metadata](#updatemetadatanode)
 * [How to add aspects](#addaspectnode)
+
+>**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
+>
+> For example, if you try and remove the `sys:hidden` aspect from a node, the following error is returned:
+>
+>```{
+> “error”: {
+>   “errorKey”: “framework.exception.ApiDefault”,
+>   “statusCode”: 400,
+>   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>   “descriptionURL”: “https://api-explorer.alfresco.com”
+>  }
+>}```
 
 Removing an aspect from a node is similar to how you add a “marker” aspect. You first get the list of aspects currently 
 applied to the node. Then you remove the aspect from the list. And finally you use an update node call with the updated 

--- a/content-services/latest/develop/rest-api-guide/folders-files.md
+++ b/content-services/latest/develop/rest-api-guide/folders-files.md
@@ -2080,6 +2080,8 @@ Update the properties, also referred to as metadata, for a folder or file.
 * [How to remove aspects](#removeaspectsnode) 
 * [How to get and set permissions](#setpermissionsnode)
 
+>**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
+
 Quite often you want to update some metadata for a folder or file. It can for example be as part of a business process 
 that is used to process content, and at different places in the flow, folders and files should be updated to reflect the 
 processing state. The ReST API implements partial update via PUT. Although technically this is not RESTful it was decided 
@@ -2221,6 +2223,20 @@ Adding aspects to a folder or file is a bit more complicated than just updating 
 
 * [How to update metadata](#updatemetadatanode)  
 * [How to remove aspects](#removeaspectsnode) 
+
+>**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
+>
+> For example, if you try and add the `sys:hidden` aspect to a node, the following error is returned:
+>
+>```{
+> “error”: {
+>   “errorKey”: “framework.exception.ApiDefault”,
+>   “statusCode”: 400,
+>   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>   “descriptionURL”: “https://api-explorer.alfresco.com”
+>  }
+>}```
 
 When you set a property on a file via the update node call the associated aspect will be applied automatically for you, 
 if it’s not already set on the node. Let’s take the out-of-the-box `cm:effectivity` aspect for example, it has two properties 
@@ -2435,6 +2451,20 @@ Removing aspects from a folder or file is a bit more complicated than just updat
 
 * [How to update metadata](#updatemetadatanode)
 * [How to add aspects](#addaspectnode)
+
+>**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
+>
+> For example, if you try and remove the `sys:hidden` aspect from a node, the following error is returned:
+>
+>```{
+> “error”: {
+>   “errorKey”: “framework.exception.ApiDefault”,
+>   “statusCode”: 400,
+>   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>   “descriptionURL”: “https://api-explorer.alfresco.com”
+>  }
+>}```
 
 Removing an aspect from a node is similar to how you add a “marker” aspect. You first get the list of aspects currently 
 applied to the node. Then you remove the aspect from the list. And finally you use an update node call with the updated 


### PR DESCRIPTION
Added note to 7.1 and 7.2 ReST API docs that API calls will not allow aspects or properties contained in the sys: namespace.