### PR TITLE
[DOCS-6751] Fix typo for property field example

### DIFF
--- a/content-services/5.2/develop/alfresco-full-text-search-ref.md
+++ b/content-services/5.2/develop/alfresco-full-text-search-ref.md
@@ -8,7 +8,7 @@ The Alfresco Full Text Search (FTS) query text can be used standalone or it can 
 
 FTS is exposed directly by the interface, which adds its own template, and is also used as its default field. The default template is:
 
-```
+```text
 %(cm:name cm:title cm:description ia:whatEvent ia:descriptionEvent lnk:title lnk:description TEXT)
 ```
 
@@ -16,60 +16,13 @@ When FTS is embedded in CMIS-SQL, only the CMIS-SQL-style property identifiers (
 
 When FTS is used standalone, fields can also be identified using `prefix:local-name` and `{uri}local-name` styles.
 
--   **[Search for a single term](#search-for-a-single-term)**  
-Single terms are tokenized before the search according to the appropriate data dictionary definition(s).
--   **[Search for a phrase](#search-for-a-phrase)**  
-Phrases are enclosed in double quotes. Any embedded quotes can be escaped using `\`. If no field is specified then the default TEXT field will be used, as with searches for a single term.
--   **[Search for an exact term](#search-for-an-exact-term)**  
-To search for an exact term, prefix the term with "=". This ensures that the term will not be tokenized, therefore you can search for stop words.
--   **[Search for term expansion](#search-for-term-expansion)**  
-To force tokenization and term expansion, prefix the term with `~`.
--   **[Search for conjunctions](#search-for-conjunctions)**  
-Single terms, phrases, and so on can be combined using "`AND`" in upper, lower, or mixed case.
--   **[Search for disjunctions](#search-for-disjunctions)**  
-Single terms, phrases, and so on can be combined using `OR` in upper, lower, or mixed case.
--   **[Search for negation](#search-for-negation)**  
- You can narrow your search results by excluding words with the `NOT` syntax.
--   **[Search for optional, mandatory, and excluded elements of a query](#search-for-optional,-mandatory,-and-excluded-elements-of-a-query)**  
-Sometimes AND and OR are not enough. If you want to find documents that must contain the term "car", score those with the term "red" higher, but do not match those just containing "red".
--   **[Search in fields](#search-in-fields)**  
-Search specific fields rather than the default. Terms, phrases, etc. can all be preceded by a field. If not the default field TEXT is used.
--   **[Search for wildcards](#search-for-wildcards)**  
-Wildcards are supported in terms, phrases, and exact phrases using `*` to match zero, one, or more characters and `?` to match a single character.
--   **[Search for ranges](#search-for-ranges)**  
-Inclusive ranges can be specified in Google-style. There is an extended syntax for more complex ranges. Unbounded ranges can be defined using MIN and MAX for numeric and date types and "\u0000" and "\FFFF" for text (anything that is invalid).
--   **[Search for fuzzy matching](#search-for-fuzzy-matching)**  
- Alfresco supports fuzzy searches based on the Lucene default Levenshtein Distance.
--   **[Search for proximity](#search-for-proximity)**  
- Google-style proximity is supported.
--   **[Search for boosts](#search-for-boosts)**  
-Query time boosts allow matches on certain parts of the query to influence the score more than others.
--   **[Search for grouping](#search-for-grouping)**  
- Use parentheses to encapsulate `OR` statements for the search engine to execute them properly.
--   **[Search for spans and positions](#search-for-spans-and-positions)**  
-Spans and positions are not implemented. Positions will depend on tokenization.
--   **[Escaping characters](#escaping-characters)**  
-Any character can be escaped using the backslash "\" in terms, IDs (field identifiers), and phrases. Java unicode escape sequences are supported. Whitespace can be escaped in terms and IDs.
--   **[Mixed FTS ID behavior](#mixed-fts-id-behavior)**  
- This relates to the priority defined on properties in the data dictionary, which can be both tokenized or untokenized.
--   **[Search for operator precedence](#search-for-operator-precedence)**  
-Operator precedence is SQL-like (not Java-like). When there is more than one logical operator in a statement, and they are not explicitly grouped using parentheses, `NOT` is evaluated first, then `AND`, and finally `OR`.
--   **[Search query syntax APIs](#search-query-syntax-apis)**  
-These examples show how to embed queries in CMIS.
--   **[Search query templates](#search-query-templates)**  
-The FTS query language supports query templates. These are intended to help when building application specific searches.
--   **[Search query literals](#search-query-literals)**  
-When you search, entries are generally a term or a phrase. The string representation you type in will be transformed to the appropriate type for each property when executing the query. For convenience, there are numeric literals but string literals can also be used.
--   **[Search using date math](#search-using-date-math)**  
-The date field types in Solr support the date math expressions.
-
 ## Search for a single term {#search-for-a-single-term}
 
 Single terms are tokenized before the search according to the appropriate data dictionary definition(s).
 
 If you do not specify a field, it will search in the content and properties. This is a shortcut for searching all properties of type content. Terms can not contain a whitespace.
 
-```
+```text
 banana
 TEXT:banana
 ```
@@ -84,18 +37,19 @@ Phrases are enclosed in double quotes. Any embedded quotes can be escaped using 
 
 The whole phrase will be tokenized before the search according to the appropriate data dictionary definition(s).
 
-```
+```text
 "big yellow banana"
 ```
+
 ## Search for an exact term {#search-for-an-exact-term}
 
-To search for an exact term, prefix the term with "=". This ensures that the term will not be tokenized, therefore you can search for stop words.
+To search for an exact term, prefix the term with `=`. This ensures that the term will not be tokenized, therefore you can search for stop words.
 
 If both FTS and ID base search are supported for a specified or implied property, then exact matching will be used where possible.
 
 For example, the following query will match `running` but will not be tokenized. If you are using stemming it might not match anything.
 
-```
+```text
 =running
 ```
 
@@ -107,7 +61,7 @@ To force tokenization and term expansion, prefix the term with `~`.
 
 For a property with both ID and FTS indexes, where the ID index is the default, force the use of the FTS index.
 
-```
+```text
 ~running
 ```
 
@@ -115,7 +69,7 @@ For a property with both ID and FTS indexes, where the ID index is the default, 
 
 Single terms, phrases, and so on can be combined using "`AND`" in upper, lower, or mixed case.
 
-```
+```text
 big AND yellow AND banana
 TEXT:big and TEXT:yellow and TEXT:banana
 ```
@@ -130,7 +84,7 @@ The `OR` operator is interpreted as "at least one is required, more than one or 
 
 If not otherwise specified, by default search fragments will be `ORed` together.
 
-```
+```text
 big yellow banana
 big OR yellow OR banana
 TEXT:big TEXT:yellow TEXT:banana
@@ -147,7 +101,7 @@ Single terms, phrases, and so on can be combined using "`NOT`" in upper, lower, 
 
 These queries search for nodes that contain the terms `yellow` in any content.
 
-```
+```text
 yellow NOT banana
 yellow !banana
 yellow -banana
@@ -160,19 +114,19 @@ The `NOT` operator can only be used for string keywords; it doesn't work for num
 
 Prefixing any search qualifier with a `-` excludes all results that are matched by that qualifier.
 
-## Search for optional, mandatory, and excluded elements of a query {#search-for-optional,-mandatory,-and-excluded-elements-of-a-query}
+## Search for optional, mandatory, and excluded elements of a query {#search-for-optional_-mandatory_-and-excluded-elements-of-a-query}
 
 Sometimes AND and OR are not enough. If you want to find documents that must contain the term "car", score those with the term "red" higher, but do not match those just containing "red".
 
 |Operator|Description|
 |--------|-----------|
-|"|"|The field, phrase, group is optional; a match increases the score.|
-|"+"|The field, phrase, group is mandatory (Note: this differs from Google - see "=")|
+|"\|"|The field, phrase, group is optional; a match increases the score.|
+|"+"|The field, phrase, group is mandatory. (**Note:** This differs from Google - see `=`)|
 |"-", "!"|The field, phrase, group must not match.|
 
 The following example finds documents that contain the term "car", score those with the term "red" higher, but does not match those just containing "red":
 
-```
+```text
 +car |red
 ```
 
@@ -184,7 +138,7 @@ All `AND` and `OR` constructs can be expressed with these operators.
 
 Search specific fields rather than the default. Terms, phrases, etc. can all be preceded by a field. If not the default field TEXT is used.
 
-```
+```text
 field:term
 field:"phrase"
 =field:exact
@@ -232,7 +186,7 @@ The `*` wildcard character can appear on its own and implies Google-style. The "
 
 The following will all find the term apple.
 
-```
+```text
 TEXT:app?e
 TEXT:app*
 TEXT:*pple
@@ -248,32 +202,23 @@ When performing a search that includes a wildcard character, it is best to wrap 
 
 ## Search for ranges {#search-for-ranges}
 
-Inclusive ranges can be specified in Google-style. There is an extended syntax for more complex ranges. Unbounded ranges can be defined using MIN and MAX for numeric and date types and "\u0000" and "\FFFF" for text (anything that is invalid).
+Inclusive ranges can be specified in Google-style. There is an extended syntax for more complex ranges. Unbounded ranges can be defined using MIN and MAX for numeric and date types and `\u0000` and `\FFFF` for text (anything that is invalid).
 
 |Lucene|Google|Description|Example|
 |------|------|-----------|-------|
-|`[#1 TO #2]`|`#1..#2`|The range #1 to #2 inclusive ``#1 <= x <= #2``
+|`[#1 TO #2]`|`#1..#2`|The range #1 to #2 inclusive ``#1 <= x <= #2``|`0..5``[0 TO 5]`|
+|`<#1 TO #2]`| |The range #1 to #2 including #2 but not #1.`#1 < x <= #2`|`<0 TO 5]`|
+|`[#1 TO #2>`| |The range #1 to #2 including #1 but not #2.`#1 <= x < #2`|`[0 TO 5>`|
+|`<#1 TO #2>`| |The range #1 to #2 exclusive.`#1 < x < #2`|`<0 TO 5>`|
 
-|`0..5``[0 TO 5]`
-
-|
-|`<#1 TO #2]`| |The range #1 to #2 including #2 but not #1.`#1 < x <= #2`
-
-|`<0 TO 5]`|
-|`[#1 TO #2>`| |The range #1 to #2 including #1 but not #2.`#1 <= x < #2`
-
-|`[0 TO 5>`|
-|`<#1 TO #2>`| |The range #1 to #2 exclusive.`#1 < x < #2`
-
-|`<0 TO 5>`|
-
-```
+```text
 TEXT:apple..banana
 my:int:[0 TO 10]
 my:float:2.5..3.5
 my:float:0..MAX
 mt:text:[l TO "\uFFFF"]
 ```
+
 ## Search for fuzzy matching {#search-for-fuzzy-matching}
 
 Alfresco supports fuzzy searches based on the Lucene default Levenshtein Distance.
@@ -282,7 +227,7 @@ To do a fuzzy search use the tilde (`~`) symbol at the end of a single word term
 
 For example, to search for a term similar in spelling to *roam* use the fuzzy search:
 
-```
+```text
 roam~0.9
 ```
 
@@ -294,34 +239,7 @@ Google-style proximity is supported.
 
 To specify proximity for fields, use grouping.
 
-```
-big * apple
-TEXT:(big * apple)
-big *(3) apple
-TEXT:(big *(3) apple)
-```
-
-## Search for fuzzy matching {#search-for-fuzzy-matching}
-
-Alfresco supports fuzzy searches based on the Lucene default Levenshtein Distance.
-
-To do a fuzzy search use the tilde (`~`) symbol at the end of a single word term with a parameter between 0 and 1 to specify the required similarity. Use a value closer to 1 for higher similarity.
-
-For example, to search for a term similar in spelling to *roam* use the fuzzy search:
-
-```
-roam~0.9
-```
-
-This search will find terms like *foam*, *roaming*, and *roams*.
-
-## Search for proximity {#search-for-proximity}
-
-Google-style proximity is supported.
-
-To specify proximity for fields, use grouping.
-
-```
+```text
 big * apple
 TEXT:(big * apple)
 big *(3) apple
@@ -334,7 +252,7 @@ Query time boosts allow matches on certain parts of the query to influence the s
 
 All query elements can be boosted: terms, phrases, exact terms, expanded terms, proximity (only in filed groups), ranges, and groups.
 
-```
+```text
 term^2.4
 "phrase"^3
 term~0.8^4
@@ -356,7 +274,7 @@ Groupings of terms are made using `( and )`. Groupings of all query elements are
 
 The query elements in field groups all apply to the same field and cannot include a field.
 
-```
+```text
 (big OR large) AND banana  
 title:((big OR large) AND banana)
 ```
@@ -367,7 +285,7 @@ Spans and positions are not implemented. Positions will depend on tokenization.
 
 Anything more detailed than one *(2) two are arbitrarily dependent on the tokenization. An identifier and pattern matching, or dual FTS and ID tokenization, might be the answer in these cases.
 
-```
+```text
 term[^] - start 
 term[$] - end 
 term[position]
@@ -375,7 +293,7 @@ term[position]
 
 These are of possible use but excluded for now. Lucene surround extensions:
 
-```
+```text
 and(terms etc) 
 99w(terms etc) 
 97n(terms etc)
@@ -383,11 +301,11 @@ and(terms etc)
 
 ## Escaping characters {#escaping-characters}
 
-Any character can be escaped using the backslash "\" in terms, IDs (field identifiers), and phrases. Java unicode escape sequences are supported. Whitespace can be escaped in terms and IDs.
+Any character can be escaped using the backslash (`\\`) in terms, IDs (field identifiers), and phrases. Java unicode escape sequences are supported. Whitespace can be escaped in terms and IDs.
 
 For example:
 
-```
+```text
 cm:my\ content:my\ name 
 ```
 
@@ -395,9 +313,9 @@ cm:my\ content:my\ name
 
 This relates to the priority defined on properties in the data dictionary, which can be both tokenized or untokenized.
 
-Explicit priority is set by prefixing the query with "=" for identifier pattern matches.
+Explicit priority is set by prefixing the query with `=` for identifier pattern matches.
 
-The tilde "~" can be used to force tokenization.
+The tilde (`~`) symbol can be used to force tokenization.
 
 ## Search for operator precedence {#search-for-operator-precedence}
 
@@ -405,7 +323,7 @@ Operator precedence is SQL-like (not Java-like). When there is more than one log
 
 The following shows the operator precedence from highest to lowest:
 
-```
+```text
 " 
 [, ], <, > 
 () 
@@ -452,7 +370,7 @@ These examples show how to embed queries in CMIS.
 
 ### Embedded in CMIS contains()
 
-```
+```text
 - strict queries
 SELECT * FROM Document WHERE CONTAINS('\'zebra\'')
 SELECT * FROM Document WHERE CONTAINS('\'quick\'')        
@@ -464,11 +382,11 @@ SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 
 ### Search Service
 
-```
+```text
 ResultSet results = searchService.query(storeRef, SearchService.LANGUAGE_FTS_ALFRESCO, "quick");
 ```
 
-```
+```text
 SearchService.LANGUAGE_FTS_ALFRESCO = "fts-alfresco"
 ```
 
@@ -478,7 +396,7 @@ FTS is supported in the node browser.
 
 ### JavaScript
 
-```
+```text
 search
 {
    query: string,          mandatory, in appropriate format and encoded for the given language
@@ -513,7 +431,7 @@ template
 
 For example:
 
-```
+```text
  var def =
   {
      query: "cm:name:test*",
@@ -532,14 +450,13 @@ The FTS query language supports query templates. These are intended to help when
 
 A template is a query but with additional support to specify template substitution.
 
--   **%field**
+* **%field**
 
     Insert the parse tree for the current `ftstest` and replace all references to fields in the current parse tree with the supplied field.
 
--   **%(field1, field2)%(field1 field2)**
+* **%(field1, field2)%(field1 field2)**
 
     (The comma is optional.) Create a disjunction, and for each field, add the parse tree for the current `ftstest` to the disjunction, and then replace all references to fields in the current parse tree with the current field from the list.
-
 
 |Name|Template|Example Query|Expanded Query|
 |----|--------|-------------|--------------|
@@ -552,7 +469,7 @@ A template is a query but with additional support to specify template substituti
 
 Templates can refer to other templates.
 
-```
+```text
 nameAndTitle -> %(cm:name, cm:title)
 nameAndTitleAndDesciption -> %(nameAndTitle, cm:description)   
 ```
@@ -561,33 +478,33 @@ nameAndTitleAndDesciption -> %(nameAndTitle, cm:description)
 
 When you search, entries are generally a term or a phrase. The string representation you type in will be transformed to the appropriate type for each property when executing the query. For convenience, there are numeric literals but string literals can also be used.
 
-**Date formatting**
+### Date formatting
 
 You can specify either a particular date or a date literal. A date literal is a fixed expression that represents a relative range of time, for example last month, this week, or next year.
 
 `dateTime` field values are stored as Coordinated Universal Time (UTC). The date fields represent a point in time with millisecond precision. For date field formatting, Solr uses [DateTimeFormatter.ISO_INSTANT](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT). The ISO instant formatter formats an instant in Coordinated Universal Time (UTC), for example:
 
-```
+```text
 YYYY-MM-DDThh:mm:ssZ
 ```
 
 where,
 
--   `YYYY` is the year.
--   `MM` is the month.
--   `DD` is the day of the month.
--   `hh` is the hour of the day as on a 24-hour clock.
--   `mm` is minutes.
--   `ss` is seconds.
--   `Z` is a literal `Z` character indicating that this string representation of the date is in UTC.
+* `YYYY` is the year.
+* `MM` is the month.
+* `DD` is the day of the month.
+* `hh` is the hour of the day as on a 24-hour clock.
+* `mm` is minutes.
+* `ss` is seconds.
+* `Z` is a literal `Z` character indicating that this string representation of the date is in UTC.
 
 > **Note:** No time zone can be specified. The string representation of dates is always expressed in UTC, for example:
 
-```
+```text
 1972-05-20T17:33:18Z
 ```
 
-**String literals**
+### String literals
 
 String literals for phrases can be enclosed in double quotes or single quotes. Java single character and `\uXXXX`-based escaping are supported within these literals.
 
@@ -597,7 +514,7 @@ Dates as any other literal can be expressed as a term or phrase. Dates are in th
 
 In range queries, strings, term, and phrases that do not parse to valid type instance for the property are treated as open ended.
 
-```
+```text
 test:integer[ 0 TO MAX] matches anything positive
 ```
 
@@ -607,37 +524,37 @@ The date field types in Solr support the date math expressions.
 
 The date math expression makes it easy to create times relative to fixed moments in time and includes the current time which can be represented using the special value of `NOW`.
 
-**Date math syntax**
+### Date math syntax
 
 The date math expressions consist either adding some quantity of time in a specified unit, or rounding the current time by a specified unit. Expressions can be chained and are evaluated left to right.
 
 For example, to represents a point in time two months from now, use:
 
-```
+```text
 NOW+2MONTHS
 ```
 
 To represents a point in time one day ago, use:
 
-```
+```text
 NOW-1DAY
 ```
 
 A slash is used to indicate rounding. To represents the beginning of the current hour, use:
 
-```
+```text
 NOW/HOUR
 ```
 
 To represent a point in time six months and three days into the future and then rounds that time to the beginning of that day, use:
 
-```
+```text
 NOW+6MONTHS+3DAYS/DAY
 ```
 
 While date math is most commonly used relative to `NOW`, it can be applied to any fixed moment in time as well:
 
-```
+```text
 1972-05-20T17:33:18.772Z+6MONTHS+3DAYS/DAY
 ```
 

--- a/content-services/5.2/develop/alfresco-full-text-search-ref.md
+++ b/content-services/5.2/develop/alfresco-full-text-search-ref.md
@@ -220,10 +220,7 @@ Property fields evaluate the search term against a particular property, special 
 |ISNOTNULL|Special|ISNOTNULL:"property-qname"|
 |EXISTS|Special|EXISTS:"name of the property"|
 |SITE|Special|SITE:"shortname of the site"|
-|TAG|Special|TAG: "name of the tag"> **Note:** `TAG` must be in upper case.
-
-|
-|
+|TAG|Special|TAG: "name of the tag". **Note:** `TAG` must be in upper case.|
 |Fully qualified data type|Data Type|{http://www.alfresco.org/model/dictionary/1.0}content:apple|
 |prefixed data type|Data Type|d:content:apple|
 

--- a/insight-engine/1.0/using/sql/syntax.md
+++ b/insight-engine/1.0/using/sql/syntax.md
@@ -131,7 +131,7 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
+|Property|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|

--- a/insight-engine/1.1/using/sql/syntax.md
+++ b/insight-engine/1.1/using/sql/syntax.md
@@ -131,7 +131,7 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
+|Property|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|

--- a/insight-engine/1.4/using/sql/syntax.md
+++ b/insight-engine/1.4/using/sql/syntax.md
@@ -131,7 +131,7 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
+|Property|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|

--- a/insight-engine/latest/using/sql/syntax.md
+++ b/insight-engine/latest/using/sql/syntax.md
@@ -145,7 +145,7 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
+|Property|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|

--- a/search-services/1.3/using/index.md
+++ b/search-services/1.3/using/index.md
@@ -145,7 +145,7 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
+|Property|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|

--- a/search-services/1.4/using/index.md
+++ b/search-services/1.4/using/index.md
@@ -145,7 +145,7 @@ Property fields evaluate the search term against a particular property, special 
 |Type|Description|
 |-----------|----|
 |Property|Fully qualified property, for example `{http://www.alfresco.org/model/content/1.0}name:apple`|
-|Poroperty|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
+|Property|Fully qualified property, for example `@{http://www.alfresco.org/model/content/1.0}name:apple`|
 |Property|CMIS style property, for example `cm_name:apple`.|
 |Property|Prefix style property, for example `cm:name:apple`.|
 |Property|Prefix style property, for example `@cm:name:apple`.|


### PR DESCRIPTION
This PR completes the updates started in PR #662.

It also fixes a number of text formatting issues in the ACS 5.2 page for better clarity (even though ACS 5.2 has reached End of Maintenance), such as:

- fixes table formatting, codeblocks, and missing (unescaped) characters
- removes in-page DITA-style table of contents (no longer needed)
- removes duplicate subsections (Search for fuzzy matching, Search for proximity)
