### PR TITLE
[DOCS-6709] Update compatible versions in Supported platforms pages

### DIFF
--- a/content-services/5.2/support/index.md
+++ b/content-services/5.2/support/index.md
@@ -118,6 +118,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 |Alfresco Records Management 2.5.1|✓|✓|✓|✓|✓|✓|✓|✓| |
 |Alfresco Sync Service 2.2 \*| | |✓|✓|✓|✓|✓|✓| |
 |Alfresco Sync Service 2.1 \*|✓|✓|✓|✓|✓|✓|✓|✓| |
+|Alfresco Desktop Sync 1.10 \*| | |✓|✓|✓|✓|✓|✓| |
 |Alfresco Desktop Sync 1.9 \*| | |✓|✓|✓|✓|✓|✓| |
 |Alfresco Desktop Sync 1.8 \*| | |✓|✓|✓|✓|✓|✓| |
 |Alfresco Desktop Sync 1.7 \*| | |✓|✓|✓|✓|✓|✓| |

--- a/content-services/6.0/support/index.md
+++ b/content-services/6.0/support/index.md
@@ -57,6 +57,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.0.1 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |
@@ -155,6 +156,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.0.1 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |

--- a/content-services/6.1/support/index.md
+++ b/content-services/6.1/support/index.md
@@ -61,6 +61,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.1.2 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |
@@ -170,6 +171,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.1.0 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |

--- a/content-services/6.2/support/index.md
+++ b/content-services/6.2/support/index.md
@@ -183,6 +183,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.3 | |
 | Alfresco Sync Service 3.2 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |
@@ -301,6 +302,7 @@ Alfresco Content Connector for Azure 1.1 | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.3 | |
 | Alfresco Sync Service 3.2 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |

--- a/content-services/6.2/support/index.md
+++ b/content-services/6.2/support/index.md
@@ -65,6 +65,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.3 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |

--- a/content-services/7.0/support/index.md
+++ b/content-services/7.0/support/index.md
@@ -68,8 +68,11 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Process Services 2.0 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.7 | |
+| Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
 | Alfresco Sync Service 3.4 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |
@@ -104,6 +107,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Services SDK 4.2 | |
 | | |
 | **Applications** | |
+| Alfresco Digital Workspace 2.8 | |
 | Alfresco Digital Workspace 2.7 | |
 | Alfresco Digital Workspace 2.6 | |
 | Alfresco Digital Workspace 2.5 | |
@@ -180,8 +184,11 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Governance Services 3.5 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.7 | |
+| Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
 | Alfresco Sync Service 3.4 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Desktop Sync 1.7 | |

--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -67,8 +67,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Process Services 2.0.1 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Transform Service 1.5.1 | |
@@ -101,6 +103,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Services SDK 4.3 | |
 | | |
 | **Applications** | |
+| Alfresco Digital Workspace 2.8 | |
 | Alfresco Digital Workspace 2.7 | |
 | Alfresco Digital Workspace 2.6 | |
 | Alfresco Digital Workspace 2.5 | |
@@ -174,7 +177,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Process Services 2.0.1 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.7 | |
+| Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Desktop Sync 1.8 | |
 | Alfresco Transform Service 1.5.1 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -67,7 +67,9 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Process Services 2.3 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
+| Alfresco Desktop Sync 1.10 | |
 | Alfresco Desktop Sync 1.9 | |
 | Alfresco Transform Service 1.5.2 | |
 | Alfresco Document Transformation Engine 2.3 | |
@@ -93,6 +95,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Services SDK 4.4 | |
 | | |
 | **Applications** | |
+| Alfresco Digital Workspace 2.8 | |
 | Alfresco Digital Workspace 2.7 | |
 | Alfresco Application Development Framework (ADF) 4.x | Some API functionality may be available only in the latest Alfresco Content Services release. |
 | Alfresco Mobile Workspace 1.2 | |


### PR DESCRIPTION
This updates the ACS Supported platforms pages so that they're aligned with the individual services, integrations, and applications. Relates to the upcoming releases only, and continues on from PR #641.