### PR TITLE
[DOCS-6854] ACS ADW compatibility fixes

### DIFF
--- a/content-services/7.0/support/index.md
+++ b/content-services/7.0/support/index.md
@@ -223,6 +223,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Services SDK 4.2 | |
 | | |
 | **Applications** | |
+| Alfresco Digital Workspace 2.6 | |
 | Alfresco Digital Workspace 2.5 | |
 | Alfresco Digital Workspace 2.4 | |
 | Alfresco Digital Workspace 2.3 | |

--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -106,7 +106,6 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Services SDK 4.3 | |
 | | |
 | **Applications** | |
-| Alfresco Digital Workspace 2.8 | |
 | Alfresco Digital Workspace 2.7 | |
 | Alfresco Digital Workspace 2.6 | |
 | Alfresco Digital Workspace 2.5 | |


### PR DESCRIPTION
Added ADW 2.6 to ACS 7.0 (in Digital Workspace Release Notes as supported).
Removed ADW 2.8 from ACS 7.1.1 (was not in Digital Workspace Release Notes as supported).

I didn't see other compatibility issues with supported versions.