### PR TITLE
[DOCS-6966] Updates to ACS 7.3 Install section

### DIFF
--- a/content-services/latest/install/containers/customize.md
+++ b/content-services/latest/install/containers/customize.md
@@ -40,13 +40,13 @@ You now need to install the AMP files into the Alfresco Content Repository image
     For example, if you're using `docker-compose.yml`, you'll find on [line 15](https://github.com/Alfresco/acs-deployment/blob/master/docker-compose/docker-compose.yml#L15){:target="_blank"}:
 
     ```bash
-    quay.io/alfresco/alfresco-content-repository:7.2.0
+    quay.io/alfresco/alfresco-content-repository:7.3.0
     ```
 
 3. Add the following Docker commands to the `repository/Dockerfile` file and save it. Make sure that you change the image name and tag to match the above step:
 
     ```Dockerfile
-    FROM quay.io/alfresco/alfresco-content-repository:7.2.0
+    FROM quay.io/alfresco/alfresco-content-repository:7.3.0
 
     # Customize container: install amps
 
@@ -76,23 +76,23 @@ You now need to install the AMP files into the Alfresco Content Repository image
 
 4. Build the image, making sure you give the image an appropriate name and tag, so you can easily identify it later.
 
-    In the example, replace `myregistrydomain/my-custom-alfresco-content-repository:7.2` and `myregistrydomain/my-custom-alfresco-content-repository:latest` with your own Docker registry, image name, and tag:
+    In the example, replace `myregistrydomain/my-custom-alfresco-content-repository:7.3` and `myregistrydomain/my-custom-alfresco-content-repository:latest` with your own Docker registry, image name, and tag:
 
     ```bash
-    docker build repository -t myregistrydomain/my-custom-alfresco-content-repository:7.2 -t myregistrydomain/my-custom-alfresco-content-repository:latest
+    docker build repository -t myregistrydomain/my-custom-alfresco-content-repository:7.3 -t myregistrydomain/my-custom-alfresco-content-repository:latest
     ```
 
     Once the image build is complete, you should see success messages:
 
     ```text
     Successfully built 632eda3ea296
-    Successfully tagged myregistrydomain/my-custom-alfresco-content-repository:7.2
+    Successfully tagged myregistrydomain/my-custom-alfresco-content-repository:7.3
     Successfully tagged myregistrydomain/my-custom-alfresco-content-repository:latest
     ```
 
 5. Replace the image used by the **alfresco** service in the Docker Compose file you chose in step 1.
 
-    For example, replace `image: quay.io/alfresco/alfresco-content-repository:7.2.0` with `image: myregistrydomain/my-custom-alfresco-content-repository:7.2`:
+    For example, replace `image: quay.io/alfresco/alfresco-content-repository:7.3.0` with `image: myregistrydomain/my-custom-alfresco-content-repository:7.3`:
 
 6. Save the file.
 
@@ -105,13 +105,13 @@ Let's repeat the process for the Alfresco Share image.
     For example, if you're using `docker-compose.yml`, you'll find on [line 93](https://github.com/Alfresco/acs-deployment/blob/master/docker-compose/docker-compose.yml#L93){:target="_blank"}:
 
     ```bash
-    quay.io/alfresco/alfresco-share:7.2.0
+    quay.io/alfresco/alfresco-share:7.3.0
     ```
 
 2. Add the following Docker commands to the `share/Dockerfile` file and save it. Make sure you change the image name and tag to match the above step:
 
     ```Dockerfile
-    FROM quay.io/alfresco/alfresco-share:7.2.0
+    FROM quay.io/alfresco/alfresco-share:7.3.0
 
     ARG TOMCAT_DIR=/usr/local/tomcat
 
@@ -125,23 +125,23 @@ Let's repeat the process for the Alfresco Share image.
 
 3. Build the image, making sure you give the image an appropriate name and tag, so you can easily identify it later.
 
-    In the following command, replace `myregistrydomain/my-custom-alfresco-share:7.2` and `myregistrydomain/my-custom-alfresco-share:latest` with your own Docker registry, image name and tag:
+    In the following command, replace `myregistrydomain/my-custom-alfresco-share:7.3` and `myregistrydomain/my-custom-alfresco-share:latest` with your own Docker registry, image name and tag:
 
     ```bash
-    docker build share -t myregistrydomain/my-custom-alfresco-share:7.2 -t myregistrydomain/my-custom-alfresco-share:latest
+    docker build share -t myregistrydomain/my-custom-alfresco-share:7.3 -t myregistrydomain/my-custom-alfresco-share:latest
     ```
 
     Once the image build is complete, you should see success messages:
 
     ```text
     Successfully built 6d5ee67935da
-    Successfully tagged myregistrydomain/my-custom-alfresco-share:7.2
+    Successfully tagged myregistrydomain/my-custom-alfresco-share:7.3
     Successfully tagged myregistrydomain/my-custom-alfresco-share:latest
     ```
 
 4. Replace the image used by the **share** service in the Docker Compose file you chose in the previous section.
 
-    For example, replace `image: quay.io/alfresco/alfresco-share:7.2.0` with `image: myregistrydomain/my-custom-alfresco-share:7.2`
+    For example, replace `image: quay.io/alfresco/alfresco-share:7.3.0` with `image: myregistrydomain/my-custom-alfresco-share:7.3`
 
 5. Save the file.
 

--- a/content-services/latest/install/containers/docker-compose.md
+++ b/content-services/latest/install/containers/docker-compose.md
@@ -110,11 +110,11 @@ Use this information to verify that the system started correctly, and to clean u
         Container                        Repository                                     Tag                 Image Id            Size
         ------------------------------------------------------------------------------------------------------------------------------
         acs-trial_activemq-1             alfresco/alfresco-activemq                     5.16.1              e9dd27ce1a5d        716.3 MB
-        acs-trial_alfresco-1             quay.io/alfresco/alfresco-content-repository   7.2.0               945933739097        1.437 GB
+        acs-trial_alfresco-1             quay.io/alfresco/alfresco-content-repository   7.3.0               945933739097        1.437 GB
         acs-trial_digital-workspace-1    quay.io/alfresco/alfresco-digital-workspace    2.6.0               1a2eaa5bf7a9        572.9 MB
         acs-trial_postgres-1             postgres                                       13.3                b2fcd079c1d4        314.7 MB
         acs-trial_proxy-1                alfresco/alfresco-acs-nginx                    3.2.0               da6d34dd9386        21.86 MB
-        acs-trial_share-1                quay.io/alfresco/alfresco-share                7.2.0               837b363e02af        758.7 MB
+        acs-trial_share-1                quay.io/alfresco/alfresco-share                7.3.0               837b363e02af        758.7 MB
         acs-trial_shared-file-store-1    quay.io/alfresco/alfresco-shared-file-store    0.16.1              dee75e9ffa5b        651.2 MB
         acs-trial_solr6-1                quay.io/alfresco/search-services               2.1.0               5800e8a31bdd        890.8 MB
         acs-trial_sync-service-1         quay.io/alfresco/service-sync                  3.5.0               7c0cee15f516        703.2 MB
@@ -248,9 +248,9 @@ Use this information to verify that the system started correctly, and to clean u
         Removing acs-trial_shared-file-store_1  ... done
         Removing acs-trial_activemq_1           ... done
         Removing network acs-trial_default
-        Removing image quay.io/alfresco/alfresco-content-repository:7.2.0
+        Removing image quay.io/alfresco/alfresco-content-repository:7.3.0
         Removing image quay.io/alfresco/alfresco-shared-file-store:0.16.1
-        Removing image quay.io/alfresco/alfresco-share:7.2.0
+        Removing image quay.io/alfresco/alfresco-share:7.3.0
         Removing image postgres:13.3
         Removing image quay.io/alfresco/search-services:2.1.0
         Removing image alfresco/alfresco-activemq:5.16.1
@@ -397,7 +397,7 @@ The Docker Compose file provides some default configuration. This section lists 
 | FILE_STORE_URL | Shared file store URL (in this case, the name of the container is used) |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | Name of the queue. The default value is `org.alfresco.transform.engine.aio.acs` |
 | PDFRENDERER_EXE | Location of the PDF Renderer binary. The default value is `/usr/bin/alfresco-pdf-renderer` |
-| LIBREOFFICE_HOME | Location of the LibreOffice installation. The default value is `/opt/libreoffice7.2` |
+| LIBREOFFICE_HOME | Location of the LibreOffice installation. The default value is `/opt/libreoffice7.3` |
 | IMAGEMAGICK_ROOT | Location of the ImageMagick installation. The default value is `/usr/lib64/ImageMagick-7.0.10` |
 | IMAGEMAGICK_DYN | Location of the ImageMagick dynamic libraries. The default value is `/usr/lib64/ImageMagick-7.0.10/lib` |
 | IMAGEMAGICK_EXE | Location of the ImageMagick binary. The default value is `/usr/bin/convert` |

--- a/content-services/latest/install/containers/docker-compose.md
+++ b/content-services/latest/install/containers/docker-compose.md
@@ -10,11 +10,11 @@ To deploy Content Services using Docker Compose, download and install [Docker](h
 
 1. Download the `docker-compose.yml` file by accessing the Content Services [Download Trial](https://www.alfresco.com/platform/content-services-ecm/trial/download){:target="_blank"} page, which will give you a 30-day license.
 
-    If you already have a valid license file for Content Services 7.3, you can apply it directly to the running system. See [Uploading a new license]({% link content-services/latest/admin/license.md %}) for more details.
+    If you already have a valid license file for Content Services 7.2, you can apply it directly to the running system. See [Uploading a new license]({% link content-services/latest/admin/license.md %}) for more details.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
 
-    > **Note:** The Download Trial is usually updated for *major.minor* versions of Content Services. The latest published version on our website is labelled *Version 7.3 - March 2022)*.
+    > **Note:** The Download Trial is usually updated for *major.minor* versions of Content Services. The latest published version on our website is labelled *Version 7.2 - March 2022)*.
 
 2. Save the `docker-compose.yml` file in a local folder.
 
@@ -104,17 +104,17 @@ Use this information to verify that the system started correctly, and to clean u
         docker-compose images
         ```
 
-        You should see a list of the services defined in your `docker-compose.yml` file (below are the tags used in the latest 7.3.0 release):
+        You should see a list of the services defined in your `docker-compose.yml` file (below are the tags used in the latest 7.2.0 release):
 
         ```text
         Container                        Repository                                     Tag                 Image Id            Size
         ------------------------------------------------------------------------------------------------------------------------------
         acs-trial_activemq-1             alfresco/alfresco-activemq                     5.16.1              e9dd27ce1a5d        716.3 MB
-        acs-trial_alfresco-1             quay.io/alfresco/alfresco-content-repository   7.3.0               945933739097        1.437 GB
+        acs-trial_alfresco-1             quay.io/alfresco/alfresco-content-repository   7.2.0               945933739097        1.437 GB
         acs-trial_digital-workspace-1    quay.io/alfresco/alfresco-digital-workspace    2.6.0               1a2eaa5bf7a9        572.9 MB
         acs-trial_postgres-1             postgres                                       13.3                b2fcd079c1d4        314.7 MB
         acs-trial_proxy-1                alfresco/alfresco-acs-nginx                    3.2.0               da6d34dd9386        21.86 MB
-        acs-trial_share-1                quay.io/alfresco/alfresco-share                7.3.0               837b363e02af        758.7 MB
+        acs-trial_share-1                quay.io/alfresco/alfresco-share                7.2.0               837b363e02af        758.7 MB
         acs-trial_shared-file-store-1    quay.io/alfresco/alfresco-shared-file-store    0.16.1              dee75e9ffa5b        651.2 MB
         acs-trial_solr6-1                quay.io/alfresco/search-services               2.1.0               5800e8a31bdd        890.8 MB
         acs-trial_sync-service-1         quay.io/alfresco/service-sync                  3.5.0               7c0cee15f516        703.2 MB
@@ -248,9 +248,9 @@ Use this information to verify that the system started correctly, and to clean u
         Removing acs-trial_shared-file-store_1  ... done
         Removing acs-trial_activemq_1           ... done
         Removing network acs-trial_default
-        Removing image quay.io/alfresco/alfresco-content-repository:7.3.0
+        Removing image quay.io/alfresco/alfresco-content-repository:7.2.0
         Removing image quay.io/alfresco/alfresco-shared-file-store:0.16.1
-        Removing image quay.io/alfresco/alfresco-share:7.3.0
+        Removing image quay.io/alfresco/alfresco-share:7.2.0
         Removing image postgres:13.3
         Removing image quay.io/alfresco/search-services:2.1.0
         Removing image alfresco/alfresco-activemq:5.16.1

--- a/content-services/latest/install/containers/docker-compose.md
+++ b/content-services/latest/install/containers/docker-compose.md
@@ -397,7 +397,7 @@ The Docker Compose file provides some default configuration. This section lists 
 | FILE_STORE_URL | Shared file store URL (in this case, the name of the container is used) |
 | TRANSFORM_ENGINE_REQUEST_QUEUE | Name of the queue. The default value is `org.alfresco.transform.engine.aio.acs` |
 | PDFRENDERER_EXE | Location of the PDF Renderer binary. The default value is `/usr/bin/alfresco-pdf-renderer` |
-| LIBREOFFICE_HOME | Location of the LibreOffice installation. The default value is `/opt/libreoffice7.3` |
+| LIBREOFFICE_HOME | Location of the LibreOffice installation. The default value is `/opt/libreoffice7.2` |
 | IMAGEMAGICK_ROOT | Location of the ImageMagick installation. The default value is `/usr/lib64/ImageMagick-7.0.10` |
 | IMAGEMAGICK_DYN | Location of the ImageMagick dynamic libraries. The default value is `/usr/lib64/ImageMagick-7.0.10/lib` |
 | IMAGEMAGICK_EXE | Location of the ImageMagick binary. The default value is `/usr/bin/convert` |

--- a/content-services/latest/install/zip/additions.md
+++ b/content-services/latest/install/zip/additions.md
@@ -56,7 +56,6 @@ Use this information to review the components or modules that integrate Content 
 | Search Services | |
 | Federation Services | |
 | Identity Service | |
-| SAML Module for Alfresco Content Services | |
 | Intelligence Services | Paid add-on module |
 | Content Connector for AWS S3 | Paid add-on module |
 | Content Connector for Azure | Paid add-on module |

--- a/content-services/latest/install/zip/amp.md
+++ b/content-services/latest/install/zip/amp.md
@@ -5,7 +5,7 @@ nav: false
 
 An Alfresco Module Package (AMP) is a bundle of code, content model, content, and the directory structure that is used to distribute additional functionality for Content Services. Use the Module Management Tool (MMT) to install and manage AMP files. You can install an AMP in an Alfresco WAR using the MMT, or by using the `apply_amps` tool.
 
-The MMT is available as a JAR file from the distribution zip (`alfresco-content-services-distribution-7.2.x.zip`), in the zip's `/bin` directory. Place the `/bin` directory and its contents in the same location where you extracted the Content Services distribution zip; for example `<installLocation>/bin`.
+The MMT is available as a JAR file from the distribution zip (`alfresco-content-services-distribution-7.3.x.zip`), in the zip's `/bin` directory. Place the `/bin` directory and its contents in the same location where you extracted the Content Services distribution zip; for example `<installLocation>/bin`.
 
 1. Browse to the `/bin` directory, for example:
 

--- a/content-services/latest/install/zip/index.md
+++ b/content-services/latest/install/zip/index.md
@@ -12,7 +12,7 @@ For a description of the system paths used within this documentation, see [Syste
 
 To install Content Services using the distribution zip (which also contains the WAR files), make sure that the required software is available on your system:
 
-* Java: OpenJDK 11 is recommended
+* Java: OpenJDK 17 is recommended
 * Application server: Apache Tomcat
 * Database: PostgreSQL or MySQL
 * Message broker: ActiveMQ

--- a/content-services/latest/install/zip/index.md
+++ b/content-services/latest/install/zip/index.md
@@ -64,7 +64,7 @@ Here's a list of the files to download and install.
 
 | File | Description |
 | ---- | ----------- |
-| alfresco-content-services-distribution-7.2.x.zip | Content Services distribution zip for new installations or upgrades. Alfresco WAR files (in distribution zip) for a manual install into an existing Tomcat application server. This distribution zip also contains the Module Management Tool (MMT) and the sample extension files, such as `alfresco-global.properties`. |
+| alfresco-content-services-distribution-7.3.x.zip | Content Services distribution zip for new installations or upgrades. Alfresco WAR files (in distribution zip) for a manual install into an existing Tomcat application server. This distribution zip also contains the Module Management Tool (MMT) and the sample extension files, such as `alfresco-global.properties`. |
 |alfresco-search-services-2.0.x.zip | Alfresco Search Services distribution zip.<br><br>See [Install Alfresco Search Services]({% link search-services/latest/install/index.md %}) for more information. |
 
 ## Preparing the filesystem and database

--- a/content-services/latest/install/zip/tomcat.md
+++ b/content-services/latest/install/zip/tomcat.md
@@ -105,7 +105,7 @@ The Content Services distribution file is a zip containing the required WAR file
 
 1. Browse to [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
-2. Download the file: `alfresco-content-services-distribution-7.2.x.zip`
+2. Download the file: `alfresco-content-services-distribution-7.3.x.zip`
 
 3. Specify a location for the download and extract the file to a system directory; for example `<installLocation>`.
 
@@ -229,7 +229,7 @@ The new keystore configuration implementation requires it to be configured with
 
 1. Move the default keystore files to your installation
 
-    1. Extract from the `alfresco-content-services-distribution-7.2.x.zip` file the following two files:
+    1. Extract from the `alfresco-content-services-distribution-7.3.x.zip` file the following two files:
 
         * `/keystore/metadata-keystore/keystore`
         * `/keystore/metadata-keystore/keystore-passwords.properties`


### PR DESCRIPTION
Applies updates for the distribution zip installation method.

⚠️ Updates for the Enterprise Docker Compose (via the Download Trial), Helm and Ansible deployments will be addressed separately.