### PR TITLE
[DOCS-6768] Fix missing characters for CMIS query examples

### DIFF
--- a/insight-engine/1.0/using/sql/syntax.md
+++ b/insight-engine/1.0/using/sql/syntax.md
@@ -311,30 +311,30 @@ OR
 
 |AND (no prefix is the same as +)|Description|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
 |OR (no prefix is the same as +)|Description|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Search for proximity
 
@@ -477,8 +477,8 @@ SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ## Search Service

--- a/insight-engine/1.1/using/sql/syntax.md
+++ b/insight-engine/1.1/using/sql/syntax.md
@@ -311,30 +311,30 @@ OR
 
 |AND (no prefix is the same as +)|Description|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
 |OR (no prefix is the same as +)|Description|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Search for proximity
 
@@ -477,8 +477,8 @@ SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ## Search Service

--- a/insight-engine/1.4/using/sql/syntax.md
+++ b/insight-engine/1.4/using/sql/syntax.md
@@ -311,30 +311,30 @@ OR
 
 |AND (no prefix is the same as +)|Description|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
 |OR (no prefix is the same as +)|Description|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Search for proximity
 
@@ -477,8 +477,8 @@ SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ## Search Service

--- a/insight-engine/latest/using/sql/syntax.md
+++ b/insight-engine/latest/using/sql/syntax.md
@@ -325,30 +325,30 @@ OR
 
 |AND (no prefix is the same as +)|Description|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
 |OR (no prefix is the same as +)|Description|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Embed queries in CMIS
 
@@ -362,8 +362,8 @@ SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ### Search Service

--- a/search-services/1.3/using/index.md
+++ b/search-services/1.3/using/index.md
@@ -325,30 +325,30 @@ OR
 
 |AND (no prefix is the same as +)|Description|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
 |OR (no prefix is the same as +)|Description|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Embed queries in CMIS
 
@@ -362,8 +362,8 @@ SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ## Search Service

--- a/search-services/1.4/using/index.md
+++ b/search-services/1.4/using/index.md
@@ -325,30 +325,30 @@ OR
 
 |AND (no prefix is the same as +)|Description|
 |----------------------------------|-----------|
-|big AND dog|big and dog must occur|
-|+big AND +dog|big and dog must occur|
-|big AND +dog|big and dog must occur|
-|+big AND dog|big and dog must occur|
-|big AND dog|big must occur and dog should occur|
-|big AND dog|big should occur and dog must occur|
-|big AND dog|both big and dog should occur, and at least one must match|
-|big AND -dog|big must occur and dog must not occur|
-|-big AND dog|big must not occur and dog must occur|
-|-big AND -dog|both big and dog must not occur|
-|big AND -dog|big should occur and dog must not occur|
+|`big AND dog`|big and dog must occur|
+|`+big AND +dog`|big and dog must occur|
+|`big AND +dog`|big and dog must occur|
+|`+big AND dog`|big and dog must occur|
+|`big AND \|dog`|big must occur and dog should occur|
+|`\|big AND dog`|big should occur and dog must occur|
+|`\|big AND \|dog`|both big and dog should occur, and at least one must match|
+|`big AND -dog`|big must occur and dog must not occur|
+|`-big AND dog`|big must not occur and dog must occur|
+|`-big AND -dog`|both big and dog must not occur|
+|`\|big AND -dog`|big should occur and dog must not occur|
 
 |OR (no prefix is the same as +)|Description|
 |---------------------------------|-----------|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|+dog OR +wolf|dog and wolf should occur, and at least one must match|
-|dog OR +wolf|dog and wolf should occur, and at least one must match|
-|+dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR wolf|dog and wolf should occur, and at least one must match|
-|dog OR -wolf|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
-|-dog OR wolf|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
-|-dog OR -wolf|dog and wolf should not occur, one of the clauses must be valid for any result|
+|`dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR +wolf`|dog and wolf should occur, and at least one must match|
+|`+dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR wolf`|dog and wolf should occur, and at least one must match|
+|`\|dog OR \|wolf`|dog and wolf should occur, and at least one must match|
+|`dog OR -wolf`|dog should occur and wolf should not occur, one of the clauses must be valid for any result|
+|`-dog OR wolf`|dog should not occur and wolf should occur, one of the clauses must be valid for any result|
+|`-dog OR -wolf`|dog and wolf should not occur, one of the clauses must be valid for any result|
 
 ## Embed queries in CMIS
 
@@ -362,8 +362,8 @@ SELECT * FROM Document WHERE CONTAINS("zebra")
 SELECT * FROM Document WHERE CONTAINS("quick")
 
 - Alfresco extensions
-SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:'Tutorial")
-SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:'Tutorial")
+SELECT * FROM Document D WHERE CONTAINS(D, 'cmis:name:\'Tutorial\'')
+SELECT cmis:name as BOO FROM Document D WHERE CONTAINS('BOO:\'Tutorial\'')
 ```
 
 ## Search Service


### PR DESCRIPTION
This PR completes the updates started by @abhinavmishra14 in PR #664 :

- Fix missing operator '|' to correctly complete the query
- Add missing character escaping for CMIS query examples to work correctly

⚠️ TODO: Verify update mentioned in https://github.com/Alfresco/docs-alfresco/pull/664#discussion_r921083179