### PR TITLE
[DOCS-7013] Fix site config for latest DTE 2.3 docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -612,7 +612,6 @@ defaults:
       path: "transformation-engine/2.2"
     values:
       version: 2.2
-      latest: true
 
 # Alfresco Content Connector for AWS S3
   - scope:


### PR DESCRIPTION
If you go to any [Alfresco Document Transformation Engine v2.2 docs page](https://docs.alfresco.com/transformation-engine/2.2/) and then try to switch to the `latest` docs by selecting **2.3 latest** from the dropdown, it just switches back to showing the earlier `2.2` release docs. This is because the **latest** version is set twice, for `2.2 `and `2.3`. This PR removes the latest setting from the 2.2 version.