### PR TITLE
[DOCS-6844] Provide the exact link for Google Docs Integration package download

### DIFF
--- a/google-drive/latest/install/index.md
+++ b/google-drive/latest/install/index.md
@@ -6,7 +6,7 @@ Use these steps to install the Google Docs Integration.
 
 1. Download the installation files.
 
-    For Alfresco Content Services, browse to [Hyland Community](https://community.hyland.com/){:target="_blank"}:
+    For Alfresco Content Services, browse to [Hyland Community](https://community.hyland.com/Products/alfresco/release-notes/release-notes/Alfresco-Google-Docs-Integration-Releases/){:target="_blank"}:
 
     | File | Description |
     | ---- | ----------- |


### PR DESCRIPTION
For a first visiting customer it is not very intuitive to search in Support->Alfresco Downloads->GoogleDocsIntegration. Providing a direct link for this page it is more efficient for the goal of installing the amps