### PR TITLE
Solr Communication Method Secret with ACS 7.2

### DIFF
--- a/search-services/latest/install/options.md
+++ b/search-services/latest/install/options.md
@@ -192,11 +192,11 @@ This task assumes you have:
 
 Use this information to install Search Services on the same machine as Alfresco Content Services without mutual TLS, using HTTP with a secret word in the request header. This means communication between the Repository and Search Services is protected by a shared secret that is passed in a configurable Request HTTP Header.
 
-**Important:** This installation method is only supported when using Content Services 7.1 and above.
+**Important:** This installation method is only supported when using Content Services 7.2 and above.
 
 This task assumes you have:
 
-* Installed Alfresco Content Services 7.1 or above.
+* Installed Alfresco Content Services 7.2 or above.
 * Set the following properties in the `<TOMCAT_HOME>/shared/classes/alfresco-global.properties` file:
 
     ```text


### PR DESCRIPTION
In the current documentation says, that in ordner to use the HTTP communication method with "secret" word in request header  you have to install Alfresco Content Services 7.1 or above.

In Reference to 
https://community.hyland.com/en/blog/posts/83712-upgrading-to-alfresco-content-services-7-2 the "secret" communcation method feature is only available in ACS 7.2 and above.

![image](https://user-images.githubusercontent.com/43071828/191944491-c23c8292-e190-45cb-8737-8b25577cbfc9.png)


I know that it was tested initially by @aborroy with ACS7.1, see https://github.com/AlfrescoLabs/alfresco-solr-comm and he showed this "secret" communication method feature in https://www.youtube.com/watch?v=BSNJz6nd8Xg

but as far as we now, this feature is only available for customers with ACS 7.2. and above.

Could you please verify this?