### PR TITLE
[DOCS-6831] GoogleDocs Integration 3.2.2

### DIFF
--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -98,6 +98,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Outlook Integration 2.9 | |
 | Alfresco Outlook Integration 2.8.1 | |
 | Alfresco Office Services 1.4 | |
+| Alfresco Google Docs Integration 3.2.2 | |
 | Alfresco Google Docs Integration 3.2.1 | |
 | Alfresco Enterprise Viewer 3.3.5 | |
 | Alfresco Content Accelerator 3.4.4 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -94,7 +94,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Collaboration Connector for Teams 1.0 | |
 | Alfresco Outlook Integration 2.9 | |
 | Alfresco Office Services 1.4.1 | |
-| Alfresco Google Docs Integration 3.2.1 | |
+| Alfresco Google Docs Integration 3.2.2 | |
 | Alfresco Content Services SDK 5.1 | |
 | Alfresco Content Services SDK 4.4 | |
 | | |
@@ -201,7 +201,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Collaboration Connector for Teams 1.0 | |
 | Alfresco Outlook Integration 2.9 | |
 | Alfresco Office Services 1.4.1 | |
-| Alfresco Google Docs Integration 3.2.1 | |
+| Alfresco Google Docs Integration 3.2.2 | |
 | Alfresco Content Services SDK 5.1 | |
 | Alfresco Content Services SDK 4.4 | |
 | | |

--- a/google-drive/latest/support/index.md
+++ b/google-drive/latest/support/index.md
@@ -8,6 +8,8 @@ The following are the supported platforms for Google Docs Integration:
 
 | Version | Notes |
 | ------- | ----- |
+| Content Services 7.2 | |
+| Content Services 7.1 | |
 | Content Services 7.0 | |
 | Content Services 6.2 | |
 | Community Edition 7.0 | |


### PR DESCRIPTION
Updated versions supported for ACS 7.1 and 7.2, and for GoogleDocs 3.2.2