### PR TITLE
[DOCS-6978] Fix reference to missing class (since Search Services 2.0)

### DIFF
--- a/search-services/latest/config/replication.md
+++ b/search-services/latest/config/replication.md
@@ -57,9 +57,9 @@ As usual, no SSL queries configured go to the slave.
 
 ### Configuring Solr master
 
-The configuration affecting replication is controlled by a single file, `alresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml`. To configure the master server, follow the steps below:
+The configuration affecting replication is controlled by a single file, `alfresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml`. To configure the master server, follow the steps below:
 
-1. Edit the `alresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml` file on the master server to change the default replication handler configuration. Remember to uncomment the `master` section.
+1. Edit the `alfresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml` file on the master server to change the default replication handler configuration. Remember to uncomment the `master` section.
 
     ```xml
     <requestHandler name="/replication" class="solr.ReplicationHandler" > 
@@ -186,7 +186,7 @@ To promote a slave, follow the steps below:
     ![]({% link search-services/images/slave-version.png %})
 
 2. Stop the Solr server on the new master.
-3. In the alresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml file, replace the Solr configuration in the replication handler that defines the slave with the one that defines the master.
+3. In the alfresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml file, replace the Solr configuration in the replication handler that defines the slave with the one that defines the master.
 
     ```xml
     <requestHandler name="/replication" class="solr.ReplicationHandler"> 

--- a/search-services/latest/config/replication.md
+++ b/search-services/latest/config/replication.md
@@ -62,7 +62,7 @@ The configuration affecting replication is controlled by a single file, `alresc
 1. Edit the `alresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml` file on the master server to change the default replication handler configuration. Remember to uncomment the `master` section.
 
     ```xml
-    <requestHandler name="/replication" class="org.alfresco.solr.handler.AlfrescoReplicationHandler" > 
+    <requestHandler name="/replication" class="solr.ReplicationHandler" > 
         <!--
            To enable simple master/slave replication, uncomment one of the 
            sections below, depending on whether this solr instance should be
@@ -105,7 +105,7 @@ Here again, the solrconfig.xml file controls the configuration affecting replica
 1. Uncomment the `slave` section.
 
     ```xml
-    <requestHandler name="/replication" class="org.alfresco.solr.handler.AlfrescoReplicationHandler" > 
+    <requestHandler name="/replication" class="solr.ReplicationHandler" > 
         <!--
            To enable simple master/slave replication, uncomment one of the 
            sections below, depending on whether this solr instance should be
@@ -189,7 +189,7 @@ To promote a slave, follow the steps below:
 3. In the alresco-search-services/solrhome/templates/re-rank/conf/solrconfig.xml file, replace the Solr configuration in the replication handler that defines the slave with the one that defines the master.
 
     ```xml
-    <requestHandler name="/replication" class="org.alfresco.solr.handler.AlfrescoReplicationHandler"> 
+    <requestHandler name="/replication" class="solr.ReplicationHandler"> 
         <!--
            To enable simple master/slave replication, uncomment one of the 
            sections below, depending on whether this solr instance should be


### PR DESCRIPTION
That class has been removed from Search Services 2.0, anyone using that configuration will get an error message.