### PR TITLE
[DOCS-6861] Add Desktop Sync 1.13 compatibility

### DIFF
--- a/content-services/7.0/support/index.md
+++ b/content-services/7.0/support/index.md
@@ -72,6 +72,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
 | Alfresco Sync Service 3.4 | |
+| Alfresco Desktop Sync 1.13 | |
 | Alfresco Desktop Sync 1.12 | |
 | Alfresco Desktop Sync 1.11 | |
 | Alfresco Desktop Sync 1.10 | |
@@ -188,6 +189,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
 | Alfresco Sync Service 3.4 | |
+| Alfresco Desktop Sync 1.13 | |
 | Alfresco Desktop Sync 1.12 | |
 | Alfresco Desktop Sync 1.11 | |
 | Alfresco Desktop Sync 1.10 | |

--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -70,6 +70,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
+| Alfresco Desktop Sync 1.13 | |
 | Alfresco Desktop Sync 1.12 | |
 | Alfresco Desktop Sync 1.11 | |
 | Alfresco Desktop Sync 1.10 | |
@@ -183,6 +184,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
 | Alfresco Sync Service 3.5 | |
+| Alfresco Desktop Sync 1.13 | |
 | Alfresco Desktop Sync 1.12 | |
 | Alfresco Desktop Sync 1.11 | |
 | Alfresco Desktop Sync 1.10 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -70,6 +70,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
+| Alfresco Desktop Sync 1.13 | |
 | Alfresco Desktop Sync 1.12 | |
 | Alfresco Desktop Sync 1.11 | |
 | Alfresco Desktop Sync 1.10 | |
@@ -177,6 +178,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
+| Alfresco Desktop Sync 1.13 | |
 | Alfresco Desktop Sync 1.12 | |
 | Alfresco Desktop Sync 1.11 | |
 | Alfresco Desktop Sync 1.10 | |


### PR DESCRIPTION
Update Desktop Sync 1.13 compatibility in the ACS 7.0 - 7.2 Supported platforms pages