### PR TITLE
Remove duplicate property field example.

### DIFF
--- a/search-services/latest/using/index.md
+++ b/search-services/latest/using/index.md
@@ -145,7 +145,6 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|


### PR DESCRIPTION
Remove duplicate property field example. There is also a typo here along with duplicate entry. 'Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|'