### PR TITLE
[DOCS-6830] SAML Module 1.2.3 added

### DIFF
--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -84,7 +84,6 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 2.0 | |
 | Identity Service 1.7 | |
 | Identity Service 1.6 | |
-| SAML Module for Alfresco Content Services 1.2.3 | |
 | SAML Module for Alfresco Content Services 1.2.2 | |
 | Alfresco Intelligence Services 1.4 | |
 | Alfresco Content Connector for AWS S3 4.1 | |

--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -84,6 +84,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 2.0 | |
 | Identity Service 1.7 | |
 | Identity Service 1.6 | |
+| SAML Module for Alfresco Content Services 1.2.3 | |
 | SAML Module for Alfresco Content Services 1.2.2 | |
 | Alfresco Intelligence Services 1.4 | |
 | Alfresco Content Connector for AWS S3 4.1 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -81,7 +81,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 1.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
-| SAML Module for Alfresco Content Services 1.2.2 | |
+| SAML Module for Alfresco Content Services 1.2.3 | |
 | Alfresco Intelligence Services 1.4.4 | |
 | Alfresco Intelligence Services 1.4.2 | |
 | Alfresco Content Connector for AWS S3 5.0 | Adds support for AWS Glacier using Cloud storage layer. |
@@ -188,7 +188,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 1.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
-| SAML Module for Alfresco Content Services 1.2.2 | |
+| SAML Module for Alfresco Content Services 1.2.3 | |
 | Alfresco Intelligence Services 1.4.4 | |
 | Alfresco Intelligence Services 1.4.2 | |
 | Alfresco Content Connector for AWS S3 5.0 | Adds support for AWS Glacier using Cloud storage layer. |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -188,6 +188,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 1.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
+| SAML Module for Alfresco Content Services 1.2.2 | |
 | Alfresco Intelligence Services 1.4.4 | |
 | Alfresco Intelligence Services 1.4.2 | |
 | Alfresco Content Connector for AWS S3 5.0 | Adds support for AWS Glacier using Cloud storage layer. |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -188,7 +188,6 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 1.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
-| SAML Module for Alfresco Content Services 1.2.3 | |
 | Alfresco Intelligence Services 1.4.4 | |
 | Alfresco Intelligence Services 1.4.2 | |
 | Alfresco Content Connector for AWS S3 5.0 | Adds support for AWS Glacier using Cloud storage layer. |

--- a/saml-module/latest/support/index.md
+++ b/saml-module/latest/support/index.md
@@ -8,6 +8,8 @@ The following are the supported platforms for SAML Module for Alfresco Content S
 
 | Version | Notes |
 | ------- | ----- |
+| Content Services 7.2 | |
+| Content Services 7.1 | |
 | Content Services 7.0 | |
 | Content Services 6.2 | |
 


### PR DESCRIPTION
SAML Module 1.2.3 added new SAML version to content services, and SAML listed as supported for ACS 7.1 and 7.2.