### PR TITLE
DOCS-6863 Add unsupported features section for Search Services 2.x

### DIFF
--- a/_data/toc/search-services.yaml
+++ b/_data/toc/search-services.yaml
@@ -15,6 +15,8 @@
           path: '/search-services/latest/upgrade/'
         - title: 'Migrate Solr 4'
           path: '/search-services/latest/upgrade/migrate/'
+        - title: 'Breaking changes from Search Services 1.x'
+          path: '/search-services/latest/upgrade/breaking-changes-1.x/'
     - title: 'Configure'
       pages:
         - title: 'Overview'

--- a/search-services/latest/upgrade/breaking-changes-1.x.md
+++ b/search-services/latest/upgrade/breaking-changes-1.x.md
@@ -1,0 +1,62 @@
+---
+title: Breaking changes from Search Services 1.x
+---
+
+Use this information to upgrade from Search Services 1.x to Search Services 2.x.
+
+## Text indexation for properties of type `d:content`
+
+Search Services 1.x indexed the content of secondary `d:content` properties defined for a custom Content Model Type. This feature is unsupported by Search Services 2.x, so it's required to re-design your Content Model before upgrading.
+
+The following sample Content Model describes a secondary `d:content` property named `doc:attachment`.
+
+```xml
+<type name="doc:sample">
+   <parent>cm:content</parent>
+   <properties>
+      <property name="doc:identifier">
+         <type>d:text</type>
+      </property>
+      <property name="doc:attachment">
+         <type>d:content</type>
+      </property>
+   </properties>
+</type>
+```
+
+When using Search Services 1.x, the content stored in `doc:attachment` is indexed and searchable. From Search Services 2.x, the property `doc:attachment` is indexed but the content is not. So searching by content of the property is not working.
+
+In order to support this Content Model from Search Services 2.x, secondary `d:content` fields must be converted to `associations` with `cm:content` nodes. The following sample Content Model applies this conversion to the previous model.
+
+```xml
+<type name="doc:sample">
+   <parent>cm:content</parent>
+   <properties>
+      <property name="doc:identifier">
+         <type>d:text</type>
+      </property>
+   </properties>
+   <mandatory-aspects>
+      <aspect>cm:attachable</aspect>
+   </mandatory-aspects>
+</type>
+
+
+<aspect name="cm:attachable">
+   <associations>
+      <association name="cm:attachments">
+         <source>
+            <mandatory>false</mandatory>
+            <many>true</many>
+         </source>
+         <target>
+            <class>cm:content</class>
+            <mandatory>false</mandatory>
+            <many>true</many>
+         </target>
+      </association>
+   </associations>
+</aspect>
+```
+
+>> Note that this Content Model modification may also affect to custom integrations, since the results are returned with a different structure.

--- a/search-services/latest/upgrade/breaking-changes-1.x.md
+++ b/search-services/latest/upgrade/breaking-changes-1.x.md
@@ -6,6 +6,8 @@ Use this information when upgrading from Search Services 1.x to Search Services 
 
 ## Text indexation for properties of type `d:content`
 
+Every type from `cm:content` includes a default `d:content` property to store the content. You can declare additional `d:content` properties, or "secondary" properties.
+
 Search Services 1.x indexed the content of secondary `d:content` properties defined for a custom Content Model Type. This feature is unsupported by Search Services 2.x, so it's required to re-design your Content Model before upgrading.
 
 The following sample Content Model describes a secondary `d:content` property named `doc:attachment`:

--- a/search-services/latest/upgrade/breaking-changes-1.x.md
+++ b/search-services/latest/upgrade/breaking-changes-1.x.md
@@ -2,13 +2,13 @@
 title: Breaking changes from Search Services 1.x
 ---
 
-Use this information to upgrade from Search Services 1.x to Search Services 2.x.
+Use this information when upgrading from Search Services 1.x to Search Services 2.x.
 
 ## Text indexation for properties of type `d:content`
 
 Search Services 1.x indexed the content of secondary `d:content` properties defined for a custom Content Model Type. This feature is unsupported by Search Services 2.x, so it's required to re-design your Content Model before upgrading.
 
-The following sample Content Model describes a secondary `d:content` property named `doc:attachment`.
+The following sample Content Model describes a secondary `d:content` property named `doc:attachment`:
 
 ```xml
 <type name="doc:sample">
@@ -26,7 +26,7 @@ The following sample Content Model describes a secondary `d:content` property na
 
 When using Search Services 1.x, the content stored in `doc:attachment` is indexed and searchable. From Search Services 2.x, the property `doc:attachment` is indexed but the content is not. So searching by content of the property is not working.
 
-In order to support this Content Model from Search Services 2.x, secondary `d:content` fields must be converted to `associations` with `cm:content` nodes. The following sample Content Model applies this conversion to the previous model.
+In order to support this Content Model from Search Services 2.x, secondary `d:content` fields must be converted to `associations` with `cm:content` nodes. The following sample Content Model applies this conversion to the previous model:
 
 ```xml
 <type name="doc:sample">
@@ -59,4 +59,4 @@ In order to support this Content Model from Search Services 2.x, secondary `d:co
 </aspect>
 ```
 
->> Note that this Content Model modification may also affect to custom integrations, since the results are returned with a different structure.
+> **Note:** This Content Model modification may also affect custom integrations, since the results are returned with a different structure.


### PR DESCRIPTION
Content Model indexation for secondary properties of type `d:content` is unsupported in Search Services 2.x