### PR TITLE
[DOCS-6793] Update task assumptions for installation without mTls on latest version

### DIFF
--- a/insight-engine/latest/install/options.md
+++ b/insight-engine/latest/install/options.md
@@ -196,7 +196,7 @@ Mutual TLS is used for authentication between the Repository and Search and Insi
 
 This task assumes you have:
 
-* Installed Alfresco Content Services 6.2 or above, see [Supported platforms]({% link insight-engine/latest/support/index.md %}).
+* Installed Alfresco Content Services 6.2 or below 7.2, see [Supported platforms]({% link insight-engine/latest/support/index.md %}).
 * Set the following properties in the `<TOMCAT_HOME>/shared/classes/alfresco-global.properties` file:
 
     ```text


### PR DESCRIPTION
Updated the assumption as "Installed Alfresco Content Services 6.2 or below 7.2". From ACS 7.2 onwards "none" as solr.secureComms is no longer valid and no longer supported.