### PR TITLE
[DOCS-6841] Add new Content Services 7.2 redirects

### DIFF
--- a/redirects/7.2/concepts/intrans-metadata-conf-patch.html
+++ b/redirects/7.2/concepts/intrans-metadata-conf-patch.html
@@ -1,0 +1,1 @@
+/search-services/latest/config/transactional/

--- a/redirects/7.2/concepts/intrans-metadata-feature.html
+++ b/redirects/7.2/concepts/intrans-metadata-feature.html
@@ -1,0 +1,1 @@
+/search-services/latest/config/transactional/


### PR DESCRIPTION
Some of the original redirects from the Admin Console were missed in the site launch. Affects Search Services docs.