### PR TITLE
[DOCS-6872] Add Content Services 7.2.x as compatible version for SAP products

### DIFF
--- a/sap-cloud/latest/support/index.md
+++ b/sap-cloud/latest/support/index.md
@@ -7,6 +7,7 @@ The following are the supported platforms for Alfresco Content Connector for SAP
 | Version | Notes |
 | ------- | ----- |
 | **Alfresco** | |
+| Content Services 7.2.x | |
 | Content Services 7.1.x | |
 | Content Services 7.0.x | |
 | Content Services 6.2.x | |

--- a/sap/latest/support/index.md
+++ b/sap/latest/support/index.md
@@ -6,6 +6,7 @@ The following are the supported platforms for Alfresco Content Connector for SAP
 
 | Version | Notes |
 | ------- | ----- |
+| Content Services 7.2.x | |
 | Content Services 7.1.x | |
 | Content Services 7.0.x | |
 | Content Services 6.2.x | |


### PR DESCRIPTION
Fix the compatible ACS versions for SAP products:

- Alfresco Content Connector for SAP Applications 5.2 
- Alfresco Content Connector for SAP Cloud 1.2