### PR TITLE
[DOCS-6999] Update Supported Platforms page (Google Docs Integration 3.3) 

### DIFF
--- a/content-services/7.2/support/index.md
+++ b/content-services/7.2/support/index.md
@@ -96,6 +96,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Collaboration Connector for Teams 1.1 | |
 | Alfresco Outlook Integration 2.9 | |
 | Alfresco Office Services 1.4.1 | |
+| Alfresco Google Docs Integration 3.3 | |
 | Alfresco Google Docs Integration 3.2.2 | |
 | Alfresco Content Services SDK 5.1 | |
 | Alfresco Content Services SDK 4.4 | |
@@ -205,6 +206,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Collaboration Connector for Teams 1.0 | |
 | Alfresco Outlook Integration 2.9 | |
 | Alfresco Office Services 1.4.1 | |
+| Alfresco Google Docs Integration 3.3 | |
 | Alfresco Google Docs Integration 3.2.2 | |
 | Alfresco Content Services SDK 5.1 | |
 | Alfresco Content Services SDK 4.4 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -96,7 +96,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Collaboration Connector for Teams 1.1 | |
 | Alfresco Outlook Integration 2.9 | |
 | Alfresco Office Services 1.4.1 | |
-| Alfresco Google Docs Integration 3.2.2 | |
+| Alfresco Google Docs Integration 3.3 | |
 | Alfresco Content Services SDK 5.1 | |
 | Alfresco Content Services SDK 4.4 | |
 | | |


### PR DESCRIPTION
Supported with ACS 7.3 and 7.2