### PR TITLE
[DOCS-6741] Alfresco Intelligence Services 1.4.4

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -79,6 +79,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 1.1 | |
 | Alfresco Identity Service 1.7 | |
 | SAML Module for Alfresco Content Services 1.2.2 | |
+| Alfresco Intelligence Services 1.4.4 | |
 | Alfresco Intelligence Services 1.4.2 | |
 | Alfresco Content Connector for AWS S3 5.0 | Adds support for AWS Glacier using Cloud storage layer. |
 | Alfresco Content Connector for Azure 3.0 | |

--- a/intelligence-services/1.3/config/comprehend.md
+++ b/intelligence-services/1.3/config/comprehend.md
@@ -346,7 +346,7 @@ alfresco:
       - ./customAIPropertyMapping.json:/usr/local/tomcat/customAIPropertyMapping.json
       - ./customAIContentModel.xml:/usr/local/tomcat/shared/classes/alfresco/extension/customAIContentModel.xml
       # DOC: file needs to end in -context.xml and to be in this location.
-      # Details on (Deployment - App Server) -> https://docs.alfresco.com/content-services/latest/develop/repo-ext-points/content-model/#definedeploy)
+      # Details on (Deployment - App Server) -> https://docs.alfresco.com/content-services/7.0/develop/repo-ext-points/content-model/#definedeploy)
       - ./custom-ai-content-model-context.xml:/usr/local/tomcat/shared/classes/alfresco/extension/custom-ai-content-model-context.xml
       - ./custom-ai-renditions-definitions.json:/usr/local/tomcat/shared/classes/alfresco/extension/transform/renditions/custom-ai-renditions-definitions.json
 ```
@@ -459,7 +459,7 @@ share:
         -Dalfresco.protocol=http
         "
     volumes:
-      # DOC: configuring Share -> https://docs.alfresco.com/content-services/latest/develop/share-ext-points/share-config/)
+      # DOC: configuring Share -> https://docs.alfresco.com/content-services/7.0/develop/share-ext-points/share-config/)
       - ./share-config-custom.xml:/usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom-dev.xml
       - ./bootstrap-custom-labels.properties:/usr/local/tomcat/shared/classes/alfresco/web-extension/messages/bootstrap-custom-labels.properties
       - ./share-custom-slingshot-application-context.xml:/usr/local/tomcat/shared/classes/alfresco/web-extension/custom-slingshot-application-context.xml

--- a/intelligence-services/1.3/index.md
+++ b/intelligence-services/1.3/index.md
@@ -22,6 +22,6 @@ Other features introduced in previous versions include:
 * Enrichment of content metadata (v1.0)
 * Easier access to insights from unstructured content (v1.0)
 
-> **Important:** The Intelligence Services module can be applied to Content Services 6.2 or later. See [Supported platforms]({% link intelligence-services/1.3/support/index.md %}) for more.
+> **Important:** The Intelligence Services module can be applied to Content Services 7.0. See [Supported platforms]({% link intelligence-services/1.3/support/index.md %}) for more.
 
 See [Intelligence Services architecture]({% link intelligence-services/1.3/admin/index.md %}) for a general overview.

--- a/intelligence-services/1.3/install/index.md
+++ b/intelligence-services/1.3/install/index.md
@@ -296,7 +296,7 @@ The Intelligence Services distribution zip file, `alfresco-ai-distribution-1.3.x
         java -jar <alfrescoInstallLocation>/bin/alfresco-mmt.jar install <installLocation>/amps-share/alfresco-ai-share-1.3.x.amp <installLocation>/tomcat/webapps/share.war
         ```
 
-    For more information, see [Using the Module Management Tool (MMT)]({% link content-services/latest/develop/extension-packaging.md %}#using-the-module-management-tool-mmt) and [Installing an Alfresco Module Package]({% link content-services/latest/install/zip/amp.md %}).
+    For more information, see [Using the Module Management Tool (MMT)]({% link content-services/7.0/develop/extension-packaging.md %}#using-the-module-management-tool-mmt) and [Installing an Alfresco Module Package]({% link content-services/7.0/install/zip/amp.md %}).
 
     Check the output to ensure that the AMP files have installed successfully.
 

--- a/intelligence-services/1.3/using/index.md
+++ b/intelligence-services/1.3/using/index.md
@@ -58,7 +58,7 @@ Follow these steps to use the default (i.e. out-of-the-box) configuration of Int
 
     At this point, your rule has been applied to request the AI renditions and add the selected AI aspects.
 
-    See the Content Services documentation, [Folder rules]({% link content-services/latest/using/content/rules.md %}) to find out more about applying folder rules.
+    See the Content Services documentation, [Folder rules]({% link content-services/7.0/using/content/rules.md %}) to find out more about applying folder rules.
 
 10. Next, upload content to your test folder.
 

--- a/intelligence-services/latest/config/comprehend.md
+++ b/intelligence-services/latest/config/comprehend.md
@@ -525,7 +525,7 @@ For more details on extending the features of Digital Workspace, see the Alfresc
 
 ```yaml
   digital-workspace:
-    image: quay.io/alfresco/alfresco-digital-workspace:2.4.0-adw
+    image: quay.io/alfresco/alfresco-digital-workspace:2.4.2
     environment:
       BASE_PATH: ./
       APP_CONFIG_PLUGIN_AI_SERVICE: "true"

--- a/intelligence-services/latest/config/comprehend.md
+++ b/intelligence-services/latest/config/comprehend.md
@@ -525,7 +525,7 @@ For more details on extending the features of Digital Workspace, see the Alfresc
 
 ```yaml
   digital-workspace:
-    image: quay.io/alfresco/alfresco-digital-workspace:2.4.2
+    image: quay.io/alfresco/alfresco-digital-workspace:2.8
     environment:
       BASE_PATH: ./
       APP_CONFIG_PLUGIN_AI_SERVICE: "true"

--- a/intelligence-services/latest/config/index.md
+++ b/intelligence-services/latest/config/index.md
@@ -86,7 +86,7 @@ A number of environment variables allow you to specify the configuration options
 
     ```yaml
     transform-router:
-        image: quay.io/alfresco/alfresco-transform-router:1.4.x
+        image: quay.io/alfresco/alfresco-transform-router:1.5.x
         environment:
             JAVA_OPTS: " -Xms256m -Xmx512m"
             FILE_STORE_URL: "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file"
@@ -111,14 +111,15 @@ A number of environment variables allow you to specify the configuration options
 4. Add the following configuration to override the settings for Digital Workspace in your deployment.
 
     ```yaml
-  digital-workspace:
-    image: quay.io/alfresco/alfresco-digital-workspace:2.4.0-adw
-    environment:
-      BASE_PATH: ./
-      APP_CONFIG_PLUGIN_AI_SERVICE: "true"
-    volumes:
-      - ./ai-view-extension.json:/usr/share/nginx/html/assets/plugins/ai-view-extension.json
+    digital-workspace:
+        image: quay.io/alfresco/alfresco-digital-workspace:2.4.2
+        environment:
+        BASE_PATH: ./
+        APP_CONFIG_PLUGIN_AI_SERVICE: "true"
+        volumes:
+        - ./ai-view-extension.json:/usr/share/nginx/html/assets/plugins/ai-view-extension.json
     ```
+
     > **Note:** The Digital Workspace configuration file, `ai-view-extension.json`, is also included in the Intelligence Services distribution zip.
 
     For more details on extending the features of Digital Workspace, see the Alfresco Content Application documentation: [Extending](https://alfresco-content-app.netlify.com/#/extending/){:target="_blank"}.

--- a/intelligence-services/latest/config/index.md
+++ b/intelligence-services/latest/config/index.md
@@ -112,7 +112,7 @@ A number of environment variables allow you to specify the configuration options
 
     ```yaml
     digital-workspace:
-        image: quay.io/alfresco/alfresco-digital-workspace:2.4.2
+        image: quay.io/alfresco/alfresco-digital-workspace:2.8
         environment:
         BASE_PATH: ./
         APP_CONFIG_PLUGIN_AI_SERVICE: "true"

--- a/intelligence-services/latest/index.md
+++ b/intelligence-services/latest/index.md
@@ -22,6 +22,6 @@ Other features introduced in previous versions include:
 * Enrichment of content metadata (v1.0)
 * Easier access to insights from unstructured content (v1.0)
 
-> **Important:** The Intelligence Services module can be applied to Content Services 6.2 or later. See [Supported platforms]({% link intelligence-services/latest/support/index.md %}) for more.
+> **Important:** The Intelligence Services module can be applied to Content Services 7.2 or later. See [Supported platforms]({% link intelligence-services/latest/support/index.md %}) for more.
 
 See [Intelligence Services architecture]({% link intelligence-services/latest/admin/index.md %}) for a general overview.

--- a/intelligence-services/latest/install/index.md
+++ b/intelligence-services/latest/install/index.md
@@ -17,7 +17,7 @@ In this section you'll install and set up everything you need to run Intelligenc
 
 ### Access to Docker images
 
-Some of the Docker images that are used by the Intelligence Services module are uploaded to a private registry, **Quay.io**. Since the Intelligence Services module adds AI capabilities to Alfresco Transform Service (see [Transform Service install overview]({% link transform-service/latest/admin/index.md %}#docker-images-overview), you'll also need access to the following image:
+Some of the Docker images that are used by the Intelligence Services module are uploaded to a private registry, **Quay.io**. Since the Intelligence Services module adds AI capabilities to Alfresco Transform Service (see [Transform Service install overview]({% link transform-service/latest/admin/index.md %}#docker-images-overview)), you'll also need access to the following image:
 
 ```bash
 alfresco/alfresco-ai-docker-engine

--- a/intelligence-services/latest/support/index.md
+++ b/intelligence-services/latest/support/index.md
@@ -7,5 +7,5 @@ The following are the supported platforms for Alfresco Intelligence Services 1.4
 | Version | Notes |
 | ------- | ----- |
 | Content Services 7.2.x | |
-| Transform Service 1.4 | |
+| Transform Service 1.5.x | |
 | Digital Workspace 2.4 | |

--- a/intelligence-services/latest/support/index.md
+++ b/intelligence-services/latest/support/index.md
@@ -8,4 +8,4 @@ The following are the supported platforms for Alfresco Intelligence Services 1.4
 | ------- | ----- |
 | Content Services 7.2.x | |
 | Transform Service 1.5.x | |
-| Digital Workspace 2.4 | |
+| Digital Workspace 2.8 | |


### PR DESCRIPTION
Summary of changes:

- For AIS 1.3.x: updated links to point to Content Services 7.1 docs.
- For AIS 1.4.4: updated supported AIS version in Content Services 7.2 Supported platforms page, and changed references to Digital Workspace 2.8, and Transform Service 1.5. The previous versions should be backward compatible.