### PR TITLE
[DOCS-6921] Added note to further clarify what version fo Helm, Kubectl and EKS versions used for helm charts

### DIFF
--- a/content-services/6.0/install/containers/helm.md
+++ b/content-services/6.0/install/containers/helm.md
@@ -14,6 +14,8 @@ The Enterprise configuration deploys the following system:
 
 Alfresco provides tested Helm charts as a "deployment template" for customers who want to take advantage of the container orchestration benefits of Kubernetes. These Helm charts are undergoing continual development and improvement, and shouldn't be used "as is" for your production environments, but should help you save time and effort deploying Content Services for your organization.
 
+>Helm charts are tested using Helm 3.5.4, kubectl 1.18.9 against an EKS cluster running Kubernetes 1.21. For more details, see [ACS Deployment Supported Versions](https://github.com/Alfresco/acs-deployment#versioning){:target="_blank"}.
+
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and don't configure any logging. This design was chosen so that you can install them in a Kubernetes cluster without changes, and they're flexible enough for adopting to your actual environment.
 
 You should use these charts in your environment only as a starting point, and modify them so that Content Services integrates into your infrastructure. You typically want to remove the PostgreSQL container, and connect the `cs-repository` directly to your database (this might require custom images to get the required JDBC driver in the container).

--- a/content-services/6.1/install/containers/helm.md
+++ b/content-services/6.1/install/containers/helm.md
@@ -14,6 +14,8 @@ The Enterprise configuration deploys the following system:
 
 Alfresco provides tested Helm charts as a "deployment template" for customers who want to take advantage of the container orchestration benefits of Kubernetes. These Helm charts are undergoing continual development and improvement, and shouldn't be used "as is" for your production environments, but should help you save time and effort deploying Content Services for your organization.
 
+>Helm charts are tested using Helm 3.5.4, kubectl 1.18.9 against an EKS cluster running Kubernetes 1.21. For more details, see [ACS Deployment Supported Versions](https://github.com/Alfresco/acs-deployment#versioning){:target="_blank"}.
+
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and don't configure any logging. This design was chosen so that you can install them in a Kubernetes cluster without changes, and they're flexible enough for adopting to your actual environment.
 
 You should use these charts in your environment only as a starting point, and modify them so that Content Services integrates into your infrastructure. You typically want to remove the PostgreSQL container, and connect the `cs-repository` directly to your database (this might require custom images to get the required JDBC driver in the container).

--- a/content-services/6.2/install/containers/helm.md
+++ b/content-services/6.2/install/containers/helm.md
@@ -14,6 +14,8 @@ The Enterprise configuration deploys the following system:
 
 Alfresco provides tested Helm charts as a "deployment template" for customers who want to take advantage of the container orchestration benefits of Kubernetes. These Helm charts are undergoing continual development and improvement, and shouldn't be used "as is" for your production environments, but should help you save time and effort deploying Content Services for your organization.
 
+>Helm charts are tested using Helm 3.5.4, kubectl 1.18.9 against an EKS cluster running Kubernetes 1.21. For more details, see [ACS Deployment Supported Versions](https://github.com/Alfresco/acs-deployment#versioning){:target="_blank"}.
+
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and don't configure any logging. This design was chosen so that you can install them in a Kubernetes cluster without changes, and they're flexible enough for adopting to your actual environment.
 
 You should use these charts in your environment only as a starting point, and modify them so that Content Services integrates into your infrastructure. You typically want to remove the PostgreSQL container, and connect the `cs-repository` directly to your database (this might require custom images to get the required JDBC driver in the container).

--- a/content-services/7.0/install/containers/helm.md
+++ b/content-services/7.0/install/containers/helm.md
@@ -17,6 +17,8 @@ The Enterprise configuration deploys the following system:
 
 Alfresco provides tested Helm charts as a "deployment template" for customers who want to take advantage of the container orchestration benefits of Kubernetes. These Helm charts are undergoing continual development and improvement, and shouldn't be used "as is" for your production environments, but should help you save time and effort deploying Content Services for your organization.
 
+>Helm charts are tested using Helm 3.5.4, kubectl 1.18.9 against an EKS cluster running Kubernetes 1.21. For more details, see [ACS Deployment Supported Versions](https://github.com/Alfresco/acs-deployment#versioning){:target="_blank"}.
+
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and don't configure any logging. This design was chosen so that you can install them in a Kubernetes cluster without changes, and they're flexible enough for adopting to your actual environment.
 
 You should use these charts in your environment only as a starting point, and modify them so that Content Services integrates into your infrastructure. You typically want to remove the PostgreSQL container, and connect the `cs-repository` directly to your database (this might require custom images to get the required JDBC driver in the container).

--- a/content-services/7.1/install/containers/helm.md
+++ b/content-services/7.1/install/containers/helm.md
@@ -17,6 +17,8 @@ The Enterprise configuration deploys the following system:
 
 Alfresco provides tested Helm charts as a "deployment template" for customers who want to take advantage of the container orchestration benefits of Kubernetes. These Helm charts are undergoing continual development and improvement, and shouldn't be used "as is" for your production environments, but should help you save time and effort deploying Content Services for your organization.
 
+>Helm charts are tested using Helm 3.5.4, kubectl 1.18.9 against an EKS cluster running Kubernetes 1.21. For more details, see [ACS Deployment Supported Versions](https://github.com/Alfresco/acs-deployment#versioning){:target="_blank"}.
+
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and don't configure any logging. This design was chosen so that you can install them in a Kubernetes cluster without changes, and they're flexible enough for adopting to your actual environment.
 
 You should use these charts in your environment only as a starting point, and modify them so that Content Services integrates into your infrastructure. You typically want to remove the PostgreSQL container, and connect the `cs-repository` directly to your database (this might require custom images to get the required JDBC driver in the container).

--- a/content-services/latest/install/containers/helm.md
+++ b/content-services/latest/install/containers/helm.md
@@ -17,6 +17,8 @@ The Enterprise configuration deploys the following system:
 
 Alfresco provides tested Helm charts as a "deployment template" for customers who want to take advantage of the container orchestration benefits of Kubernetes. These Helm charts are undergoing continual development and improvement, and shouldn't be used "as is" for your production environments, but should help you save time and effort deploying Content Services for your organization.
 
+>Helm charts are tested using Helm 3.5.4, kubectl 1.18.9 against an EKS cluster running Kubernetes 1.21. For more details, see [ACS Deployment Supported Versions](https://github.com/Alfresco/acs-deployment#versioning){:target="_blank"}.
+
 The Helm charts in this repository provide a PostgreSQL database in a Docker container and don't configure any logging. This design was chosen so that you can install them in a Kubernetes cluster without changes, and they're flexible enough for adopting to your actual environment.
 
 You should use these charts in your environment only as a starting point, and modify them so that Content Services integrates into your infrastructure. You typically want to remove the PostgreSQL container, and connect the `cs-repository` directly to your database (this might require custom images to get the required JDBC driver in the container).


### PR DESCRIPTION
Added note to further clarify what version of Helm, Kubectl and EKS is used for helm charts as this documentation is first place users are looking for. This note will provide clearification on tested versions.

This issue is being tracked using https://alfresco.atlassian.net/browse/DOCS-6921