### PR TITLE
[DOCS-6747] ACS Helm install updates based on PR #356, #357, #358

### DIFF
--- a/content-services/6.2/install/containers/helm.md
+++ b/content-services/6.2/install/containers/helm.md
@@ -169,21 +169,30 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
    kubectl apply -f external-dns.yaml -n kube-system
    ```
 
-5. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
+5. List node groups for your cluster and make note of nodegroup name `YOUR-NODEGROUP` (replace `YOUR-CLUSTER-NAME` with
+   the name you gave your cluster).
+
+   ```bash
+   bash aws eks list-nodegroups --cluster-name YOUR-CLUSTER-NAME
+   ```
+
+6. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the
+   name you gave your cluster and `YOUR-NODEGROUP` with your nodegroup name):
 
     ```bash
-    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name linux-nodes --query "nodegroup.nodeRole" --output text
+    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name YOUR-NODEGROUP --query "nodegroup.nodeRole" --output text
     ```
 
-6. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
+7. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the
+   previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
 
-    ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
+   ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
 
 #### File system
 
 1. Create an Elastic File System in the VPC created by EKS using [these steps](https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html){:target="_blank"} ensuring a mount target is created in each subnet. Make a note of the File System ID (circled in the screenshot below):
 
-    ![EFS]({% link content-services/images/eks-efs.png %})
+   ![EFS]({% link content-services/images/eks-efs.png %})
 
 2. Find the ID of the VPC created when your cluster was built (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
 
@@ -199,17 +208,24 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
 
 4. Go to the [Security Groups section of the VPC Console](https://console.aws.amazon.com/vpc/home#SecurityGroups){:target="_blank"} and search for the VPC using the ID retrieved in step 2, as shown in the screenshot below:
 
-    ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
+   ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
 
 5. Click on the default security group for the VPC (highlighted in the screenshot above) and add an inbound rule for NFS traffic from the VPC CIDR range as shown in the screenshot below:
 
-    ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
+   ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
 
-6. Deploy an NFS Client Provisioner with Helm using the following command (replace `EFS-DNS-NAME` with the string `file-system-id.efs.aws-region.amazonaws.com` where the `file-system-id` is the ID retrieved in step 1 and `aws-region` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
+6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string
+   `FILE-SYSTEM-ID.efs.AWS-REGION.amazonaws.com` where the `FILE-SYSTEM-ID` is the ID retrieved in step 1 and
+   `AWS-REGION` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
 
-    ```bash
-    helm install alfresco-nfs-provisioner stable/nfs-client-provisioner --set nfs.server="EFS-DNS-NAME" --set nfs.path="/" --set storageClass.name="nfs-client" --set storageClass.archiveOnDelete=false -n kube-system
-    ```
+   ```bash
+   helm repo add  nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
+   helm install alfresco-nfs-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+   --set nfs.server="EFS-DNS-NAME" \
+   --set nfs.path="/" \
+   --set storageClass.name="nfs-client" \
+   --set storageClass.archiveOnDelete=false -n kube-system   
+   ```
 
 ### Deploy Content Services
 
@@ -281,7 +297,7 @@ kubectl create namespace alfresco
 3. Deploy the ingress (replace `ACM_CERTIFICATE_ARN` and `YOUR-DOMAIN-NAME` with the ARN of the certificate and hosted zone created earlier in the DNS section):
 
     ```bash
-    helm install acs-ingress ingress-nginx/ingress-nginx \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1\
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \
@@ -297,7 +313,7 @@ kubectl create namespace alfresco
     --namespace alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 #### Docker registry secret
 
@@ -352,7 +368,7 @@ helm install acs alfresco/alfresco-content-services \
     --namespace=alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 ### Access
 
@@ -464,9 +480,9 @@ The easiest way to troubleshoot issues on a Kubernetes deployment is to use the 
 
 5. Select `alfresco` from the **Namespace** menu, click **Pods**, and then the pod name.
 
-    To view the logs, press the **Menu** icon in the toolbar as highlighted below:
+   To view the logs, press the **Menu** icon in the toolbar as highlighted below:
 
-    ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
+   ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
 
 ### Port-forwarding to a pod
 

--- a/content-services/7.0/install/containers/helm.md
+++ b/content-services/7.0/install/containers/helm.md
@@ -172,21 +172,30 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
    kubectl apply -f external-dns.yaml -n kube-system
    ```
 
-5. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
+5. List node groups for your cluster and make note of nodegroup name `YOUR-NODEGROUP` (replace `YOUR-CLUSTER-NAME` with
+   the name you gave your cluster).
+
+   ```bash
+   bash aws eks list-nodegroups --cluster-name YOUR-CLUSTER-NAME
+   ```
+
+6. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the
+   name you gave your cluster and `YOUR-NODEGROUP` with your nodegroup name):
 
     ```bash
-    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name linux-nodes --query "nodegroup.nodeRole" --output text
+    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name YOUR-NODEGROUP --query "nodegroup.nodeRole" --output text
     ```
 
-6. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
+7. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the
+   previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
 
-    ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
+   ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
 
 #### File system
 
 1. Create an Elastic File System in the VPC created by EKS using [these steps](https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html){:target="_blank"} ensuring a mount target is created in each subnet. Make a note of the File System ID (circled in the screenshot below):
 
-    ![EFS]({% link content-services/images/eks-efs.png %})
+   ![EFS]({% link content-services/images/eks-efs.png %})
 
 2. Find the ID of the VPC created when your cluster was built (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
 
@@ -202,17 +211,24 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
 
 4. Go to the [Security Groups section of the VPC Console](https://console.aws.amazon.com/vpc/home#SecurityGroups){:target="_blank"} and search for the VPC using the ID retrieved in step 2, as shown in the screenshot below:
 
-    ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
+   ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
 
 5. Click on the default security group for the VPC (highlighted in the screenshot above) and add an inbound rule for NFS traffic from the VPC CIDR range as shown in the screenshot below:
 
-    ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
+   ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
 
-6. Deploy an NFS Client Provisioner with Helm using the following command (replace `EFS-DNS-NAME` with the string `file-system-id.efs.aws-region.amazonaws.com` where the `file-system-id` is the ID retrieved in step 1 and `aws-region` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
+6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string
+   `FILE-SYSTEM-ID.efs.AWS-REGION.amazonaws.com` where the `FILE-SYSTEM-ID` is the ID retrieved in step 1 and
+   `AWS-REGION` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
 
-    ```bash
-    helm install alfresco-nfs-provisioner stable/nfs-client-provisioner --set nfs.server="EFS-DNS-NAME" --set nfs.path="/" --set storageClass.name="nfs-client" --set storageClass.archiveOnDelete=false -n kube-system
-    ```
+   ```bash
+   helm repo add  nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
+   helm install alfresco-nfs-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+   --set nfs.server="EFS-DNS-NAME" \
+   --set nfs.path="/" \
+   --set storageClass.name="nfs-client" \
+   --set storageClass.archiveOnDelete=false -n kube-system   
+   ```
 
 ### Deploy Content Services
 
@@ -284,7 +300,7 @@ kubectl create namespace alfresco
 3. Deploy the ingress (replace `ACM_CERTIFICATE_ARN` and `YOUR-DOMAIN-NAME` with the ARN of the certificate and hosted zone created earlier in the DNS section):
 
     ```bash
-    helm install acs-ingress ingress-nginx/ingress-nginx \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1\
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \
@@ -300,7 +316,7 @@ kubectl create namespace alfresco
     --namespace alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 #### Docker registry secret
 
@@ -355,7 +371,7 @@ helm install acs alfresco/alfresco-content-services \
     --namespace=alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 ### Access
 
@@ -467,9 +483,9 @@ The easiest way to troubleshoot issues on a Kubernetes deployment is to use the 
 
 5. Select `alfresco` from the **Namespace** menu, click **Pods**, and then the pod name.
 
-    To view the logs, press the **Menu** icon in the toolbar as highlighted below:
+   To view the logs, press the **Menu** icon in the toolbar as highlighted below:
 
-    ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
+   ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
 
 ### Port-forwarding to a pod
 

--- a/content-services/7.1/install/containers/helm.md
+++ b/content-services/7.1/install/containers/helm.md
@@ -161,21 +161,30 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
    kubectl apply -f external-dns.yaml -n kube-system
    ```
 
-5. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
+5. List node groups for your cluster and make note of nodegroup name `YOUR-NODEGROUP` (replace `YOUR-CLUSTER-NAME` with
+   the name you gave your cluster).
+
+   ```bash
+   bash aws eks list-nodegroups --cluster-name YOUR-CLUSTER-NAME
+   ```
+
+6. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the
+   name you gave your cluster and `YOUR-NODEGROUP` with your nodegroup name):
 
     ```bash
-    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name linux-nodes --query "nodegroup.nodeRole" --output text
+    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name YOUR-NODEGROUP --query "nodegroup.nodeRole" --output text
     ```
 
-6. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
+7. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the
+   previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
 
-    ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
+   ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
 
 #### File system
 
 1. Create an Elastic File System in the VPC created by EKS using [these steps](https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html){:target="_blank"} ensuring a mount target is created in each subnet. Make a note of the File System ID (circled in the screenshot below):
 
-    ![EFS]({% link content-services/images/eks-efs.png %})
+   ![EFS]({% link content-services/images/eks-efs.png %})
 
 2. Find the ID of the VPC created when your cluster was built (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
 
@@ -191,13 +200,15 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
 
 4. Go to the [Security Groups section of the VPC Console](https://console.aws.amazon.com/vpc/home#SecurityGroups){:target="_blank"} and search for the VPC using the ID retrieved in step 2, as shown in the screenshot below:
 
-    ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
+   ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
 
 5. Click on the default security group for the VPC (highlighted in the screenshot above) and add an inbound rule for NFS traffic from the VPC CIDR range as shown in the screenshot below:
 
-    ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
+   ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
 
-6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string `file-system-id.efs.aws-region.amazonaws.com` where the `file-system-id` is the ID retrieved in step 1 and `aws-region` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
+6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string
+   `FILE-SYSTEM-ID.efs.AWS-REGION.amazonaws.com` where the `FILE-SYSTEM-ID` is the ID retrieved in step 1 and
+   `AWS-REGION` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
 
     ```bash
     helm repo add stable https://kubernetes-charts.storage.googleapis.com
@@ -274,7 +285,7 @@ kubectl create namespace alfresco
 3. Deploy the ingress (replace `ACM_CERTIFICATE_ARN` and `YOUR-DOMAIN-NAME` with the ARN of the certificate and hosted zone created earlier in the DNS section):
 
     ```bash
-    helm install acs-ingress ingress-nginx/ingress-nginx \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1\
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \
@@ -290,7 +301,7 @@ kubectl create namespace alfresco
     --namespace alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 #### Docker registry secret
 
@@ -359,7 +370,7 @@ helm install acs alfresco/alfresco-content-services \
     --namespace=alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 ### Access
 
@@ -471,9 +482,9 @@ The easiest way to troubleshoot issues on a Kubernetes deployment is to use the 
 
 5. Select `alfresco` from the **Namespace** menu, click **Pods**, and then the pod name.
 
-    To view the logs, press the **Menu** icon in the toolbar as highlighted below:
+   To view the logs, press the **Menu** icon in the toolbar as highlighted below:
 
-    ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
+   ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
 
 ### Port-forwarding to a pod
 

--- a/content-services/7.2/install/containers/helm.md
+++ b/content-services/7.2/install/containers/helm.md
@@ -161,21 +161,30 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
    kubectl apply -f external-dns.yaml -n kube-system
    ```
 
-5. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
+5. List node groups for your cluster and make note of nodegroup name `YOUR-NODEGROUP` (replace `YOUR-CLUSTER-NAME` with
+   the name you gave your cluster).
+
+   ```bash
+   bash aws eks list-nodegroups --cluster-name YOUR-CLUSTER-NAME
+   ```
+
+6. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the
+   name you gave your cluster and `YOUR-NODEGROUP` with your nodegroup name):
 
     ```bash
-    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name linux-nodes --query "nodegroup.nodeRole" --output text
+    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name YOUR-NODEGROUP --query "nodegroup.nodeRole" --output text
     ```
 
-6. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
+7. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the
+   previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
 
-    ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
+   ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
 
 #### File system
 
 1. Create an Elastic File System in the VPC created by EKS using [these steps](https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html){:target="_blank"} ensuring a mount target is created in each subnet. Make a note of the File System ID (circled in the screenshot below):
 
-    ![EFS]({% link content-services/images/eks-efs.png %})
+   ![EFS]({% link content-services/images/eks-efs.png %})
 
 2. Find the ID of the VPC created when your cluster was built (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
 
@@ -191,13 +200,15 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
 
 4. Go to the [Security Groups section of the VPC Console](https://console.aws.amazon.com/vpc/home#SecurityGroups){:target="_blank"} and search for the VPC using the ID retrieved in step 2, as shown in the screenshot below:
 
-    ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
+   ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
 
 5. Click on the default security group for the VPC (highlighted in the screenshot above) and add an inbound rule for NFS traffic from the VPC CIDR range as shown in the screenshot below:
 
-    ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
+   ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
 
-6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string `file-system-id.efs.aws-region.amazonaws.com` where the `file-system-id` is the ID retrieved in step 1 and `aws-region` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
+6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string
+   `FILE-SYSTEM-ID.efs.AWS-REGION.amazonaws.com` where the `FILE-SYSTEM-ID` is the ID retrieved in step 1 and
+   `AWS-REGION` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
 
     ```bash
     helm repo add stable https://kubernetes-charts.storage.googleapis.com
@@ -274,7 +285,7 @@ kubectl create namespace alfresco
 3. Deploy the ingress (replace `ACM_CERTIFICATE_ARN` and `YOUR-DOMAIN-NAME` with the ARN of the certificate and hosted zone created earlier in the DNS section):
 
     ```bash
-    helm install acs-ingress ingress-nginx/ingress-nginx \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1\
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \
@@ -290,7 +301,7 @@ kubectl create namespace alfresco
     --namespace alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 #### Docker registry secret
 
@@ -359,7 +370,7 @@ helm install acs alfresco/alfresco-content-services \
     --namespace=alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 ### Access
 
@@ -471,9 +482,9 @@ The easiest way to troubleshoot issues on a Kubernetes deployment is to use the 
 
 5. Select `alfresco` from the **Namespace** menu, click **Pods**, and then the pod name.
 
-    To view the logs, press the **Menu** icon in the toolbar as highlighted below:
+   To view the logs, press the **Menu** icon in the toolbar as highlighted below:
 
-    ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
+   ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
 
 ### Port-forwarding to a pod
 

--- a/content-services/latest/install/containers/helm.md
+++ b/content-services/latest/install/containers/helm.md
@@ -161,21 +161,30 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
    kubectl apply -f external-dns.yaml -n kube-system
    ```
 
-5. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
+5. List node groups for your cluster and make note of nodegroup name `YOUR-NODEGROUP` (replace `YOUR-CLUSTER-NAME` with
+   the name you gave your cluster).
+
+   ```bash
+   bash aws eks list-nodegroups --cluster-name YOUR-CLUSTER-NAME
+   ```
+
+6. Find the name of the role used by the nodes by running the following command (replace `YOUR-CLUSTER-NAME` with the
+   name you gave your cluster and `YOUR-NODEGROUP` with your nodegroup name):
 
     ```bash
-    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name linux-nodes --query "nodegroup.nodeRole" --output text
+    aws eks describe-nodegroup --cluster-name YOUR-CLUSTER-NAME --nodegroup-name YOUR-NODEGROUP --query "nodegroup.nodeRole" --output text
     ```
 
-6. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
+7. In the [IAM console](https://console.aws.amazon.com/iam/home){:target="_blank"} find the role discovered in the
+   previous step and attach the **AmazonRoute53FullAccess** managed policy as shown in the screenshot below:
 
-    ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
+   ![Attach Policy]({% link content-services/images/eks-attach-policy.png %})
 
 #### File system
 
 1. Create an Elastic File System in the VPC created by EKS using [these steps](https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html){:target="_blank"} ensuring a mount target is created in each subnet. Make a note of the File System ID (circled in the screenshot below):
 
-    ![EFS]({% link content-services/images/eks-efs.png %})
+   ![EFS]({% link content-services/images/eks-efs.png %})
 
 2. Find the ID of the VPC created when your cluster was built (replace `YOUR-CLUSTER-NAME` with the name you gave your cluster):
 
@@ -191,13 +200,15 @@ Now we have an EKS cluster up and running, there are a few one time steps we nee
 
 4. Go to the [Security Groups section of the VPC Console](https://console.aws.amazon.com/vpc/home#SecurityGroups){:target="_blank"} and search for the VPC using the ID retrieved in step 2, as shown in the screenshot below:
 
-    ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
+   ![VPC Default Security Group]({% link content-services/images/eks-vpc-security-group.png %})
 
 5. Click on the default security group for the VPC (highlighted in the screenshot above) and add an inbound rule for NFS traffic from the VPC CIDR range as shown in the screenshot below:
 
-    ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
+   ![NFS Inbound Rules]({% link content-services/images/eks-nfs-inbound-rules.png %})
 
-6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string `file-system-id.efs.aws-region.amazonaws.com` where the `file-system-id` is the ID retrieved in step 1 and `aws-region` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
+6. Deploy an NFS Client Provisioner with Helm using the following commands (replace `EFS-DNS-NAME` with the string
+   `FILE-SYSTEM-ID.efs.AWS-REGION.amazonaws.com` where the `FILE-SYSTEM-ID` is the ID retrieved in step 1 and
+   `AWS-REGION` is the region you're using, e.g. `fs-72f5e4f1.efs.us-east-1.amazonaws.com`):
 
     ```bash
     helm repo add stable https://kubernetes-charts.storage.googleapis.com
@@ -274,7 +285,7 @@ kubectl create namespace alfresco
 3. Deploy the ingress (replace `ACM_CERTIFICATE_ARN` and `YOUR-DOMAIN-NAME` with the ARN of the certificate and hosted zone created earlier in the DNS section):
 
     ```bash
-    helm install acs-ingress ingress-nginx/ingress-nginx \
+    helm install acs-ingress ingress-nginx/ingress-nginx --version=3.7.1\
     --set controller.scope.enabled=true \
     --set controller.scope.namespace=alfresco \
     --set rbac.create=true \
@@ -290,7 +301,7 @@ kubectl create namespace alfresco
     --namespace alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 #### Docker registry secret
 
@@ -359,7 +370,7 @@ helm install acs alfresco/alfresco-content-services \
     --namespace=alfresco
     ```
 
-    > **Note:** The command will wait until the deployment is ready.
+   > **Note:** The command will wait until the deployment is ready.
 
 ### Access
 
@@ -471,9 +482,9 @@ The easiest way to troubleshoot issues on a Kubernetes deployment is to use the 
 
 5. Select `alfresco` from the **Namespace** menu, click **Pods**, and then the pod name.
 
-    To view the logs, press the **Menu** icon in the toolbar as highlighted below:
+   To view the logs, press the **Menu** icon in the toolbar as highlighted below:
 
-    ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
+   ![Kubernetes Dashboard]({% link content-services/images/k8s-dashboard.png %})
 
 ### Port-forwarding to a pod
 


### PR DESCRIPTION
Helm install updates for 6.2 to latest based on following external PRs:

* nodegroup is not linux-nodes, need to find name of node group created as part of cluster creation: #356 
* Changes needed for acs-ingress install: #357 
* Fixes for nfs-provisioner in K8 1.20 and later: #358
  