### PR TITLE
[DOCS-6619] Fix typos in Content Services docs

### DIFF
--- a/content-services/5.2/admin/security.md
+++ b/content-services/5.2/admin/security.md
@@ -381,7 +381,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Alfresco Content Services uses cryptographic password hashing technique to securely store passwords.
 
-All versions Alfresco Content Services 5.2.7 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM and CIFS) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Alfresco Content Services 5.2.7 to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for NTLM and CIFS authentication.
+All versions Alfresco Content Services 5.2.7 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM and CIFS) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Alfresco Content Services 5.2.7 to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for NTLM and CIFS authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Alfresco Content Services 5.2.7 is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/5.2/admin/workflows.md
+++ b/content-services/5.2/admin/workflows.md
@@ -61,7 +61,7 @@ A graphical workflow modeler is often used to create a workflow. The following d
 
 ![A diagram of an Alfresco workflow]({% link content-services/images/wf-diag-workflow-1.jpg %})
 
-The workflow engine executes BPMN 2.0 process definitions. BPNM 2.0 (Business Process Model and Notation) is an open standard developed by the Object Management Group (OMG) to provide a notation that is easily understandable by all business users: business analysts designing processes, developers implementing technology to perform those processes, and, business people managing and monitoring those processes. BPMN creates a standardized bridge for the gap between the business process design and process.
+The workflow engine executes BPMN 2.0 process definitions. BPMN 2.0 (Business Process Model and Notation) is an open standard developed by the Object Management Group (OMG) to provide a notation that is easily understandable by all business users: business analysts designing processes, developers implementing technology to perform those processes, and, business people managing and monitoring those processes. BPMN creates a standardized bridge for the gap between the business process design and process.
 
 Standard BPMN 2.0 process definition models can be exchanged between graphical editors, and executed on any BPMN 2.0 compliant engine. Be aware that if you use technology specific features in your definition, you will not be able to use that workflow on a different technology. For example, if you define a workflow to work with Alfresco Content Services, you will not be able to run it on a TIBCO server.
 

--- a/content-services/6.0/admin/security.md
+++ b/content-services/6.0/admin/security.md
@@ -202,7 +202,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Content Services uses cryptographic password hashing technique to securely store passwords.
 
-Content Services 6.0.1 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM and CIFS) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM and CIFS authentication.
+Content Services 6.0.1 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM and CIFS) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM and CIFS authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Content Services is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/6.1/admin/security.md
+++ b/content-services/6.1/admin/security.md
@@ -202,7 +202,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Content Services uses cryptographic password hashing technique to securely store passwords.
 
-Content Services 6.1.1 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM authentication.
+Content Services 6.1.1 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Content Services is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/6.2/admin/security.md
+++ b/content-services/6.2/admin/security.md
@@ -275,7 +275,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Content Services uses cryptographic password hashing technique to securely store passwords.
 
-All versions Content Services 6.2 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM authentication.
+All versions Content Services 6.2 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Content Services is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/6.2/admin/workflows.md
+++ b/content-services/6.2/admin/workflows.md
@@ -30,7 +30,7 @@ A graphical workflow modeler is often used to create a workflow. The following d
 
 ![wf-diag-workflow-1]({% link content-services/images/wf-diag-workflow-1.jpg %})
 
-The workflow engine executes BPMN 2.0 process definitions. BPNM 2.0 (Business Process Model and Notation) is an open standard developed by the Object Management Group (OMG) to provide a notation that is easily understandable by all business users: business analysts designing processes, developers implementing technology to perform those processes, and, business people managing and monitoring those processes. BPMN creates a standardized bridge for the gap between the business process design and process.
+The workflow engine executes BPMN 2.0 process definitions. BPMN 2.0 (Business Process Model and Notation) is an open standard developed by the Object Management Group (OMG) to provide a notation that is easily understandable by all business users: business analysts designing processes, developers implementing technology to perform those processes, and, business people managing and monitoring those processes. BPMN creates a standardized bridge for the gap between the business process design and process.
 
 Standard BPMN 2.0 process definition models can be exchanged between graphical editors, and executed on any BPMN 2.0 compliant engine. Be aware that if you use technology specific features in your definition, you'll not be able to use that workflow on a different technology. For example, if you define a workflow to work with Content Services, you'll not be able to run it on a TIBCO server.
 

--- a/content-services/7.0/admin/security.md
+++ b/content-services/7.0/admin/security.md
@@ -425,7 +425,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Content Services uses cryptographic password hashing technique to securely store passwords.
 
-All versions prior to Alfresco One 5.1.5 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for `alfrescoNTLM` authentication.
+All versions prior to Alfresco One 5.1.5 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for `alfrescoNTLM` authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Content Services is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/7.0/install/zip/additions.md
+++ b/content-services/7.0/install/zip/additions.md
@@ -26,7 +26,7 @@ The source-localized files are encoded in ASCII, and the special and accented ch
 
 If you wish to use a translation that is not supplied with Content Services, then you must add the appropriate TinyMCE language pack for the translation to work correctly.
 
-1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"} {:target="_blank"}.
+1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"}.
 
 2. Download the required TinyMCE language pack.
 

--- a/content-services/7.1/admin/security.md
+++ b/content-services/7.1/admin/security.md
@@ -425,7 +425,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Content Services uses cryptographic password hashing technique to securely store passwords.
 
-All versions prior to Alfresco One 5.1.5 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for `alfrescoNTLM` authentication.
+All versions prior to Alfresco One 5.1.5 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for `alfrescoNTLM` authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Content Services is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/7.1/develop/rest-api-guide/folders-files.md
+++ b/content-services/7.1/develop/rest-api-guide/folders-files.md
@@ -2203,24 +2203,26 @@ Adding aspects to a folder or file is a bit more complicated than just updating 
 
 **API Explorer URL:** [http://localhost:8080/api-explorer/#!/nodes/updateNode](http://localhost:8080/api-explorer/#!/nodes/updateNode){:target="_blank"}
 
-**See also:** 
+**See also:**
 
 * [How to update metadata](#updatemetadatanode)  
-* [How to remove aspects](#removeaspectsnode) 
+* [How to remove aspects](#removeaspectsnode)
 
 >**Note:** It is not possible to include aspects or properties that are part of the `systemModel` (i.e. namespace `sys:`) in API calls.
-> 
-> For example, if you try and add the `sys:hidden` aspect to a node, the following error is returned: 
-> 
->```{
-> “error”: {
->   “errorKey”: “framework.exception.ApiDefault”,
->   “statusCode”: 400,
->   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
->   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
->   “descriptionURL”: “https://api-explorer.alfresco.com”
->  }
->}```
+>
+> For example, if you try and add the `sys:hidden` aspect to a node, the following error is returned:
+>
+> ```json
+> {
+>   “error”: {
+>     “errorKey”: “framework.exception.ApiDefault”,
+>     “statusCode”: 400,
+>     “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>     “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>     “descriptionURL”: “https://api-explorer.alfresco.com”
+>   }
+> }
+> ```
 
 When you set a property on a file via the update node call the associated aspect will be applied automatically for you, 
 if it’s not already set on the node. Let’s take the out-of-the-box `cm:effectivity` aspect for example, it has two properties 
@@ -2440,15 +2442,17 @@ Removing aspects from a folder or file is a bit more complicated than just updat
 >
 > For example, if you try and remove the `sys:hidden` aspect from a node, the following error is returned:
 >
->```{
-> “error”: {
->   “errorKey”: “framework.exception.ApiDefault”,
->   “statusCode”: 400,
->   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
->   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
->   “descriptionURL”: “https://api-explorer.alfresco.com”
->  }
->}```
+> ```json
+> {
+>   “error”: {
+>     “errorKey”: “framework.exception.ApiDefault”,
+>     “statusCode”: 400,
+>     “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>     “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>     “descriptionURL”: “https://api-explorer.alfresco.com”
+>   }
+> }
+> ```
 
 Removing an aspect from a node is similar to how you add a “marker” aspect. You first get the list of aspects currently 
 applied to the node. Then you remove the aspect from the list. And finally you use an update node call with the updated 

--- a/content-services/7.1/install/zip/additions.md
+++ b/content-services/7.1/install/zip/additions.md
@@ -26,7 +26,7 @@ The source-localized files are encoded in ASCII, and the special and accented ch
 
 If you wish to use a translation that is not supplied with Content Services, then you must add the appropriate TinyMCE language pack for the translation to work correctly.
 
-1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"} {:target="_blank"}.
+1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"}.
 
 2. Download the required TinyMCE language pack.
 

--- a/content-services/community/admin/security.md
+++ b/content-services/community/admin/security.md
@@ -65,7 +65,7 @@ This login protection feature is enabled by default, and can be configured by ad
 
 Community Edition uses cryptographic password hashing technique to securely store passwords.
 
-All versions Community Edition 201911 GA used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Community Edition to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM authentication.
+All versions Community Edition 201911 GA used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Community Edition to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for alfrescoNTLM authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Community Edition is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/community/admin/workflows.md
+++ b/content-services/community/admin/workflows.md
@@ -30,7 +30,7 @@ A graphical workflow modeler is often used to create a workflow. The following d
 
 ![wf-diag-workflow-1]({% link content-services/images/wf-diag-workflow-1.jpg %})
 
-The workflow engine executes BPMN 2.0 process definitions. BPNM 2.0 (Business Process Model and Notation) is an open standard developed by the Object Management Group (OMG) to provide a notation that is easily understandable by all business users: business analysts designing processes, developers implementing technology to perform those processes, and, business people managing and monitoring those processes. BPMN creates a standardized bridge for the gap between the business process design and process.
+The workflow engine executes BPMN 2.0 process definitions. BPMN 2.0 (Business Process Model and Notation) is an open standard developed by the Object Management Group (OMG) to provide a notation that is easily understandable by all business users: business analysts designing processes, developers implementing technology to perform those processes, and, business people managing and monitoring those processes. BPMN creates a standardized bridge for the gap between the business process design and process.
 
 Standard BPMN 2.0 process definition models can be exchanged between graphical editors, and executed on any BPMN 2.0 compliant engine. Be aware that if you use technology specific features in your definition, you'll not be able to use that workflow on a different technology. For example, if you define a workflow to work with Content Services, you'll not be able to run it on a TIBCO server.
 

--- a/content-services/community/install/zip/additions.md
+++ b/content-services/community/install/zip/additions.md
@@ -27,7 +27,7 @@ The source-localized files are encoded in ASCII, and the special and accented ch
 
 If you wish to use a translation that is not supplied with Community Edition, then you must add the appropriate TinyMCE language pack for the translation to work correctly.
 
-1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"} {:target="_blank"}.
+1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"}.
 
 2. Download the required TinyMCE language pack.
 

--- a/content-services/latest/admin/security.md
+++ b/content-services/latest/admin/security.md
@@ -425,7 +425,7 @@ Re-encryption occurs while the repository is running. For runtime re-encryption,
 
 Content Services uses cryptographic password hashing technique to securely store passwords.
 
-All versions prior to Alfresco One 5.1.5 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NLTM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for `alfrescoNTLM` authentication.
+All versions prior to Alfresco One 5.1.5 used the MD4 (Message Digest 4) and SHA256 hash algorithms (mainly to support NTLM) to store critical data. But this is no longer considered a secure approach as the hashed password is very easy to decrypt. You now have the option to configure Content Services to use Bcrypt to store passwords. By default, the system uses MD4 to allow users to use MD4 hashed passwords for `alfrescoNTLM` authentication.
 
 Bcrypt is an adaptive hash function based on the Blowfish symmetric block cipher cryptographic algorithm. It is incredibly slow to hash input compared to other functions, but this results in a much better output hash. Content Services is configured to use a strength of `10` to provide a good compromise of speed and strength.
 

--- a/content-services/latest/develop/rest-api-guide/folders-files.md
+++ b/content-services/latest/develop/rest-api-guide/folders-files.md
@@ -2219,7 +2219,7 @@ Adding aspects to a folder or file is a bit more complicated than just updating 
 
 **API Explorer URL:** [http://localhost:8080/api-explorer/#!/nodes/updateNode](http://localhost:8080/api-explorer/#!/nodes/updateNode){:target="_blank"}
 
-**See also:** 
+**See also:**
 
 * [How to update metadata](#updatemetadatanode)  
 * [How to remove aspects](#removeaspectsnode) 
@@ -2228,15 +2228,17 @@ Adding aspects to a folder or file is a bit more complicated than just updating 
 >
 > For example, if you try and add the `sys:hidden` aspect to a node, the following error is returned:
 >
->```{
-> “error”: {
->   “errorKey”: “framework.exception.ApiDefault”,
->   “statusCode”: 400,
->   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
->   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
->   “descriptionURL”: “https://api-explorer.alfresco.com”
->  }
->}```
+> ```json
+> {
+>   “error”: {
+>     “errorKey”: “framework.exception.ApiDefault”,
+>     “statusCode”: 400,
+>     “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>     “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>     “descriptionURL”: “https://api-explorer.alfresco.com”
+>   }
+> }
+> ```
 
 When you set a property on a file via the update node call the associated aspect will be applied automatically for you, 
 if it’s not already set on the node. Let’s take the out-of-the-box `cm:effectivity` aspect for example, it has two properties 
@@ -2447,6 +2449,7 @@ We can see in the response under `aspectNames` that the new `cm:classifiable` as
 Removing aspects from a folder or file is a bit more complicated than just updating properties. Here is how to do it.
 
 **API Explorer URL:** [http://localhost:8080/api-explorer/#!/nodes/updateNode](http://localhost:8080/api-explorer/#!/nodes/updateNode){:target="_blank"}
+
 **See also:**
 
 * [How to update metadata](#updatemetadatanode)
@@ -2456,15 +2459,17 @@ Removing aspects from a folder or file is a bit more complicated than just updat
 >
 > For example, if you try and remove the `sys:hidden` aspect from a node, the following error is returned:
 >
->```{
-> “error”: {
->   “errorKey”: “framework.exception.ApiDefault”,
->   “statusCode”: 400,
->   “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
->   “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
->   “descriptionURL”: “https://api-explorer.alfresco.com”
->  }
->}```
+> ```json
+> {
+>   “error”: {
+>     “errorKey”: “framework.exception.ApiDefault”,
+>     “statusCode”: 400,
+>     “briefSummary”: “NameSpace cannot be used by API: sys:hidden”,
+>     “stackTrace”: “For security reasons the stack trace is no longer displayed, but the property is kept for previous versions”,
+>     “descriptionURL”: “https://api-explorer.alfresco.com”
+>   }
+> }
+> ```
 
 Removing an aspect from a node is similar to how you add a “marker” aspect. You first get the list of aspects currently 
 applied to the node. Then you remove the aspect from the list. And finally you use an update node call with the updated 

--- a/content-services/latest/install/zip/additions.md
+++ b/content-services/latest/install/zip/additions.md
@@ -26,7 +26,7 @@ The source-localized files are encoded in ASCII, and the special and accented ch
 
 If you wish to use a translation that is not supplied with Content Services, then you must add the appropriate TinyMCE language pack for the translation to work correctly.
 
-1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"} {:target="_blank"}.
+1. Browse to the [TinyMCE website](https://www.tiny.cloud/?ctrl=lang&act=download&pr_id=1){:target="_blank"}.
 
 2. Download the required TinyMCE language pack.
 


### PR DESCRIPTION
Summary of changes:

- Fixes typos for NTLM & BPMN
- Fix codeblocks within **Notes**
- Fix link format in ACS ZIp install - additional software page