### PR TITLE
[DOCS-6794] Fixed enterprise docker image names in SDK 4.4 pom.xml config

### DIFF
--- a/content-services/latest/develop/sdk.md
+++ b/content-services/latest/develop/sdk.md
@@ -1823,7 +1823,7 @@ Starting from a newly created Alfresco SDK project (All-In-One, Platform JAR, or
 
 ### Working with Enterprise {#workingwithenterprise}
 
-By default the Alfresco SDK will use Community Edition releases but it can be configured to use Enterprise Edition releases. Here you will learn how to 
+By default, the Alfresco SDK will use Community Edition releases, but it can be configured to use Enterprise Edition releases. Here you will learn how to 
 set up a project to work with an Enterprise Edition release, highlighting the changes required to make it work.
 
 If you would like to work with the Alfresco Enterprise Edition, then this requires just a few property changes and a license installation. You also need 
@@ -1835,11 +1835,11 @@ to have access to the private Alfresco Nexus repository and the private Alfresco
 #### Installing the license
 
 The very first task to complete is about installing an enterprise license, otherwise the server will remain in read-only mode. This task is required if and 
-only if you used the All-In-One archetype or the Platform JAR archetype to generate your project. If you used the Share JAR archetype to generate your project, 
+only if you used the All-In-One archetype, or the Platform JAR archetype to generate your project. If you used the Share JAR archetype to generate your project, 
 feel free to ignore this task and move on the next one.
 
-If you are an Alfresco Partner or Customer, you can request an enterprise license by you opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}. 
-The Enterprise license is nothing more and nothing less than a file with `lic` extension. The Enterprise license file goes into `src/main/docker/license` 
+If you are an Alfresco Partner or Customer, you can request an enterprise license by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}. 
+The Enterprise license is nothing more and nothing less than a file with `lic` extension. The Enterprise license file goes into the `src/main/docker/license` 
 folder (this folder will be located under the platform JAR submodule if you're using the All-In-One archetype). The license will be copied into the ACS Docker 
 container before it is started. The license file name doesn't matter, but make sure that you keep it simple and maintain the `lic` extension.
 
@@ -1854,18 +1854,21 @@ You'll need to update the following settings in the `pom.xml` file:
 <alfresco.bomDependencyArtifactId>acs-packaging</alfresco.bomDependencyArtifactId>
 ```
 
-* Change the Docker ACS image name:
+* Change the Docker ACS image names for the Alfresco repository and the Alfresco Share UI:
 
 ```xml
-<docker.acs.image>alfresco/alfresco-content-repository</docker.acs.image>
+<docker.acs.image>quay.io/alfresco/alfresco-content-repository</docker.acs.image>
+
+<docker.share.image>quay.io/alfresco/alfresco-share</docker.share.image>
 ```
 
-Changing these parameters instructs the project to use the proper maven dependencies and Docker images.
+Changing these parameters instructs the project to use the proper maven dependencies and Docker images. Note that the 
+Docker images are located in the private **quay.io** Docker Registry.
 
-Depending on the needs of your project, it will probably be necessary to change the `org.alfresco:alfresco-remote-api` dependency to 
+Depending on the needs of your project, it might be necessary to change the `org.alfresco:alfresco-remote-api` dependency to 
 `org.alfresco:alfresco-enterprise-remote-api` or adding any other enterprise dependency like `org.alfresco:alfresco-enterprise-repository`. In any case, 
-it won't be necessary to include the version of any of these dependencies due to the addition of the BOM dependency in the `dependencyManagement` 
-section of the parent `pom.xml` file. 
+it won't be necessary to include the dependency version as the BOM dependency in the `dependencyManagement` 
+section of the parent `pom.xml` file handles that. 
 
 #### Configuring the Enterprise version
 
@@ -1892,7 +1895,7 @@ $ ./run.sh build_start
 
 If you're using Windows, you'll need to use the `run.bat` script instead of `run.sh`.
 
-#### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}.
+#### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}
 
 The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository 
 ([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/Alfresco/alfresco-sdk/issues/636.