### PR TITLE
[DOCS-6768] Fix missing operator '|' and add missing character escaping for CMIS query examples

### DIFF
--- a/search-services/latest/using/index.md
+++ b/search-services/latest/using/index.md
@@ -358,12 +358,11 @@ These examples show how to embed queries in CMIS.
 
 ```sql
 - strict queries
-SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ## Search Service

--- a/search-services/latest/using/index.md
+++ b/search-services/latest/using/index.md
@@ -323,8 +323,8 @@ OR
 
 `AND` and `OR` can be combined with `+`, `|`, `-` with the following meanings:
 
-|AND (no prefix is the same as +)|Explanation|
-|----------------------------------|-----------|
+|AND (no prefix is the same as +)|Description|
+|--------------------------------|-----------|
 |`big AND dog`|big and dog must occur|
 |`+big AND +dog`|big and dog must occur|
 |`big AND +dog`|big and dog must occur|
@@ -337,8 +337,8 @@ OR
 |`-big AND -dog`|both big and dog must not occur|
 |`\|big AND -dog`|big should occur and dog must not occur|
 
-|OR (no prefix is the same as +)|Explanation|
-|---------------------------------|-----------|
+|OR (no prefix is the same as +)|Description|
+|-------------------------------|-----------|
 |`dog OR wolf`|dog and wolf should occur, and at least one must match|
 |`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
 |`dog OR +wolf`|dog and wolf should occur, and at least one must match|

--- a/search-services/latest/using/index.md
+++ b/search-services/latest/using/index.md
@@ -323,32 +323,32 @@ OR
 
 `AND` and `OR` can be combined with `+`, `|`, `-` with the following meanings:
 
-|AND (no prefix is the same as +)|Description|
+|AND (no prefix is the same as +)|Explanation|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
-|OR (no prefix is the same as +)|Description|
+|OR (no prefix is the same as +)|Explanation|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Embed queries in CMIS
 


### PR DESCRIPTION
Fix missing operator '|' and add missing character escaping for CMIS query examples to work correctly

- Fixed the missing operator '|' that completes the correct query. 

    - Search like 'big must occur and dog should occur' would be return only if term is prefixed with '|' , example:  `big AND |dog`

       This fix can be compared with: https://github.com/Alfresco/docs-alfresco/blob/master/content-services/5.2/develop/alfresco-full-text-search-ref.md?plain=1#L425

- Added missing character escaping for CMIS query examples to work correctly.
    - CMIS contains had missing escaping character. Query result in parsing error without escaping character.
Examples from here works: https://github.com/Alfresco/docs-alfresco/blob/master/content-services/5.2/develop/alfresco-full-text-search-ref.md?plain=1#L463
