### PR TITLE
[DOCS-6394] ATS host URL change in command line start

### DIFF
--- a/transform-service/1.2/install/index.md
+++ b/transform-service/1.2/install/index.md
@@ -417,10 +417,10 @@ The Transform Service distribution zip file includes all the files required to p
 
     # Transform Router properties:
     transform.service.enabled=true
-    transform.service.url=http://localhost:8095/
+    transform.service.url=http://<Transform Service host>:8095/
 
     # Transform Core properties:
-    localTransform.core-aio.url=http://transform-core-aio:8090/
+    localTransform.core-aio.url=http://<Transform Service host>:8090/
     ```
 
     This overrides the default properties provided by Content Services.

--- a/transform-service/1.3/install/index.md
+++ b/transform-service/1.3/install/index.md
@@ -518,10 +518,10 @@ before continuing.
 
     # Transform Router properties:
     transform.service.enabled=true
-    transform.service.url=http://localhost:8095/
+    transform.service.url=http://<Transform Service host>:8095/
 
     # Transform Core properties:
-    localTransform.core-aio.url=http://transform-core-aio:8090/
+    localTransform.core-aio.url=http://<Transform Service host>:8090/
     ```
 
     This overrides the default properties provided by Content Services.

--- a/transform-service/1.4/install/index.md
+++ b/transform-service/1.4/install/index.md
@@ -557,10 +557,10 @@ before continuing.
 
     # Transform Router properties:
     transform.service.enabled=true
-    transform.service.url=http://localhost:8095/
+    transform.service.url=http://<Transform Service host>:8095/
 
     # Transform Core properties:
-    localTransform.core-aio.url=http://transform-core-aio:8090/
+    localTransform.core-aio.url=http://<Transform Service host>:8090/
     ```
 
     This overrides the default properties provided by Content Services.

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -642,10 +642,10 @@ before continuing.
 
     # Transform Router properties:
     transform.service.enabled=true
-    transform.service.url=http://localhost:8095/
+    transform.service.url=http://<Transform Service host>:8095/
 
     # Transform Core properties:
-    localTransform.core-aio.url=http://transform-core-aio:8090/
+    localTransform.core-aio.url=http://<Transform Service host>:8090/
     ```
 
     This overrides the default properties provided by Content Services.


### PR DESCRIPTION
ATS host URL change in command line start, replaces #711 