### PR TITLE
[DOCS-6858] Update Transform Engine notes with additional clarification

### DIFF
--- a/transform-service/1.2/install/index.md
+++ b/transform-service/1.2/install/index.md
@@ -383,7 +383,7 @@ The Transform Service distribution zip file includes all the files required to p
      -jar alfresco-transform-core-aio-boot-x.y.z.jar
     ```
 
-    > **Note:** You may need to change the paths depending on your operating system.
+    > **Note:** LibreOffice, ImageMagick and Alfresco PDF Renderer binaries needs to be installed on the server where all-in-one core T-Engine is setup. Please see Prerequisites. You may need to change the paths depending on your operating system.
 
     Check the output to ensure that it starts successfully.
 

--- a/transform-service/1.3/install/index.md
+++ b/transform-service/1.3/install/index.md
@@ -484,7 +484,7 @@ before continuing.
      -jar alfresco-transform-core-aio-boot-x.y.z.jar
     ```
 
-    > **Note:** You may need to change the paths depending on your operating system.
+    > **Note:** LibreOffice, ImageMagick and Alfresco PDF Renderer binaries needs to be installed on the server where all-in-one core T-Engine is setup. Please see Prerequisites. You may need to change the paths depending on your operating system.
 
     Check the output to ensure that it starts successfully.
 

--- a/transform-service/1.4/install/index.md
+++ b/transform-service/1.4/install/index.md
@@ -523,7 +523,7 @@ before continuing.
      -jar alfresco-transform-core-aio-boot-x.y.z.jar
     ```
 
-    > **Note:** You may need to change the paths depending on your operating system.
+    > **Note:** LibreOffice, ImageMagick and Alfresco PDF Renderer binaries needs to be installed on the server where all-in-one core T-Engine is setup. Please see Prerequisites. You may need to change the paths depending on your operating system.
 
     Check the output to ensure that it starts successfully.
 

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -594,7 +594,7 @@ before continuing.
      -jar alfresco-transform-core-aio-boot-2.6.x.jar
     ```
 
-    > **Note:** You may need to change the paths depending on your operating system. For example:
+    > **Note:** LibreOffice, ImageMagick and Alfresco PDF Renderer binaries needs to be installed on the server where all-in-one core T-Engine is setup. Please see Prerequisites. You may need to change the paths depending on your operating system. For example:
     > java -DPDFRENDERER_EXE="/usr/local/acs72/alfresco-pdf-renderer/alfresco-pdf-renderer" \
        -DLIBREOFFICE_HOME="/usr/local/acs72/libreoffice" \
        -DIMAGEMAGICK_ROOT="/usr/local/acs72/imagemagick" \


### PR DESCRIPTION
Update the Transform Engine (T-Engine) notes to clarify that LibreOffice, ImageMagick and Alfresco PDF Renderer binaries must be installed with the T-Engine for it to be fully functional.
Most users that i know, were confused at this point and tend to miss important steps outlined in prerequisites. 