### PR TITLE
[DOCS-6764] Add scheduler contract path property to SFS startup for Windows

### DIFF
--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -525,7 +525,7 @@ before continuing.
 4. Start the Shared File Store controller:
 
     ```java
-    java -DfileStorePath=/path/to/your/AlfrescoFileStore
+    java -DfileStorePath=/path/to/your/AlfrescoFileStore -Dscheduler.contract.path=/path/to/tempdir/scheduler.json
      -jar alfresco-shared-file-store-controller-x.y.z.jar
     ```
 


### PR DESCRIPTION
adding the scheduler contract path property to SFS startup. This is required to be set for people running on windows.