### PR TITLE
[DOCS-7003] Update redirects for Content Services 7.2

### DIFF
--- a/redirects/7.2/concepts/API-FreeMarker-JSPpage.html
+++ b/redirects/7.2/concepts/API-FreeMarker-JSPpage.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/javascript-root-objects/
+/content-services/7.2/develop/repo-ext-points/javascript-root-objects/

--- a/redirects/7.2/concepts/API-FreeMarker-arch.html
+++ b/redirects/7.2/concepts/API-FreeMarker-arch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/API-FreeMarker-models.html
+++ b/redirects/7.2/concepts/API-FreeMarker-models.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/API-FreeMarker-tfiles.html
+++ b/redirects/7.2/concepts/API-FreeMarker-tfiles.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/API-JS-Scripts.html
+++ b/redirects/7.2/concepts/API-JS-Scripts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/API-JS-intro.html
+++ b/redirects/7.2/concepts/API-JS-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/javascript-root-objects/
+/content-services/7.2/develop/repo-ext-points/javascript-root-objects/

--- a/redirects/7.2/concepts/APISurf-intro.html
+++ b/redirects/7.2/concepts/APISurf-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/Bulk-Import-Tool.html
+++ b/redirects/7.2/concepts/Bulk-Import-Tool.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/FSTR-custom-props.html
+++ b/redirects/7.2/concepts/FSTR-custom-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/FSTR-intro.html
+++ b/redirects/7.2/concepts/FSTR-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/FSTR-launcher-props.html
+++ b/redirects/7.2/concepts/FSTR-launcher-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/IMAP-subsystem-props.html
+++ b/redirects/7.2/concepts/IMAP-subsystem-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/JMX-props-config.html
+++ b/redirects/7.2/concepts/JMX-props-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/OOo-subsystems-intro.html
+++ b/redirects/7.2/concepts/OOo-subsystems-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/OOoJodconverter-subsystem-props.html
+++ b/redirects/7.2/concepts/OOoJodconverter-subsystem-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/libreoffice/
+/content-services/7.2/config/libreoffice/

--- a/redirects/7.2/concepts/Outlook-intro.html
+++ b/redirects/7.2/concepts/Outlook-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/concepts/Share-Doclib-Extend-Intro.html
+++ b/redirects/7.2/concepts/Share-Doclib-Extend-Intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/acs-deploy-architecture.html
+++ b/redirects/7.2/concepts/acs-deploy-architecture.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/concepts/activemq-config.html
+++ b/redirects/7.2/concepts/activemq-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/activemq/
+/content-services/7.2/config/activemq/

--- a/redirects/7.2/concepts/activemq-overview.html
+++ b/redirects/7.2/concepts/activemq-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/additional-query-fields.html
+++ b/redirects/7.2/concepts/additional-query-fields.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-dashlets/
+/content-services/7.2/develop/share-ext-points/aikau-dashlets/

--- a/redirects/7.2/concepts/admin-indexes.html
+++ b/redirects/7.2/concepts/admin-indexes.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/admin-password.html
+++ b/redirects/7.2/concepts/admin-password.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/concepts/adminconsole-about.html
+++ b/redirects/7.2/concepts/adminconsole-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/adminconsole-active-sessions.html
+++ b/redirects/7.2/concepts/adminconsole-active-sessions.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/adminconsole-custom-example.html
+++ b/redirects/7.2/concepts/adminconsole-custom-example.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/concepts/adminconsole-custom.html
+++ b/redirects/7.2/concepts/adminconsole-custom.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/adminconsole-directorymgt.html
+++ b/redirects/7.2/concepts/adminconsole-directorymgt.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/adminconsole-hot-threads.html
+++ b/redirects/7.2/concepts/adminconsole-hot-threads.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/adminconsole-log-settings.html
+++ b/redirects/7.2/concepts/adminconsole-log-settings.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/adminconsole-replication-config.html
+++ b/redirects/7.2/concepts/adminconsole-replication-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/concepts/adminconsole-scheduled-jobs.html
+++ b/redirects/7.2/concepts/adminconsole-scheduled-jobs.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/concepts/adminconsole-system-performance.html
+++ b/redirects/7.2/concepts/adminconsole-system-performance.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/adminconsole-systemsummary.html
+++ b/redirects/7.2/concepts/adminconsole-systemsummary.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/adminconsole-test-transform.html
+++ b/redirects/7.2/concepts/adminconsole-test-transform.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/adminconsole-thread-dump.html
+++ b/redirects/7.2/concepts/adminconsole-thread-dump.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/adminconsole-thread-profiler.html
+++ b/redirects/7.2/concepts/adminconsole-thread-profiler.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/adminconsole-thread-sampler.html
+++ b/redirects/7.2/concepts/adminconsole-thread-sampler.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/admintools-cmm-importexport.html
+++ b/redirects/7.2/concepts/admintools-cmm-importexport.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/concepts/admintools-cmm-info.html
+++ b/redirects/7.2/concepts/admintools-cmm-info.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/concepts/admintools-cmm-intro.html
+++ b/redirects/7.2/concepts/admintools-cmm-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/admintools-cmm-tutorial.html
+++ b/redirects/7.2/concepts/admintools-cmm-tutorial.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/concepts/admintools-groups-intro.html
+++ b/redirects/7.2/concepts/admintools-groups-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/concepts/admintools-replication-config.html
+++ b/redirects/7.2/concepts/admintools-replication-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/concepts/admintools-replication-intro.html
+++ b/redirects/7.2/concepts/admintools-replication-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/concepts/admintools-replication-manage.html
+++ b/redirects/7.2/concepts/admintools-replication-manage.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/concepts/admintools-users-intro.html
+++ b/redirects/7.2/concepts/admintools-users-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/concepts/admintools-using-cmm.html
+++ b/redirects/7.2/concepts/admintools-using-cmm.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/concepts/admintools.html
+++ b/redirects/7.2/concepts/admintools.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/aikau-intro.html
+++ b/redirects/7.2/concepts/aikau-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/alf-keystores.html
+++ b/redirects/7.2/concepts/alf-keystores.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/alfresco-arch-about.html
+++ b/redirects/7.2/concepts/alfresco-arch-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/
+/content-services/7.2/

--- a/redirects/7.2/concepts/alfresco-components.html
+++ b/redirects/7.2/concepts/alfresco-components.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/alfresco-features.html
+++ b/redirects/7.2/concepts/alfresco-features.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/alfresco-principles.html
+++ b/redirects/7.2/concepts/alfresco-principles.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/alfresco-read-only.html
+++ b/redirects/7.2/concepts/alfresco-read-only.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/concepts/alfresco-superusers.html
+++ b/redirects/7.2/concepts/alfresco-superusers.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/alfresco-tutorial-01.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-01.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-02.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-02.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-03.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-03.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-04.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-04.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-05.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-05.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-06.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-06.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-07.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-07.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-08.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-08.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-09.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-09.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-10.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-10.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-11.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-11.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-12.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-12.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-13.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-13.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-14.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-14.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-17.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-17.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-18.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-18.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-19.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-19.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-20.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-20.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-21.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-21.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-22.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-22.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-23.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-23.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-24.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-24.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-25.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-25.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-26.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-26.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-27.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-27.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/alfresco-tutorial-28.html
+++ b/redirects/7.2/concepts/alfresco-tutorial-28.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/
+/content-services/7.2/tutorial/

--- a/redirects/7.2/concepts/amazon-rds.html
+++ b/redirects/7.2/concepts/amazon-rds.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/concepts/api-about.html
+++ b/redirects/7.2/concepts/api-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/aspect-about.html
+++ b/redirects/7.2/concepts/aspect-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/concepts/asr-overview.html
+++ b/redirects/7.2/concepts/asr-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/at-adminconsole.html
+++ b/redirects/7.2/concepts/at-adminconsole.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/audit-app.html
+++ b/redirects/7.2/concepts/audit-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/audit-check-status.html
+++ b/redirects/7.2/concepts/audit-check-status.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/audit-config-files.html
+++ b/redirects/7.2/concepts/audit-config-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/audit-custom-audit-config.html
+++ b/redirects/7.2/concepts/audit-custom-audit-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/concepts/audit-deconstructing-the-sample-files.html
+++ b/redirects/7.2/concepts/audit-deconstructing-the-sample-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/concepts/audit-default-configuration.html
+++ b/redirects/7.2/concepts/audit-default-configuration.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/concepts/audit-enable.html
+++ b/redirects/7.2/concepts/audit-enable.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/concepts/audit-example-filter.html
+++ b/redirects/7.2/concepts/audit-example-filter.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/audit-filters.html
+++ b/redirects/7.2/concepts/audit-filters.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/audit-intro.html
+++ b/redirects/7.2/concepts/audit-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/audit-overview.html
+++ b/redirects/7.2/concepts/audit-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/concepts/audit-redirected-props.html
+++ b/redirects/7.2/concepts/audit-redirected-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/audit-rest-api.html
+++ b/redirects/7.2/concepts/audit-rest-api.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/audit-sample-files.html
+++ b/redirects/7.2/concepts/audit-sample-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/audit-tutorials.html
+++ b/redirects/7.2/concepts/audit-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/auth-alfrescontlm-props.html
+++ b/redirects/7.2/concepts/auth-alfrescontlm-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/auth-basics.html
+++ b/redirects/7.2/concepts/auth-basics.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-chain-chained.html
+++ b/redirects/7.2/concepts/auth-chain-chained.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/auth-config-examples.html
+++ b/redirects/7.2/concepts/auth-config-examples.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-external-intro.html
+++ b/redirects/7.2/concepts/auth-external-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-external-props.html
+++ b/redirects/7.2/concepts/auth-external-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/auth-intro.html
+++ b/redirects/7.2/concepts/auth-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-kerberos-clientconfig.html
+++ b/redirects/7.2/concepts/auth-kerberos-clientconfig.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-kerberos-intro.html
+++ b/redirects/7.2/concepts/auth-kerberos-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-kerberos-props.html
+++ b/redirects/7.2/concepts/auth-kerberos-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-ldap-ADtips.html
+++ b/redirects/7.2/concepts/auth-ldap-ADtips.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/auth-ldap-intro.html
+++ b/redirects/7.2/concepts/auth-ldap-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-ldap-openldaptips.html
+++ b/redirects/7.2/concepts/auth-ldap-openldaptips.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/concepts/auth-ldap-props.html
+++ b/redirects/7.2/concepts/auth-ldap-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/auth-subsystem-chain.html
+++ b/redirects/7.2/concepts/auth-subsystem-chain.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-subsystem-components.html
+++ b/redirects/7.2/concepts/auth-subsystem-components.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-subsystem-defaultauth.html
+++ b/redirects/7.2/concepts/auth-subsystem-defaultauth.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/subsystems/
+/content-services/7.2/config/subsystems/

--- a/redirects/7.2/concepts/auth-subsystem-intro.html
+++ b/redirects/7.2/concepts/auth-subsystem-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-subsystem-types.html
+++ b/redirects/7.2/concepts/auth-subsystem-types.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/auth-ticket.html
+++ b/redirects/7.2/concepts/auth-ticket.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/backup-intro.html
+++ b/redirects/7.2/concepts/backup-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/content-services/7.2/admin/backup-restore/

--- a/redirects/7.2/concepts/bcrypt-overview.html
+++ b/redirects/7.2/concepts/bcrypt-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/blog-comment.html
+++ b/redirects/7.2/concepts/blog-comment.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/blog-intro.html
+++ b/redirects/7.2/concepts/blog-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/brute-force-passwords.html
+++ b/redirects/7.2/concepts/brute-force-passwords.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/bulk-import-importing.html
+++ b/redirects/7.2/concepts/bulk-import-importing.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/bulk-import-in-place.html
+++ b/redirects/7.2/concepts/bulk-import-in-place.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/bulk-import-prepare-filesystem.html
+++ b/redirects/7.2/concepts/bulk-import-prepare-filesystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/bulk-import-via-the-ui.html
+++ b/redirects/7.2/concepts/bulk-import-via-the-ui.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/cache-indsettings.html
+++ b/redirects/7.2/concepts/cache-indsettings.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/calendar-intro.html
+++ b/redirects/7.2/concepts/calendar-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/ccs-home.html
+++ b/redirects/7.2/concepts/ccs-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/ccs-overview.html
+++ b/redirects/7.2/concepts/ccs-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/ccs-props.html
+++ b/redirects/7.2/concepts/ccs-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/ch-administering.html
+++ b/redirects/7.2/concepts/ch-administering.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/ch-backup-restore.html
+++ b/redirects/7.2/concepts/ch-backup-restore.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/content-services/7.2/admin/backup-restore/

--- a/redirects/7.2/concepts/ch-configuration.html
+++ b/redirects/7.2/concepts/ch-configuration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/ch-install.html
+++ b/redirects/7.2/concepts/ch-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/ch-reference.html
+++ b/redirects/7.2/concepts/ch-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/concepts/ch-troubleshoot.html
+++ b/redirects/7.2/concepts/ch-troubleshoot.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/ch-upgrade.html
+++ b/redirects/7.2/concepts/ch-upgrade.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/concepts/cifs-outside-interface-intro.html
+++ b/redirects/7.2/concepts/cifs-outside-interface-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/concepts/clean-content.html
+++ b/redirects/7.2/concepts/clean-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/cluster-properties.html
+++ b/redirects/7.2/concepts/cluster-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/cluster-scenario-redundancy.html
+++ b/redirects/7.2/concepts/cluster-scenario-redundancy.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/cluster-scenario-throughput.html
+++ b/redirects/7.2/concepts/cluster-scenario-throughput.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/cluster-share.html
+++ b/redirects/7.2/concepts/cluster-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/cluster-startup.html
+++ b/redirects/7.2/concepts/cluster-startup.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/cluster-track-issue.html
+++ b/redirects/7.2/concepts/cluster-track-issue.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/cmd-line-config.html
+++ b/redirects/7.2/concepts/cmd-line-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/cmm-video-tutorials.html
+++ b/redirects/7.2/concepts/cmm-video-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/video/model/
+/content-services/7.2/tutorial/video/model/

--- a/redirects/7.2/concepts/config-alf-webproxy.html
+++ b/redirects/7.2/concepts/config-alf-webproxy.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/configuration-overview.html
+++ b/redirects/7.2/concepts/configuration-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/configure-ssl-intro.html
+++ b/redirects/7.2/concepts/configure-ssl-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/content-model-cmis.html
+++ b/redirects/7.2/concepts/content-model-cmis.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/content-model-deploy.html
+++ b/redirects/7.2/concepts/content-model-deploy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/content-model-preconfigured.html
+++ b/redirects/7.2/concepts/content-model-preconfigured.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-controls/
+/content-services/7.2/develop/share-ext-points/form-controls/

--- a/redirects/7.2/concepts/content-modeling-about.html
+++ b/redirects/7.2/concepts/content-modeling-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/cs-aggregating.html
+++ b/redirects/7.2/concepts/cs-aggregating.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/cs-centera.html
+++ b/redirects/7.2/concepts/cs-centera.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/cs-file.html
+++ b/redirects/7.2/concepts/cs-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/cs-manage.html
+++ b/redirects/7.2/concepts/cs-manage.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/cs-overview.html
+++ b/redirects/7.2/concepts/cs-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/cs-types.html
+++ b/redirects/7.2/concepts/cs-types.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/csrf-policy.html
+++ b/redirects/7.2/concepts/csrf-policy.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/dashboard-intro.html
+++ b/redirects/7.2/concepts/dashboard-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/dashboard-use.html
+++ b/redirects/7.2/concepts/dashboard-use.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/datalists-intro.html
+++ b/redirects/7.2/concepts/datalists-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/datalists-item-multiple.html
+++ b/redirects/7.2/concepts/datalists-item-multiple.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/concepts/datalists-items.html
+++ b/redirects/7.2/concepts/datalists-items.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/db-config-properties.html
+++ b/redirects/7.2/concepts/db-config-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/default-files-config.html
+++ b/redirects/7.2/concepts/default-files-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/deploy-concepts.html
+++ b/redirects/7.2/concepts/deploy-concepts.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/concepts/deploy-contents.html
+++ b/redirects/7.2/concepts/deploy-contents.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/concepts/deploy-options.html
+++ b/redirects/7.2/concepts/deploy-options.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/deploy-overview.html
+++ b/redirects/7.2/concepts/deploy-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/
+/content-services/7.2/install/

--- a/redirects/7.2/concepts/deploy-prereqs.html
+++ b/redirects/7.2/concepts/deploy-prereqs.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/dev-api-by-function.html
+++ b/redirects/7.2/concepts/dev-api-by-function.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-add-aspects-to-node.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-add-aspects-to-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-add-remove-comments-on-node.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-add-remove-comments-on-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-add-remove-tags-on-node.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-add-remove-tags-on-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-auth-with-repo.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-auth-with-repo.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/install/
+/content-services/7.2/develop/rest-api-guide/install/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-copy-folders-files.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-copy-folders-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-create-folder.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-create-folder.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-delete-a-node.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-delete-a-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/content-services/7.2/admin/db-cleanup/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-download-multiple-files.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-download-multiple-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/header/
+/content-services/7.2/tutorial/share/header/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-content-by-search-query.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-content-by-search-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-content-by-term.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-content-by-term.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-people-by-term.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-people-by-term.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-sites-by-term.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-finding-sites-by-term.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-file-content.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-file-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-file-rendition-content.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-file-rendition-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/content-services/7.2/develop/repo-ext-points/audit-log/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-node-metadata.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-node-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-repo-info.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-repo-info.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/get-repo-info/
+/content-services/7.2/develop/rest-api-guide/get-repo-info/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-set-node-permissions.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-set-node-permissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-version-history.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-get-version-history.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-install-api-explorer.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-install-api-explorer.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/install/
+/content-services/7.2/develop/rest-api-guide/install/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-install-http-call-tool.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-install-http-call-tool.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/install/
+/content-services/7.2/develop/rest-api-guide/install/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-install-json-format-tool.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-install-json-format-tool.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/install/
+/content-services/7.2/develop/rest-api-guide/install/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-intro.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-link-to-file.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-link-to-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-children-root-folder-filter.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-children-root-folder-filter.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-children-root-folder.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-children-root-folder.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-file-rendition-content.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-file-rendition-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-trashcan.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-list-trashcan.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-lock-unlock-files.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-lock-unlock-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-delete-audit-entries-for-app.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-delete-audit-entries-for-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-delete-audit-entry-for-app.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-delete-audit-entry-for-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/audit-apps/
+/content-services/7.2/develop/rest-api-guide/audit-apps/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-enable-auditing-and-alfresco-access-audit-app.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-enable-auditing-and-alfresco-access-audit-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-enable-disable-app.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-enable-disable-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/content-services/7.2/develop/repo-ext-points/audit-log/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-get-app.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-get-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/content-services/7.2/develop/repo-ext-points/audit-log/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-get-audit-entry.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-get-audit-entry.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-list-apps.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-list-apps.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-list-audit-entries-for-app.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-list-audit-entries-for-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/audit-apps/
+/content-services/7.2/develop/rest-api-guide/audit-apps/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-list-audit-entries-node.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-audit-apps-list-audit-entries-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/audit-apps/
+/content-services/7.2/develop/rest-api-guide/audit-apps/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-add-person-group-to-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-add-person-group-to-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-create-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-create-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-create-person.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-create-person.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-delete-person-group-from-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-delete-person-group-from-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/ratings/
+/content-services/7.2/develop/repo-ext-points/ratings/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-get-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-get-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-get-person.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-get-person.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/audit-apps/
+/content-services/7.2/develop/rest-api-guide/audit-apps/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-intro.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-groups.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-groups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-people-groups-in-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-people-groups-in-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-people.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-people.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/get-repo-info/
+/content-services/7.2/develop/rest-api-guide/get-repo-info/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-person-group-membership.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-list-person-group-membership.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-set-permissions-for-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-set-permissions-for-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-update-group.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-update-group.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-update-person-password.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-update-person-password.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm-examples/
+/content-services/7.2/install/containers/helm-examples/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-update-person.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-people-groups-update-person.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/people-groups/
+/content-services/7.2/develop/rest-api-guide/people-groups/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-add-content.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-add-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-add-members.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-add-members.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-create.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-intro.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-update.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-manage-sites-update.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/sites/
+/content-services/7.2/develop/rest-api-guide/sites/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-mng-folders-files.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-mng-folders-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/smart-folders/
+/content-services/7.2/using/smart-folders/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-move-folders-files.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-move-folders-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-remove-aspects-from-node.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-remove-aspects-from-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-restore-trashcan-items.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-restore-trashcan-items.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-searching-for-nodes.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-searching-for-nodes.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-set-up-assoc-folders-files.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-set-up-assoc-folders-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-things-to-know-before-you-start.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-things-to-know-before-you-start.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-update-node-metadata.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-update-node-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-upload-file-custom-type.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-upload-file-custom-type.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-upload-file-new-version.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-upload-file-new-version.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest-upload-file.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest-upload-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/dev-api-by-language-alf-rest.html
+++ b/redirects/7.2/concepts/dev-api-by-language-alf-rest.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/dev-api-by-language-cmis.html
+++ b/redirects/7.2/concepts/dev-api-by-language-cmis.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-api-functional-reference.html
+++ b/redirects/7.2/concepts/dev-api-functional-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-api-intro.html
+++ b/redirects/7.2/concepts/dev-api-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-api-overview.html
+++ b/redirects/7.2/concepts/dev-api-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-api-use-cases.html
+++ b/redirects/7.2/concepts/dev-api-use-cases.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/dev-arch-overview.html
+++ b/redirects/7.2/concepts/dev-arch-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-extensions-content-models-tutorials-intro.html
+++ b/redirects/7.2/concepts/dev-extensions-content-models-tutorials-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-extensions-modules-amp-format.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-amp-format.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-modules-amp-intro.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-amp-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-modules-amp-mapping.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-amp-mapping.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-modules-bootstrapping-files-spaces-xml.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-bootstrapping-files-spaces-xml.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/concepts/dev-extensions-modules-custom-amp.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-custom-amp.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/dev-extensions-modules-import-strategy.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-import-strategy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/concepts/dev-extensions-modules-importing-module-data.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-importing-module-data.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/concepts/dev-extensions-modules-management-tool.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-management-tool.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-modules-module-context.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-module-context.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-modules-module-log4j.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-module-log4j.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/admin-console-components/
+/content-services/7.2/develop/repo-ext-points/admin-console-components/

--- a/redirects/7.2/concepts/dev-extensions-modules-module-properties.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-module-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-modules-structure.html
+++ b/redirects/7.2/concepts/dev-extensions-modules-structure.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-packaging-techniques-amps.html
+++ b/redirects/7.2/concepts/dev-extensions-packaging-techniques-amps.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-packaging-techniques-jar-files.html
+++ b/redirects/7.2/concepts/dev-extensions-packaging-techniques-jar-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-packaging-techniques.html
+++ b/redirects/7.2/concepts/dev-extensions-packaging-techniques.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-share-aggregate-dependencies.html
+++ b/redirects/7.2/concepts/dev-extensions-share-aggregate-dependencies.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/dev-extensions-share-aikau-dashlets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-aikau-dashlets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-dashlets/
+/content-services/7.2/develop/share-ext-points/aikau-dashlets/

--- a/redirects/7.2/concepts/dev-extensions-share-aikau-menus.html
+++ b/redirects/7.2/concepts/dev-extensions-share-aikau-menus.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/concepts/dev-extensions-share-aikau-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-aikau-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/concepts/dev-extensions-share-aikau-widgets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-aikau-widgets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-widgets/
+/content-services/7.2/develop/share-ext-points/aikau-widgets/

--- a/redirects/7.2/concepts/dev-extensions-share-architecture-extension-points-intro-aikau-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-architecture-extension-points-intro-aikau-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/concepts/dev-extensions-share-architecture-extension-points-intro-surf-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-architecture-extension-points-intro-surf-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/concepts/dev-extensions-share-architecture-extension-points.html
+++ b/redirects/7.2/concepts/dev-extensions-share-architecture-extension-points.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-extensions-share-configuration.html
+++ b/redirects/7.2/concepts/dev-extensions-share-configuration.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-extensions-share-css-data-image-support.html
+++ b/redirects/7.2/concepts/dev-extensions-share-css-data-image-support.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/dev-extensions-share-custom-mimetype.html
+++ b/redirects/7.2/concepts/dev-extensions-share-custom-mimetype.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/mimetypes/
+/content-services/7.2/develop/repo-ext-points/mimetypes/

--- a/redirects/7.2/concepts/dev-extensions-share-doclib-actions.html
+++ b/redirects/7.2/concepts/dev-extensions-share-doclib-actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/doclib/
+/content-services/7.2/develop/share-ext-points/doclib/

--- a/redirects/7.2/concepts/dev-extensions-share-evaluators.html
+++ b/redirects/7.2/concepts/dev-extensions-share-evaluators.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/evaluators/
+/content-services/7.2/develop/share-ext-points/evaluators/

--- a/redirects/7.2/concepts/dev-extensions-share-extension-points-introduction.html
+++ b/redirects/7.2/concepts/dev-extensions-share-extension-points-introduction.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/dev-extensions-share-form-controls.html
+++ b/redirects/7.2/concepts/dev-extensions-share-form-controls.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-controls/
+/content-services/7.2/develop/share-ext-points/form-controls/

--- a/redirects/7.2/concepts/dev-extensions-share-form-field-validation-handlers.html
+++ b/redirects/7.2/concepts/dev-extensions-share-form-field-validation-handlers.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/concepts/dev-extensions-share-form-filters.html
+++ b/redirects/7.2/concepts/dev-extensions-share-form-filters.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/concepts/dev-extensions-share-module-autodeploy.html
+++ b/redirects/7.2/concepts/dev-extensions-share-module-autodeploy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-extensions-share-module-dependencies.html
+++ b/redirects/7.2/concepts/dev-extensions-share-module-dependencies.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/web-scripts/
+/content-services/7.2/develop/share-ext-points/web-scripts/

--- a/redirects/7.2/concepts/dev-extensions-share-module-deployment.html
+++ b/redirects/7.2/concepts/dev-extensions-share-module-deployment.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-extension-modules/
+/content-services/7.2/develop/share-ext-points/surf-extension-modules/

--- a/redirects/7.2/concepts/dev-extensions-share-module-dynamic-configuration.html
+++ b/redirects/7.2/concepts/dev-extensions-share-module-dynamic-configuration.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-aikau-dashlets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-aikau-dashlets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/content-services/7.2/develop/sdk/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-aikau-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-aikau-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/style/
+/content-services/7.2/tutorial/share/style/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-aikau-widgets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-aikau-widgets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-dashlets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-dashlets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/content-services/7.2/develop/sdk/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-webscripts.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-webscripts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-widgets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-override-ootb-surf-widgets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/concepts/dev-extensions-share-page-creation.html
+++ b/redirects/7.2/concepts/dev-extensions-share-page-creation.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-pages/
+/content-services/7.2/develop/share-ext-points/aikau-pages/

--- a/redirects/7.2/concepts/dev-extensions-share-site-presets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-site-presets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/site-presets/
+/content-services/7.2/develop/share-ext-points/site-presets/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-checksums.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-checksums.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-dashlets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-dashlets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-dashlets/
+/content-services/7.2/develop/share-ext-points/surf-dashlets/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-extension-modules-introduction.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-extension-modules-introduction.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-extension-modules/
+/content-services/7.2/develop/share-ext-points/surf-extension-modules/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-extension-modules.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-extension-modules.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/modify-ootb-code/
+/content-services/7.2/develop/share-ext-points/modify-ootb-code/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-maven.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-maven.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/
+/content-services/7.2/tutorial/share/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-pages/
+/content-services/7.2/develop/share-ext-points/surf-pages/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-web-script-js-root-objects.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-web-script-js-root-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/javascript-root-objects/
+/content-services/7.2/develop/share-ext-points/javascript-root-objects/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-web-scripts.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-web-scripts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/web-scripts/
+/content-services/7.2/develop/share-ext-points/web-scripts/

--- a/redirects/7.2/concepts/dev-extensions-share-surf-widgets.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surf-widgets.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/concepts/dev-extensions-share-surfbug.html
+++ b/redirects/7.2/concepts/dev-extensions-share-surfbug.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/tools/
+/content-services/7.2/develop/tools/

--- a/redirects/7.2/concepts/dev-extensions-share-template-markup.html
+++ b/redirects/7.2/concepts/dev-extensions-share-template-markup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/concepts/dev-extensions-share-themes.html
+++ b/redirects/7.2/concepts/dev-extensions-share-themes.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-themes/
+/content-services/7.2/develop/share-ext-points/share-themes/

--- a/redirects/7.2/concepts/dev-extensions-share-tutorials-conditional-rendering-evaluations.html
+++ b/redirects/7.2/concepts/dev-extensions-share-tutorials-conditional-rendering-evaluations.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/dev-extensions-share-tutorials-fm-models-about.html
+++ b/redirects/7.2/concepts/dev-extensions-share-tutorials-fm-models-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/dev-extensions-share-tutorials-header-menu-title.html
+++ b/redirects/7.2/concepts/dev-extensions-share-tutorials-header-menu-title.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/debug/
+/content-services/7.2/tutorial/share/debug/

--- a/redirects/7.2/concepts/dev-extensions-share-tutorials-intro.html
+++ b/redirects/7.2/concepts/dev-extensions-share-tutorials-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/dev-extensions-share-tutorials-pages.html
+++ b/redirects/7.2/concepts/dev-extensions-share-tutorials-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/dev-extensions-share-ui-framework-localization.html
+++ b/redirects/7.2/concepts/dev-extensions-share-ui-framework-localization.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/dev-extensions-share-useful-tools-firebug.html
+++ b/redirects/7.2/concepts/dev-extensions-share-useful-tools-firebug.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/tools/
+/content-services/7.2/develop/tools/

--- a/redirects/7.2/concepts/dev-extensions-share-useful-tools.html
+++ b/redirects/7.2/concepts/dev-extensions-share-useful-tools.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/dev-extensions-share-widget-customization.html
+++ b/redirects/7.2/concepts/dev-extensions-share-widget-customization.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/concepts/dev-extensions-share.html
+++ b/redirects/7.2/concepts/dev-extensions-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/dev-for-developers.html
+++ b/redirects/7.2/concepts/dev-for-developers.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/
+/content-services/7.2/develop/

--- a/redirects/7.2/concepts/dev-glossary.html
+++ b/redirects/7.2/concepts/dev-glossary.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-modules.html
+++ b/redirects/7.2/concepts/dev-modules.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/concepts/dev-platform-arch.html
+++ b/redirects/7.2/concepts/dev-platform-arch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-platform-extension-points.html
+++ b/redirects/7.2/concepts/dev-platform-extension-points.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-platform-extensions-getting-started.html
+++ b/redirects/7.2/concepts/dev-platform-extensions-getting-started.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/dev-platform-extensions-tutorials.html
+++ b/redirects/7.2/concepts/dev-platform-extensions-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/dev-platform-extensions.html
+++ b/redirects/7.2/concepts/dev-platform-extensions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/overview-ext-points/
+/content-services/7.2/develop/overview-ext-points/

--- a/redirects/7.2/concepts/dev-platform-integration-arch.html
+++ b/redirects/7.2/concepts/dev-platform-integration-arch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/dev-platform-integration-points.html
+++ b/redirects/7.2/concepts/dev-platform-integration-points.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-platform-integrations-getting-started.html
+++ b/redirects/7.2/concepts/dev-platform-integrations-getting-started.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-platform-integrations.html
+++ b/redirects/7.2/concepts/dev-platform-integrations.html
@@ -1,1 +1,1 @@
-/content-services/latest/
+/content-services/7.2/

--- a/redirects/7.2/concepts/dev-protocols.html
+++ b/redirects/7.2/concepts/dev-protocols.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/dev-reference-guide.html
+++ b/redirects/7.2/concepts/dev-reference-guide.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-repository-concepts.html
+++ b/redirects/7.2/concepts/dev-repository-concepts.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/dev-services.html
+++ b/redirects/7.2/concepts/dev-services.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/dev-share-extensions-getting-started.html
+++ b/redirects/7.2/concepts/dev-share-extensions-getting-started.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/dev-system-arch-platform.html
+++ b/redirects/7.2/concepts/dev-system-arch-platform.html
@@ -1,1 +1,1 @@
-/content-services/latest/
+/content-services/7.2/

--- a/redirects/7.2/concepts/dev-system-arch-web-ui-app-dev-adf.html
+++ b/redirects/7.2/concepts/dev-system-arch-web-ui-app-dev-adf.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-system-arch-web-ui-app-dev-js-api.html
+++ b/redirects/7.2/concepts/dev-system-arch-web-ui-app-dev-js-api.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-system-arch-web-ui-app-dev.html
+++ b/redirects/7.2/concepts/dev-system-arch-web-ui-app-dev.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/dev-system-arch-web-ui.html
+++ b/redirects/7.2/concepts/dev-system-arch-web-ui.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/discussions-intro.html
+++ b/redirects/7.2/concepts/discussions-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/dist-zip-structure.html
+++ b/redirects/7.2/concepts/dist-zip-structure.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/tomcat/
+/content-services/7.2/install/zip/tomcat/

--- a/redirects/7.2/concepts/docker-images.html
+++ b/redirects/7.2/concepts/docker-images.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/concepts/doclib-client-side-template-and-action-extensions.html
+++ b/redirects/7.2/concepts/doclib-client-side-template-and-action-extensions.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/concepts/doclib-jsNode-reference.html
+++ b/redirects/7.2/concepts/doclib-jsNode-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/doclib-predefined-evaluators-reference.html
+++ b/redirects/7.2/concepts/doclib-predefined-evaluators-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/doclib-reference.html
+++ b/redirects/7.2/concepts/doclib-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/concepts/doclib-repository-tier.html
+++ b/redirects/7.2/concepts/doclib-repository-tier.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/doclib-web-tier.html
+++ b/redirects/7.2/concepts/doclib-web-tier.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/download-enterprise.html
+++ b/redirects/7.2/concepts/download-enterprise.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/email-groupspermissions.html
+++ b/redirects/7.2/concepts/email-groupspermissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/email-inboundsmtp-props.html
+++ b/redirects/7.2/concepts/email-inboundsmtp-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/email-intro.html
+++ b/redirects/7.2/concepts/email-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/email-outboundsmtp-props.html
+++ b/redirects/7.2/concepts/email-outboundsmtp-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/email-target-node.html
+++ b/redirects/7.2/concepts/email-target-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/email-templates-intro.html
+++ b/redirects/7.2/concepts/email-templates-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/email.html
+++ b/redirects/7.2/concepts/email.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/enabling-cors.html
+++ b/redirects/7.2/concepts/enabling-cors.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/concepts/encrypt-consideration.html
+++ b/redirects/7.2/concepts/encrypt-consideration.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/encrypt-properties.html
+++ b/redirects/7.2/concepts/encrypt-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/encrypted-config-properties.html
+++ b/redirects/7.2/concepts/encrypted-config-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/encrypted-config.html
+++ b/redirects/7.2/concepts/encrypted-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/encrypted-cs-home.html
+++ b/redirects/7.2/concepts/encrypted-cs-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/encrypted-overview.html
+++ b/redirects/7.2/concepts/encrypted-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/fileserv-ftp-props.html
+++ b/redirects/7.2/concepts/fileserv-ftp-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/fileserv-subsystem-intro.html
+++ b/redirects/7.2/concepts/fileserv-subsystem-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/filtered-search-prop.html
+++ b/redirects/7.2/concepts/filtered-search-prop.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/share-admin-tools/
+/content-services/7.2/admin/share-admin-tools/

--- a/redirects/7.2/concepts/filtered-search.html
+++ b/redirects/7.2/concepts/filtered-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/share-admin-tools/
+/content-services/7.2/admin/share-admin-tools/

--- a/redirects/7.2/concepts/forms-evensequ.html
+++ b/redirects/7.2/concepts/forms-evensequ.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/forms-intro.html
+++ b/redirects/7.2/concepts/forms-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/forms-mechanism.html
+++ b/redirects/7.2/concepts/forms-mechanism.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/forms-use.html
+++ b/redirects/7.2/concepts/forms-use.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/concepts/global-props-intro.html
+++ b/redirects/7.2/concepts/global-props-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/gs-being-social.html
+++ b/redirects/7.2/concepts/gs-being-social.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/gs-building-site.html
+++ b/redirects/7.2/concepts/gs-building-site.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/gs-intro.html
+++ b/redirects/7.2/concepts/gs-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/gs-personal-alfresco.html
+++ b/redirects/7.2/concepts/gs-personal-alfresco.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/gs-site-prepare.html
+++ b/redirects/7.2/concepts/gs-site-prepare.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/gs-summary.html
+++ b/redirects/7.2/concepts/gs-summary.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/guestGroups.html
+++ b/redirects/7.2/concepts/guestGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/ha-intro.html
+++ b/redirects/7.2/concepts/ha-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/hazelcast-cluster-share.html
+++ b/redirects/7.2/concepts/hazelcast-cluster-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/heartbeatintro.html
+++ b/redirects/7.2/concepts/heartbeatintro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/iframe-policy.html
+++ b/redirects/7.2/concepts/iframe-policy.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/imap-intro.html
+++ b/redirects/7.2/concepts/imap-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/imap-mountpoints.html
+++ b/redirects/7.2/concepts/imap-mountpoints.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/imap-virtual-view.html
+++ b/redirects/7.2/concepts/imap-virtual-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/implserv-authentication.html
+++ b/redirects/7.2/concepts/implserv-authentication.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/implserv-authority.html
+++ b/redirects/7.2/concepts/implserv-authority.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/implserv-ownable.html
+++ b/redirects/7.2/concepts/implserv-ownable.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/implserv-permiss.html
+++ b/redirects/7.2/concepts/implserv-permiss.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/implserv-person.html
+++ b/redirects/7.2/concepts/implserv-person.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/import-transfer.html
+++ b/redirects/7.2/concepts/import-transfer.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/install-distribute-test.html
+++ b/redirects/7.2/concepts/install-distribute-test.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/concepts/install-integrations-overview.html
+++ b/redirects/7.2/concepts/install-integrations-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/install-lolibfiles.html
+++ b/redirects/7.2/concepts/install-lolibfiles.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/additions/
+/content-services/7.2/install/zip/additions/

--- a/redirects/7.2/concepts/install-single-test.html
+++ b/redirects/7.2/concepts/install-single-test.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/install-zip-overview.html
+++ b/redirects/7.2/concepts/install-zip-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/intro-core.html
+++ b/redirects/7.2/concepts/intro-core.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/intro-db-setup.html
+++ b/redirects/7.2/concepts/intro-db-setup.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/concepts/is-config.html
+++ b/redirects/7.2/concepts/is-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/is-properties.html
+++ b/redirects/7.2/concepts/is-properties.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/java-commandline.html
+++ b/redirects/7.2/concepts/java-commandline.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/java-public-api-list.html
+++ b/redirects/7.2/concepts/java-public-api-list.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/jmx-editman-beans.html
+++ b/redirects/7.2/concepts/jmx-editman-beans.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/concepts/jmx-enhance.html
+++ b/redirects/7.2/concepts/jmx-enhance.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/jmx-intro-config.html
+++ b/redirects/7.2/concepts/jmx-intro-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/jmx-mbeans.html
+++ b/redirects/7.2/concepts/jmx-mbeans.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/jmx-readonly-beans.html
+++ b/redirects/7.2/concepts/jmx-readonly-beans.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/jmx-reference/
+/content-services/7.2/admin/jmx-reference/

--- a/redirects/7.2/concepts/jmx-reference.html
+++ b/redirects/7.2/concepts/jmx-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/concepts/jvm-lowend.html
+++ b/redirects/7.2/concepts/jvm-lowend.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/jvm-prop.html
+++ b/redirects/7.2/concepts/jvm-prop.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/concepts/jvm-settings.html
+++ b/redirects/7.2/concepts/jvm-settings.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/jvm-tuning.html
+++ b/redirects/7.2/concepts/jvm-tuning.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/kb-preset-internationalization.html
+++ b/redirects/7.2/concepts/kb-preset-internationalization.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/concepts/keystore-config.html
+++ b/redirects/7.2/concepts/keystore-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/keystore-generate.html
+++ b/redirects/7.2/concepts/keystore-generate.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/keystore-registration.html
+++ b/redirects/7.2/concepts/keystore-registration.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/ldap-sync-user.html
+++ b/redirects/7.2/concepts/ldap-sync-user.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/library-add-content-intro.html
+++ b/redirects/7.2/concepts/library-add-content-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/concepts/library-add-folders.html
+++ b/redirects/7.2/concepts/library-add-folders.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/concepts/library-build.html
+++ b/redirects/7.2/concepts/library-build.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/concepts/library-comments.html
+++ b/redirects/7.2/concepts/library-comments.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/concepts/library-external-myfiles.html
+++ b/redirects/7.2/concepts/library-external-myfiles.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/library-external-shared.html
+++ b/redirects/7.2/concepts/library-external-shared.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/library-external.html
+++ b/redirects/7.2/concepts/library-external.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/library-folder-intro.html
+++ b/redirects/7.2/concepts/library-folder-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/library-folder-rules-defined.html
+++ b/redirects/7.2/concepts/library-folder-rules-defined.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/concepts/library-folder-rules-linked.html
+++ b/redirects/7.2/concepts/library-folder-rules-linked.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/concepts/library-folder-rules.html
+++ b/redirects/7.2/concepts/library-folder-rules.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/concepts/library-intro.html
+++ b/redirects/7.2/concepts/library-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/library-item-edit-intro.html
+++ b/redirects/7.2/concepts/library-item-edit-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/concepts/library-items-individual.html
+++ b/redirects/7.2/concepts/library-items-individual.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/concepts/library-options.html
+++ b/redirects/7.2/concepts/library-options.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/library-organize.html
+++ b/redirects/7.2/concepts/library-organize.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/concepts/library-share-opinion.html
+++ b/redirects/7.2/concepts/library-share-opinion.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/concepts/license-process.html
+++ b/redirects/7.2/concepts/license-process.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/license/
+/content-services/7.2/admin/license/

--- a/redirects/7.2/concepts/links-intro.html
+++ b/redirects/7.2/concepts/links-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/maincomponents-disable.html
+++ b/redirects/7.2/concepts/maincomponents-disable.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/concepts/manage-cs-home.html
+++ b/redirects/7.2/concepts/manage-cs-home.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/manage-share.html
+++ b/redirects/7.2/concepts/manage-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/managing-transformations.html
+++ b/redirects/7.2/concepts/managing-transformations.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/master-deploy.html
+++ b/redirects/7.2/concepts/master-deploy.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/
+/content-services/7.2/install/

--- a/redirects/7.2/concepts/master-using-intro.html
+++ b/redirects/7.2/concepts/master-using-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/concepts/members-manage.html
+++ b/redirects/7.2/concepts/members-manage.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/metadata-model-aspects.html
+++ b/redirects/7.2/concepts/metadata-model-aspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/metadata-model-assoc.html
+++ b/redirects/7.2/concepts/metadata-model-assoc.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/metadata-model-contraints.html
+++ b/redirects/7.2/concepts/metadata-model-contraints.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/metadata-model-define.html
+++ b/redirects/7.2/concepts/metadata-model-define.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/metadata-model-header.html
+++ b/redirects/7.2/concepts/metadata-model-header.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/metadata-model-inheritance.html
+++ b/redirects/7.2/concepts/metadata-model-inheritance.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/metadata-model-namespace.html
+++ b/redirects/7.2/concepts/metadata-model-namespace.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/metadata-model-props.html
+++ b/redirects/7.2/concepts/metadata-model-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/migrating-servers.html
+++ b/redirects/7.2/concepts/migrating-servers.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/content-services/7.2/admin/migration/

--- a/redirects/7.2/concepts/migrating.html
+++ b/redirects/7.2/concepts/migrating.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/content-services/7.2/admin/migration/

--- a/redirects/7.2/concepts/mobile-config-overview.html
+++ b/redirects/7.2/concepts/mobile-config-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/concepts/models-about.html
+++ b/redirects/7.2/concepts/models-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/modify-alf-apps.html
+++ b/redirects/7.2/concepts/modify-alf-apps.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/monitoring-intro.html
+++ b/redirects/7.2/concepts/monitoring-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/concepts/mssql-config-settings.html
+++ b/redirects/7.2/concepts/mssql-config-settings.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/concepts/mt-enable.html
+++ b/redirects/7.2/concepts/mt-enable.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/concepts/mt-implement.html
+++ b/redirects/7.2/concepts/mt-implement.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/concepts/mt-intro.html
+++ b/redirects/7.2/concepts/mt-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/concepts/mt-not-implemented.html
+++ b/redirects/7.2/concepts/mt-not-implemented.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/concepts/mt-webclient-admin.html
+++ b/redirects/7.2/concepts/mt-webclient-admin.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/concepts/mysql-config-settings.html
+++ b/redirects/7.2/concepts/mysql-config-settings.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/concepts/mytasks.html
+++ b/redirects/7.2/concepts/mytasks.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/concepts/network-sites-manage.html
+++ b/redirects/7.2/concepts/network-sites-manage.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/opencmis-ext-adding.html
+++ b/redirects/7.2/concepts/opencmis-ext-adding.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/behavior-policies/
+/content-services/7.2/develop/repo-ext-points/behavior-policies/

--- a/redirects/7.2/concepts/opencmis-ext-creating-aspects.html
+++ b/redirects/7.2/concepts/opencmis-ext-creating-aspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/concepts/opencmis-ext-intro.html
+++ b/redirects/7.2/concepts/opencmis-ext-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/concepts/opencmis-ext-using.html
+++ b/redirects/7.2/concepts/opencmis-ext-using.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/
+/content-services/7.2/tutorial/platform/

--- a/redirects/7.2/concepts/people-intro.html
+++ b/redirects/7.2/concepts/people-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/prereq-opt-install.html
+++ b/redirects/7.2/concepts/prereq-opt-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/additions/
+/content-services/7.2/install/zip/additions/

--- a/redirects/7.2/concepts/prop-tables.html
+++ b/redirects/7.2/concepts/prop-tables.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/content-services/7.2/admin/db-cleanup/

--- a/redirects/7.2/concepts/recommend-split.html
+++ b/redirects/7.2/concepts/recommend-split.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/concepts/remove-apps-install.html
+++ b/redirects/7.2/concepts/remove-apps-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/replicated-content.html
+++ b/redirects/7.2/concepts/replicated-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/replication.html
+++ b/redirects/7.2/concepts/replication.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/content-services/7.2/admin/backup-restore/

--- a/redirects/7.2/concepts/repository-csrf-policy.html
+++ b/redirects/7.2/concepts/repository-csrf-policy.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/repository-intro.html
+++ b/redirects/7.2/concepts/repository-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/concepts/repository-security-policies-filters.html
+++ b/redirects/7.2/concepts/repository-security-policies-filters.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/reverse-proxy.html
+++ b/redirects/7.2/concepts/reverse-proxy.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/concepts/rm-searchsyntax-APIs.html
+++ b/redirects/7.2/concepts/rm-searchsyntax-APIs.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/concepts/saml-overview.html
+++ b/redirects/7.2/concepts/saml-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/scheduled-jobs.html
+++ b/redirects/7.2/concepts/scheduled-jobs.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/schema-diff-tool-dumps-auto.html
+++ b/redirects/7.2/concepts/schema-diff-tool-dumps-auto.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/metadata-extractors/
+/content-services/7.2/develop/repo-ext-points/metadata-extractors/

--- a/redirects/7.2/concepts/schema-diff-tool-dumps-jmx.html
+++ b/redirects/7.2/concepts/schema-diff-tool-dumps-jmx.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/schema-diff-tool-dumps.html
+++ b/redirects/7.2/concepts/schema-diff-tool-dumps.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/schema-diff-tool-intro.html
+++ b/redirects/7.2/concepts/schema-diff-tool-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/schema-diff-tool-validation-differencing.html
+++ b/redirects/7.2/concepts/schema-diff-tool-validation-differencing.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/schema-diff-tool-validation-validation.html
+++ b/redirects/7.2/concepts/schema-diff-tool-validation-validation.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/search-api-defaults.html
+++ b/redirects/7.2/concepts/search-api-defaults.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/search-api-facetFields.html
+++ b/redirects/7.2/concepts/search-api-facetFields.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-facetIntervals.html
+++ b/redirects/7.2/concepts/search-api-facetIntervals.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/search-api-facetQueries.html
+++ b/redirects/7.2/concepts/search-api-facetQueries.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-fields.html
+++ b/redirects/7.2/concepts/search-api-fields.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/search-api-filterQueries.html
+++ b/redirects/7.2/concepts/search-api-filterQueries.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-highlight.html
+++ b/redirects/7.2/concepts/search-api-highlight.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/search-api-include.html
+++ b/redirects/7.2/concepts/search-api-include.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/search-api-includeRequest.html
+++ b/redirects/7.2/concepts/search-api-includeRequest.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-limits.html
+++ b/redirects/7.2/concepts/search-api-limits.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/metadata-extractors/
+/content-services/7.2/develop/repo-ext-points/metadata-extractors/

--- a/redirects/7.2/concepts/search-api-paging.html
+++ b/redirects/7.2/concepts/search-api-paging.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/search-api-pivots.html
+++ b/redirects/7.2/concepts/search-api-pivots.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-query.html
+++ b/redirects/7.2/concepts/search-api-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/search-api-range.html
+++ b/redirects/7.2/concepts/search-api-range.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-scope.html
+++ b/redirects/7.2/concepts/search-api-scope.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm/
+/content-services/7.2/install/containers/helm/

--- a/redirects/7.2/concepts/search-api-sort.html
+++ b/redirects/7.2/concepts/search-api-sort.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/search-api-spellcheck.html
+++ b/redirects/7.2/concepts/search-api-spellcheck.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api-stats.html
+++ b/redirects/7.2/concepts/search-api-stats.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/search-api-templates.html
+++ b/redirects/7.2/concepts/search-api-templates.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/concepts/search-api.html
+++ b/redirects/7.2/concepts/search-api.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/search-examples.html
+++ b/redirects/7.2/concepts/search-examples.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/concepts/search-results.html
+++ b/redirects/7.2/concepts/search-results.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/concepts/searches.html
+++ b/redirects/7.2/concepts/searches.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/concepts/secur-DynAuthRoles.html
+++ b/redirects/7.2/concepts/secur-DynAuthRoles.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-about.html
+++ b/redirects/7.2/concepts/secur-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-acl-example.html
+++ b/redirects/7.2/concepts/secur-acl-example.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-acl-modifying.html
+++ b/redirects/7.2/concepts/secur-acl-modifying.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-acl-ordereval.html
+++ b/redirects/7.2/concepts/secur-acl-ordereval.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-acl.html
+++ b/redirects/7.2/concepts/secur-acl.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-authorities.html
+++ b/redirects/7.2/concepts/secur-authorities.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-config-about.html
+++ b/redirects/7.2/concepts/secur-config-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-implserv.html
+++ b/redirects/7.2/concepts/secur-implserv.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-methodlevel-define.html
+++ b/redirects/7.2/concepts/secur-methodlevel-define.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-peopleusers.html
+++ b/redirects/7.2/concepts/secur-peopleusers.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-permissions.html
+++ b/redirects/7.2/concepts/secur-permissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-public-service.html
+++ b/redirects/7.2/concepts/secur-public-service.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-zones-apprelated.html
+++ b/redirects/7.2/concepts/secur-zones-apprelated.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-zones-authrelated.html
+++ b/redirects/7.2/concepts/secur-zones-authrelated.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/secur-zones.html
+++ b/redirects/7.2/concepts/secur-zones.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/security-policy.html
+++ b/redirects/7.2/concepts/security-policy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-extension-modules/
+/content-services/7.2/develop/share-ext-points/surf-extension-modules/

--- a/redirects/7.2/concepts/seven-shortcuts.html
+++ b/redirects/7.2/concepts/seven-shortcuts.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/sf-best-practice.html
+++ b/redirects/7.2/concepts/sf-best-practice.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-config-workflow.html
+++ b/redirects/7.2/concepts/sf-config-workflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-folder-custom.html
+++ b/redirects/7.2/concepts/sf-folder-custom.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/concepts/sf-folder-system.html
+++ b/redirects/7.2/concepts/sf-folder-system.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/concepts/sf-folder-type.html
+++ b/redirects/7.2/concepts/sf-folder-type.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/concepts/sf-folder.html
+++ b/redirects/7.2/concepts/sf-folder.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-intro.html
+++ b/redirects/7.2/concepts/sf-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-metadata-inheritance.html
+++ b/redirects/7.2/concepts/sf-metadata-inheritance.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-prereqs.html
+++ b/redirects/7.2/concepts/sf-prereqs.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-ref-global-props.html
+++ b/redirects/7.2/concepts/sf-ref-global-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/concepts/sf-ref-template-guidance.html
+++ b/redirects/7.2/concepts/sf-ref-template-guidance.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/concepts/sf-share-actions.html
+++ b/redirects/7.2/concepts/sf-share-actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/concepts/sf-terms.html
+++ b/redirects/7.2/concepts/sf-terms.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/concepts/sf-using-intro.html
+++ b/redirects/7.2/concepts/sf-using-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/smart-folders/
+/content-services/7.2/using/smart-folders/

--- a/redirects/7.2/concepts/sf-whatis.html
+++ b/redirects/7.2/concepts/sf-whatis.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/smart-folders/
+/content-services/7.2/using/smart-folders/

--- a/redirects/7.2/concepts/sh-uh-introduction.html
+++ b/redirects/7.2/concepts/sh-uh-introduction.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/share-configuration-files.html
+++ b/redirects/7.2/concepts/share-configuration-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/content-services/7.2/develop/sdk/

--- a/redirects/7.2/concepts/share-configuring-intro.html
+++ b/redirects/7.2/concepts/share-configuring-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/share-customizing-document-library-views.html
+++ b/redirects/7.2/concepts/share-customizing-document-library-views.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/concepts/share-policies.html
+++ b/redirects/7.2/concepts/share-policies.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/share-repodoclib.html
+++ b/redirects/7.2/concepts/share-repodoclib.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/share-security-policies-filters.html
+++ b/redirects/7.2/concepts/share-security-policies-filters.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/site-build.html
+++ b/redirects/7.2/concepts/site-build.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/site-existing.html
+++ b/redirects/7.2/concepts/site-existing.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/site-using-2.html
+++ b/redirects/7.2/concepts/site-using-2.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/sites-dashlet-use.html
+++ b/redirects/7.2/concepts/sites-dashlet-use.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/sites-intro.html
+++ b/redirects/7.2/concepts/sites-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/concepts/spring-fw-modularity.html
+++ b/redirects/7.2/concepts/spring-fw-modularity.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/spring-web-mvc.html
+++ b/redirects/7.2/concepts/spring-web-mvc.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/start-stop-intro.html
+++ b/redirects/7.2/concepts/start-stop-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/concepts/store-config-fullexample.html
+++ b/redirects/7.2/concepts/store-config-fullexample.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/concepts/store-manage-content.html
+++ b/redirects/7.2/concepts/store-manage-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/concepts/store-using.html
+++ b/redirects/7.2/concepts/store-using.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/concepts/subsystem-categories.html
+++ b/redirects/7.2/concepts/subsystem-categories.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/subsystem-configuration.html
+++ b/redirects/7.2/concepts/subsystem-configuration.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/subsystems/
+/content-services/7.2/config/subsystems/

--- a/redirects/7.2/concepts/subsystem-intro.html
+++ b/redirects/7.2/concepts/subsystem-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/subsystems/
+/content-services/7.2/config/subsystems/

--- a/redirects/7.2/concepts/subsystem-props.html
+++ b/redirects/7.2/concepts/subsystem-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/subsystems/
+/content-services/7.2/config/subsystems/

--- a/redirects/7.2/concepts/super-search-manager.html
+++ b/redirects/7.2/concepts/super-search-manager.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/share-admin-tools/
+/content-services/7.2/admin/share-admin-tools/

--- a/redirects/7.2/concepts/supported-platforms-ACS.html
+++ b/redirects/7.2/concepts/supported-platforms-ACS.html
@@ -1,1 +1,1 @@
-/content-services/latest/support/
+/content-services/7.2/support/

--- a/redirects/7.2/concepts/surf-authenticators.html
+++ b/redirects/7.2/concepts/surf-authenticators.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/surf-components.html
+++ b/redirects/7.2/concepts/surf-components.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/surf-connectors-endpoints.html
+++ b/redirects/7.2/concepts/surf-connectors-endpoints.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/surf-connectors-intro.html
+++ b/redirects/7.2/concepts/surf-connectors-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/surf-content-delivery.html
+++ b/redirects/7.2/concepts/surf-content-delivery.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/surf-credentials.html
+++ b/redirects/7.2/concepts/surf-credentials.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/surf-fwork-intro.html
+++ b/redirects/7.2/concepts/surf-fwork-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/surf-mvc.html
+++ b/redirects/7.2/concepts/surf-mvc.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/surf-objects.html
+++ b/redirects/7.2/concepts/surf-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/surf-pres-content.html
+++ b/redirects/7.2/concepts/surf-pres-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/surf-remote-api.html
+++ b/redirects/7.2/concepts/surf-remote-api.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/surf-templates-regions.html
+++ b/redirects/7.2/concepts/surf-templates-regions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/surf-templates.html
+++ b/redirects/7.2/concepts/surf-templates.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/surf-tutorials.html
+++ b/redirects/7.2/concepts/surf-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/surf-types-of-content(replace-surf-concepts).html
+++ b/redirects/7.2/concepts/surf-types-of-content(replace-surf-concepts).html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/surf-view-fwork-intro.html
+++ b/redirects/7.2/concepts/surf-view-fwork-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/concepts/surf-webscripts.html
+++ b/redirects/7.2/concepts/surf-webscripts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/aikau-intro-ref/
+/content-services/7.2/develop/reference/aikau-intro-ref/

--- a/redirects/7.2/concepts/sync-collision.html
+++ b/redirects/7.2/concepts/sync-collision.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/sync-delete.html
+++ b/redirects/7.2/concepts/sync-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/sync-intro.html
+++ b/redirects/7.2/concepts/sync-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/sync-props.html
+++ b/redirects/7.2/concepts/sync-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/sync-triggers.html
+++ b/redirects/7.2/concepts/sync-triggers.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/sysadmin-subsystem-intro.html
+++ b/redirects/7.2/concepts/sysadmin-subsystem-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/sysadmin-subsystem-props.html
+++ b/redirects/7.2/concepts/sysadmin-subsystem-props.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/concepts/templated-nodes-intro.html
+++ b/redirects/7.2/concepts/templated-nodes-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/concepts/ten-mistakes.html
+++ b/redirects/7.2/concepts/ten-mistakes.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/testing-alfresco-upgrade.html
+++ b/redirects/7.2/concepts/testing-alfresco-upgrade.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/concepts/testing-alfresco.html
+++ b/redirects/7.2/concepts/testing-alfresco.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/concepts/themes-intro.html
+++ b/redirects/7.2/concepts/themes-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-themes/
+/content-services/7.2/develop/share-ext-points/share-themes/

--- a/redirects/7.2/concepts/transerv-overview.html
+++ b/redirects/7.2/concepts/transerv-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/concepts/trashcan-cleaner.html
+++ b/redirects/7.2/concepts/trashcan-cleaner.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/content-services/7.2/admin/db-cleanup/

--- a/redirects/7.2/concepts/troubleshoot-JMXdumper.html
+++ b/redirects/7.2/concepts/troubleshoot-JMXdumper.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/troubleshoot-imap.html
+++ b/redirects/7.2/concepts/troubleshoot-imap.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/troubleshoot-inboundemail.html
+++ b/redirects/7.2/concepts/troubleshoot-inboundemail.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/troubleshoot-install.html
+++ b/redirects/7.2/concepts/troubleshoot-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/activemq/
+/content-services/7.2/config/activemq/

--- a/redirects/7.2/concepts/troubleshoot-webdav.html
+++ b/redirects/7.2/concepts/troubleshoot-webdav.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/concepts/troubleshooting-conf.html
+++ b/redirects/7.2/concepts/troubleshooting-conf.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/troubleshooting-type.html
+++ b/redirects/7.2/concepts/troubleshooting-type.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/twelve-tips.html
+++ b/redirects/7.2/concepts/twelve-tips.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/concepts/ui-description.html
+++ b/redirects/7.2/concepts/ui-description.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/concepts/upgrade-community.html
+++ b/redirects/7.2/concepts/upgrade-community.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/concepts/upgrade-path.html
+++ b/redirects/7.2/concepts/upgrade-path.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/concepts/versioning.html
+++ b/redirects/7.2/concepts/versioning.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/concepts/welcome.html
+++ b/redirects/7.2/concepts/welcome.html
@@ -1,1 +1,1 @@
-/content-services/latest/
+/content-services/7.2/

--- a/redirects/7.2/concepts/wf-activiti-workflow-console.html
+++ b/redirects/7.2/concepts/wf-activiti-workflow-console.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/concepts/wf-architecture.html
+++ b/redirects/7.2/concepts/wf-architecture.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-artifacts.html
+++ b/redirects/7.2/concepts/wf-artifacts.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-instances.html
+++ b/redirects/7.2/concepts/wf-instances.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-events.html
+++ b/redirects/7.2/concepts/wf-process-def-events.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-gateways-exclusive.html
+++ b/redirects/7.2/concepts/wf-process-def-gateways-exclusive.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/wf-process-def-gateways-parallel.html
+++ b/redirects/7.2/concepts/wf-process-def-gateways-parallel.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-gateways.html
+++ b/redirects/7.2/concepts/wf-process-def-gateways.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-listeners-execution.html
+++ b/redirects/7.2/concepts/wf-process-def-listeners-execution.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-listeners-task.html
+++ b/redirects/7.2/concepts/wf-process-def-listeners-task.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-listeners.html
+++ b/redirects/7.2/concepts/wf-process-def-listeners.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-node-objects.html
+++ b/redirects/7.2/concepts/wf-process-def-node-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-sequence-flows.html
+++ b/redirects/7.2/concepts/wf-process-def-sequence-flows.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-tasks.html
+++ b/redirects/7.2/concepts/wf-process-def-tasks.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def-variables.html
+++ b/redirects/7.2/concepts/wf-process-def-variables.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-process-def.html
+++ b/redirects/7.2/concepts/wf-process-def.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-specifying-task-type.html
+++ b/redirects/7.2/concepts/wf-specifying-task-type.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-task-model.html
+++ b/redirects/7.2/concepts/wf-task-model.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-tools.html
+++ b/redirects/7.2/concepts/wf-tools.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wf-whatis-workflow.html
+++ b/redirects/7.2/concepts/wf-whatis-workflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/concepts/wiki-intro.html
+++ b/redirects/7.2/concepts/wiki-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/concepts/ws-I18N.html
+++ b/redirects/7.2/concepts/ws-I18N.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-Java-URI.html
+++ b/redirects/7.2/concepts/ws-Java-URI.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/concepts/ws-Java-model.html
+++ b/redirects/7.2/concepts/ws-Java-model.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/ws-Java-response.html
+++ b/redirects/7.2/concepts/ws-Java-response.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/concepts/ws-Java-service.html
+++ b/redirects/7.2/concepts/ws-Java-service.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/concepts/ws-Java-services.html
+++ b/redirects/7.2/concepts/ws-Java-services.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/ws-Java-spring.html
+++ b/redirects/7.2/concepts/ws-Java-spring.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/ws-anatomy.html
+++ b/redirects/7.2/concepts/ws-anatomy.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/ws-and-Java.html
+++ b/redirects/7.2/concepts/ws-and-Java.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-authenticating.html
+++ b/redirects/7.2/concepts/ws-authenticating.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-caching-about.html
+++ b/redirects/7.2/concepts/ws-caching-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-call-services.html
+++ b/redirects/7.2/concepts/ws-call-services.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-client-limitations.html
+++ b/redirects/7.2/concepts/ws-client-limitations.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-component-name.html
+++ b/redirects/7.2/concepts/ws-component-name.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-component-place.html
+++ b/redirects/7.2/concepts/ws-component-place.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-components.html
+++ b/redirects/7.2/concepts/ws-components.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-controll-script.html
+++ b/redirects/7.2/concepts/ws-controll-script.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/concepts/ws-custom-client-authentication.html
+++ b/redirects/7.2/concepts/ws-custom-client-authentication.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-desc-cache-controls.html
+++ b/redirects/7.2/concepts/ws-desc-cache-controls.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-desc-doc.html
+++ b/redirects/7.2/concepts/ws-desc-doc.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/ws-exception-handling.html
+++ b/redirects/7.2/concepts/ws-exception-handling.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/concepts/ws-folderListing-intro.html
+++ b/redirects/7.2/concepts/ws-folderListing-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-forcing-success.html
+++ b/redirects/7.2/concepts/ws-forcing-success.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/concepts/ws-format-reader.html
+++ b/redirects/7.2/concepts/ws-format-reader.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/javascript-root-objects/
+/content-services/7.2/develop/repo-ext-points/javascript-root-objects/

--- a/redirects/7.2/concepts/ws-forms-about.html
+++ b/redirects/7.2/concepts/ws-forms-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-framework.html
+++ b/redirects/7.2/concepts/ws-framework.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-hello-user-explain.html
+++ b/redirects/7.2/concepts/ws-hello-user-explain.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-hello-world-explain.html
+++ b/redirects/7.2/concepts/ws-hello-world-explain.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-intro.html
+++ b/redirects/7.2/concepts/ws-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/ws-invoke-where.html
+++ b/redirects/7.2/concepts/ws-invoke-where.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-java-backed-webscripts.html
+++ b/redirects/7.2/concepts/ws-java-backed-webscripts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-json-callbacks.html
+++ b/redirects/7.2/concepts/ws-json-callbacks.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-model-construct.html
+++ b/redirects/7.2/concepts/ws-model-construct.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/ws-overview.html
+++ b/redirects/7.2/concepts/ws-overview.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/concepts/ws-presentation-intro.html
+++ b/redirects/7.2/concepts/ws-presentation-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-presentation-locations.html
+++ b/redirects/7.2/concepts/ws-presentation-locations.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/web-scripts/
+/content-services/7.2/develop/share-ext-points/web-scripts/

--- a/redirects/7.2/concepts/ws-presentation-root-objects.html
+++ b/redirects/7.2/concepts/ws-presentation-root-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/concepts/ws-reference.html
+++ b/redirects/7.2/concepts/ws-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/concepts/ws-resp-code-set.html
+++ b/redirects/7.2/concepts/ws-resp-code-set.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-resp-code-template.html
+++ b/redirects/7.2/concepts/ws-resp-code-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-resp-template.html
+++ b/redirects/7.2/concepts/ws-resp-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/concepts/ws-respTemp-model.html
+++ b/redirects/7.2/concepts/ws-respTemp-model.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/concepts/ws-respTemp-services.html
+++ b/redirects/7.2/concepts/ws-respTemp-services.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-runtime-cache-controls.html
+++ b/redirects/7.2/concepts/ws-runtime-cache-controls.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/concepts/ws-tunneling-http-methods.html
+++ b/redirects/7.2/concepts/ws-tunneling-http-methods.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/concepts/ws-types-data.html
+++ b/redirects/7.2/concepts/ws-types-data.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-types.html
+++ b/redirects/7.2/concepts/ws-types.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/ws-uri-template.html
+++ b/redirects/7.2/concepts/ws-uri-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/concepts/your-space-intro.html
+++ b/redirects/7.2/concepts/your-space-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/concepts/zeroday-database.html
+++ b/redirects/7.2/concepts/zeroday-database.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-appending-content.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-appending-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding-get.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding-get.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding-post.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding-post.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/permissions/
+/content-services/7.2/develop/repo-ext-points/permissions/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding-succint.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding-succint.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-browser-binding.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-intro.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/
+/content-services/7.2/develop/repo-ext-points/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-item-support.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-item-support.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/pra/1/concepts/cmis-1.1-using-aspects.html
+++ b/redirects/7.2/pra/1/concepts/cmis-1.1-using-aspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-basics.html
+++ b/redirects/7.2/pra/1/concepts/cmis-basics.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/pra/1/concepts/cmis-bindings.html
+++ b/redirects/7.2/pra/1/concepts/cmis-bindings.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/pra/1/concepts/cmis-concepts.html
+++ b/redirects/7.2/pra/1/concepts/cmis-concepts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/pra/1/concepts/cmis-config.html
+++ b/redirects/7.2/pra/1/concepts/cmis-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/content-services/7.2/admin/db-cleanup/

--- a/redirects/7.2/pra/1/concepts/cmis-domain-model.html
+++ b/redirects/7.2/pra/1/concepts/cmis-domain-model.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-get-document-content.html
+++ b/redirects/7.2/pra/1/concepts/cmis-get-document-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-get-node-children.html
+++ b/redirects/7.2/pra/1/concepts/cmis-get-node-children.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-get-node-details.html
+++ b/redirects/7.2/pra/1/concepts/cmis-get-node-details.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-get-service-document.html
+++ b/redirects/7.2/pra/1/concepts/cmis-get-service-document.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-getting-started.html
+++ b/redirects/7.2/pra/1/concepts/cmis-getting-started.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-objects.html
+++ b/redirects/7.2/pra/1/concepts/cmis-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-put-document-content.html
+++ b/redirects/7.2/pra/1/concepts/cmis-put-document-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-query.html
+++ b/redirects/7.2/pra/1/concepts/cmis-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-request-url-format-onpremise.html
+++ b/redirects/7.2/pra/1/concepts/cmis-request-url-format-onpremise.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/pra/1/concepts/cmis-request-url-format.html
+++ b/redirects/7.2/pra/1/concepts/cmis-request-url-format.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/pra/1/concepts/cmis-request.html
+++ b/redirects/7.2/pra/1/concepts/cmis-request.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/pra/1/concepts/cmis-services-about.html
+++ b/redirects/7.2/pra/1/concepts/cmis-services-about.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/pra/1/concepts/pra-rest-api-explorer.html
+++ b/redirects/7.2/pra/1/concepts/pra-rest-api-explorer.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/pra/1/tasks/opencmis-ext-workbench.html
+++ b/redirects/7.2/pra/1/tasks/opencmis-ext-workbench.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/pra/1/topics/cmis-welcome.html
+++ b/redirects/7.2/pra/1/topics/cmis-welcome.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/pra/1/topics/pra-welcome-aara.html
+++ b/redirects/7.2/pra/1/topics/pra-welcome-aara.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/pra/1/topics/pra-welcome.html
+++ b/redirects/7.2/pra/1/topics/pra-welcome.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/API-FreeMarker-CurrentDate.html
+++ b/redirects/7.2/references/API-FreeMarker-CurrentDate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-cropContent.html
+++ b/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-cropContent.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-dateCompare.html
+++ b/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-dateCompare.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/ratings/
+/content-services/7.2/develop/repo-ext-points/ratings/

--- a/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-hasAspect.html
+++ b/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-hasAspect.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-hasPermission.html
+++ b/redirects/7.2/references/API-FreeMarker-DefaultModelMethods-hasPermission.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/references/API-FreeMarker-People-getCapabilities.html
+++ b/redirects/7.2/references/API-FreeMarker-People-getCapabilities.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-FreeMarker-People-getContainerGroups.html
+++ b/redirects/7.2/references/API-FreeMarker-People-getContainerGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-FreeMarker-People.html
+++ b/redirects/7.2/references/API-FreeMarker-People.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-FreeMarker-TemplateNode.html
+++ b/redirects/7.2/references/API-FreeMarker-TemplateNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-FreeMarker-Workflow.html
+++ b/redirects/7.2/references/API-FreeMarker-Workflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-FreeMarker-WorkflowTaskItem.html
+++ b/redirects/7.2/references/API-FreeMarker-WorkflowTaskItem.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-FreeMarker-defaultmodel.html
+++ b/redirects/7.2/references/API-FreeMarker-defaultmodel.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/freemarker-ref/
+/content-services/7.2/develop/reference/freemarker-ref/

--- a/redirects/7.2/references/API-FreeMarker-defaultmodelmethods.html
+++ b/redirects/7.2/references/API-FreeMarker-defaultmodelmethods.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-FreeMarker-intro.html
+++ b/redirects/7.2/references/API-FreeMarker-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-Actions.html
+++ b/redirects/7.2/references/API-JS-Actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-Activities.html
+++ b/redirects/7.2/references/API-JS-Activities.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/API-JS-AuthorityService.html
+++ b/redirects/7.2/references/API-JS-AuthorityService.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-CategoryNode.html
+++ b/redirects/7.2/references/API-JS-CategoryNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-CheckInOut.html
+++ b/redirects/7.2/references/API-JS-CheckInOut.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/references/API-JS-Classification.html
+++ b/redirects/7.2/references/API-JS-Classification.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Content.html
+++ b/redirects/7.2/references/API-JS-Content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/references/API-JS-ModifyCreate.html
+++ b/redirects/7.2/references/API-JS-ModifyCreate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Ownership.html
+++ b/redirects/7.2/references/API-JS-Ownership.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-People.html
+++ b/redirects/7.2/references/API-JS-People.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-RenditionDefinition.html
+++ b/redirects/7.2/references/API-JS-RenditionDefinition.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-RenditionService-createRenditionDefinition.html
+++ b/redirects/7.2/references/API-JS-RenditionService-createRenditionDefinition.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-RenditionService-getRenditionByName.html
+++ b/redirects/7.2/references/API-JS-RenditionService-getRenditionByName.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-RenditionService-getRenditions.html
+++ b/redirects/7.2/references/API-JS-RenditionService-getRenditions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-RenditionService-render.html
+++ b/redirects/7.2/references/API-JS-RenditionService-render.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-RenditionService.html
+++ b/redirects/7.2/references/API-JS-RenditionService.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-ScriptAction-execute.html
+++ b/redirects/7.2/references/API-JS-ScriptAction-execute.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/API-JS-ScriptAction-executeAsynchronously.html
+++ b/redirects/7.2/references/API-JS-ScriptAction-executeAsynchronously.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptContentData.html
+++ b/redirects/7.2/references/API-JS-ScriptContentData.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-ScriptGroup-addAuthority.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-addAuthority.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-ScriptGroup-getAllParentGroups.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-getAllParentGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-ScriptGroup-getChildGroups.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-getChildGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-ScriptGroup-getChildUsers.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-getChildUsers.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-ScriptGroup-getParentGroups.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-getParentGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-ScriptGroup-getZones.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-getZones.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-ScriptGroup-removeGroup.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-removeGroup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-ScriptGroup-removeUser.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup-removeUser.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-ScriptGroup.html
+++ b/redirects/7.2/references/API-JS-ScriptGroup.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-ScriptNode-Tagging-childrenByTags.html
+++ b/redirects/7.2/references/API-JS-ScriptNode-Tagging-childrenByTags.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptNode-Tagging-getTagScope.html
+++ b/redirects/7.2/references/API-JS-ScriptNode-Tagging-getTagScope.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptNode-Tagging.html
+++ b/redirects/7.2/references/API-JS-ScriptNode-Tagging.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptNode-Thumbnail-createThumbnail.html
+++ b/redirects/7.2/references/API-JS-ScriptNode-Thumbnail-createThumbnail.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-ScriptNode-Thumbnail-getThumbnailDefinitions.html
+++ b/redirects/7.2/references/API-JS-ScriptNode-Thumbnail-getThumbnailDefinitions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptNode-Thumbnail-getThumbnails.html
+++ b/redirects/7.2/references/API-JS-ScriptNode-Thumbnail-getThumbnails.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptNode.html
+++ b/redirects/7.2/references/API-JS-ScriptNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-ScriptThumbnail-updateThumbnail.html
+++ b/redirects/7.2/references/API-JS-ScriptThumbnail-updateThumbnail.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ScriptThumbnail.html
+++ b/redirects/7.2/references/API-JS-ScriptThumbnail.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-ScriptUser.html
+++ b/redirects/7.2/references/API-JS-ScriptUser.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-ScriptVersion.html
+++ b/redirects/7.2/references/API-JS-ScriptVersion.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Scripting-API.html
+++ b/redirects/7.2/references/API-JS-Scripting-API.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-Search.html
+++ b/redirects/7.2/references/API-JS-Search.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Security.html
+++ b/redirects/7.2/references/API-JS-Security.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-Services.html
+++ b/redirects/7.2/references/API-JS-Services.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/API-JS-Session-setValue.html
+++ b/redirects/7.2/references/API-JS-Session-setValue.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Site-acquireContainer.html
+++ b/redirects/7.2/references/API-JS-Site-acquireContainer.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Site-createAndSaveContainer.html
+++ b/redirects/7.2/references/API-JS-Site-createAndSaveContainer.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Site-createContainer.html
+++ b/redirects/7.2/references/API-JS-Site-createContainer.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Site-getContainer.html
+++ b/redirects/7.2/references/API-JS-Site-getContainer.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Site-getCustomProperty.html
+++ b/redirects/7.2/references/API-JS-Site-getCustomProperty.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Site-getMembersRole.html
+++ b/redirects/7.2/references/API-JS-Site-getMembersRole.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Site-getMembersRoleInfo.html
+++ b/redirects/7.2/references/API-JS-Site-getMembersRoleInfo.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Site-inviteNominatedexisting.html
+++ b/redirects/7.2/references/API-JS-Site-inviteNominatedexisting.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Site-inviteNominatednew.html
+++ b/redirects/7.2/references/API-JS-Site-inviteNominatednew.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Site-isMember.html
+++ b/redirects/7.2/references/API-JS-Site-isMember.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Site-isMemberOfGroup.html
+++ b/redirects/7.2/references/API-JS-Site-isMemberOfGroup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Site-listInvitations.html
+++ b/redirects/7.2/references/API-JS-Site-listInvitations.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-Site-listMembers.html
+++ b/redirects/7.2/references/API-JS-Site-listMembers.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-Site-removeMembership.html
+++ b/redirects/7.2/references/API-JS-Site-removeMembership.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Site-save.html
+++ b/redirects/7.2/references/API-JS-Site-save.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Site-setMembership.html
+++ b/redirects/7.2/references/API-JS-Site-setMembership.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/references/API-JS-Site.html
+++ b/redirects/7.2/references/API-JS-Site.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/references/API-JS-SiteService-cleanSitePermissions.html
+++ b/redirects/7.2/references/API-JS-SiteService-cleanSitePermissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-SiteService-createSite.html
+++ b/redirects/7.2/references/API-JS-SiteService-createSite.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/references/API-JS-SiteService-findSites.html
+++ b/redirects/7.2/references/API-JS-SiteService-findSites.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-SiteService-getSite.html
+++ b/redirects/7.2/references/API-JS-SiteService-getSite.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-SiteService-getSites.html
+++ b/redirects/7.2/references/API-JS-SiteService-getSites.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/references/API-JS-SiteService-hasCreateSitePermissions.html
+++ b/redirects/7.2/references/API-JS-SiteService-hasCreateSitePermissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-SiteService-isSiteManager.html
+++ b/redirects/7.2/references/API-JS-SiteService-isSiteManager.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-SiteService-listSiteRoles.html
+++ b/redirects/7.2/references/API-JS-SiteService-listSiteRoles.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/references/API-JS-SiteService-listSites.html
+++ b/redirects/7.2/references/API-JS-SiteService-listSites.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-SiteService-listUserSites.html
+++ b/redirects/7.2/references/API-JS-SiteService-listUserSites.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-SiteService.html
+++ b/redirects/7.2/references/API-JS-SiteService.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-SiteserviceObject.html
+++ b/redirects/7.2/references/API-JS-SiteserviceObject.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-TagScope-getCount.html
+++ b/redirects/7.2/references/API-JS-TagScope-getCount.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-TaggingService-createTag.html
+++ b/redirects/7.2/references/API-JS-TaggingService-createTag.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-TaggingService-deleteTag.html
+++ b/redirects/7.2/references/API-JS-TaggingService-deleteTag.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-TaggingService-getTag.html
+++ b/redirects/7.2/references/API-JS-TaggingService-getTag.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-TaggingService-getTags.html
+++ b/redirects/7.2/references/API-JS-TaggingService-getTags.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-TaggingService-tagScope.html
+++ b/redirects/7.2/references/API-JS-TaggingService-tagScope.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-TaggingService.html
+++ b/redirects/7.2/references/API-JS-TaggingService.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-Thumbnail.html
+++ b/redirects/7.2/references/API-JS-Thumbnail.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-ThumbnailService-getMimeAwarePlaceHolderResourcePath.html
+++ b/redirects/7.2/references/API-JS-ThumbnailService-getMimeAwarePlaceHolderResourcePath.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-ThumbnailService.html
+++ b/redirects/7.2/references/API-JS-ThumbnailService.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-Transformation-document.html
+++ b/redirects/7.2/references/API-JS-Transformation-document.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-Transformation-freemarker.html
+++ b/redirects/7.2/references/API-JS-Transformation-freemarker.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Transformation-image.html
+++ b/redirects/7.2/references/API-JS-Transformation-image.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/references/API-JS-Utility-createPaging.html
+++ b/redirects/7.2/references/API-JS-Utility-createPaging.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-Utility-longQName.html
+++ b/redirects/7.2/references/API-JS-Utility-longQName.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Utility-moduleInstalled.html
+++ b/redirects/7.2/references/API-JS-Utility-moduleInstalled.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-Utility-shortQName.html
+++ b/redirects/7.2/references/API-JS-Utility-shortQName.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Utility-toISO8601Long.html
+++ b/redirects/7.2/references/API-JS-Utility-toISO8601Long.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-Utility.html
+++ b/redirects/7.2/references/API-JS-Utility.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/references/API-JS-Versions.html
+++ b/redirects/7.2/references/API-JS-Versions.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/references/API-JS-WorkflowDefinition-startWorkflow.html
+++ b/redirects/7.2/references/API-JS-WorkflowDefinition-startWorkflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowDefinition.html
+++ b/redirects/7.2/references/API-JS-WorkflowDefinition.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowInstance.html
+++ b/redirects/7.2/references/API-JS-WorkflowInstance.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowManager-getPooledTasks.html
+++ b/redirects/7.2/references/API-JS-WorkflowManager-getPooledTasks.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-WorkflowManager-getTaskById.html
+++ b/redirects/7.2/references/API-JS-WorkflowManager-getTaskById.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-WorkflowManager.html
+++ b/redirects/7.2/references/API-JS-WorkflowManager.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowNode.html
+++ b/redirects/7.2/references/API-JS-WorkflowNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowPath.html
+++ b/redirects/7.2/references/API-JS-WorkflowPath.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowService.html
+++ b/redirects/7.2/references/API-JS-WorkflowService.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-WorkflowTask.html
+++ b/redirects/7.2/references/API-JS-WorkflowTask.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/references/API-JS-addAspect.html
+++ b/redirects/7.2/references/API-JS-addAspect.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-addAuthority.html
+++ b/redirects/7.2/references/API-JS-addAuthority.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-addNode.html
+++ b/redirects/7.2/references/API-JS-addNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-cancelCheckout.html
+++ b/redirects/7.2/references/API-JS-cancelCheckout.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-changePassword.html
+++ b/redirects/7.2/references/API-JS-changePassword.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-checkin.html
+++ b/redirects/7.2/references/API-JS-checkin.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/references/API-JS-checkout.html
+++ b/redirects/7.2/references/API-JS-checkout.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-childFileFolders.html
+++ b/redirects/7.2/references/API-JS-childFileFolders.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-childbyNamePath.html
+++ b/redirects/7.2/references/API-JS-childbyNamePath.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-copy.html
+++ b/redirects/7.2/references/API-JS-copy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-create.html
+++ b/redirects/7.2/references/API-JS-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-createAssoc.html
+++ b/redirects/7.2/references/API-JS-createAssoc.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-createFile.html
+++ b/redirects/7.2/references/API-JS-createFile.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-createFolder.html
+++ b/redirects/7.2/references/API-JS-createFolder.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-createGroup.html
+++ b/redirects/7.2/references/API-JS-createGroup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-createNode.html
+++ b/redirects/7.2/references/API-JS-createNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/API-JS-createPerson.html
+++ b/redirects/7.2/references/API-JS-createPerson.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-createRootGroup.html
+++ b/redirects/7.2/references/API-JS-createRootGroup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-createVersion.html
+++ b/redirects/7.2/references/API-JS-createVersion.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-disableAccount.html
+++ b/redirects/7.2/references/API-JS-disableAccount.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-enableAccount.html
+++ b/redirects/7.2/references/API-JS-enableAccount.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-ensureVersioningEnabled.html
+++ b/redirects/7.2/references/API-JS-ensureVersioningEnabled.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/patches/
+/content-services/7.2/develop/repo-ext-points/patches/

--- a/redirects/7.2/references/API-JS-findNode.html
+++ b/redirects/7.2/references/API-JS-findNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-getAllClassificationAspects.html
+++ b/redirects/7.2/references/API-JS-getAllClassificationAspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-getAllRootGroups.html
+++ b/redirects/7.2/references/API-JS-getAllRootGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/ratings/
+/content-services/7.2/develop/repo-ext-points/ratings/

--- a/redirects/7.2/references/API-JS-getAllRootGroupsInZone.html
+++ b/redirects/7.2/references/API-JS-getAllRootGroupsInZone.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-getCapabilities.html
+++ b/redirects/7.2/references/API-JS-getCapabilities.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-getContainerGroups.html
+++ b/redirects/7.2/references/API-JS-getContainerGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-getFeedControls.html
+++ b/redirects/7.2/references/API-JS-getFeedControls.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-getGroup.html
+++ b/redirects/7.2/references/API-JS-getGroup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/ratings/
+/content-services/7.2/develop/repo-ext-points/ratings/

--- a/redirects/7.2/references/API-JS-getGroupForFullAuthorityName.html
+++ b/redirects/7.2/references/API-JS-getGroupForFullAuthorityName.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-getGroups.html
+++ b/redirects/7.2/references/API-JS-getGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-getGroupsInZone.html
+++ b/redirects/7.2/references/API-JS-getGroupsInZone.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-getImmutableProperties.html
+++ b/redirects/7.2/references/API-JS-getImmutableProperties.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-getPeople.html
+++ b/redirects/7.2/references/API-JS-getPeople.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-getPeoplePaging.html
+++ b/redirects/7.2/references/API-JS-getPeoplePaging.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/API-JS-getPermissions.html
+++ b/redirects/7.2/references/API-JS-getPermissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-getPerson.html
+++ b/redirects/7.2/references/API-JS-getPerson.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-getPersonFullName.html
+++ b/redirects/7.2/references/API-JS-getPersonFullName.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-getPropertyNames.html
+++ b/redirects/7.2/references/API-JS-getPropertyNames.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-getTypePropertyNames.html
+++ b/redirects/7.2/references/API-JS-getTypePropertyNames.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-guessEncoding.html
+++ b/redirects/7.2/references/API-JS-guessEncoding.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/API-JS-hasAspect.html
+++ b/redirects/7.2/references/API-JS-hasAspect.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-hasPermission.html
+++ b/redirects/7.2/references/API-JS-hasPermission.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-isAccountEnabled.html
+++ b/redirects/7.2/references/API-JS-isAccountEnabled.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-isSubType.html
+++ b/redirects/7.2/references/API-JS-isSubType.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-luceneSearch.html
+++ b/redirects/7.2/references/API-JS-luceneSearch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-node-revert.html
+++ b/redirects/7.2/references/API-JS-node-revert.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-node-save.html
+++ b/redirects/7.2/references/API-JS-node-save.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/API-JS-postActivity.html
+++ b/redirects/7.2/references/API-JS-postActivity.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-query.html
+++ b/redirects/7.2/references/API-JS-query.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-remove.html
+++ b/redirects/7.2/references/API-JS-remove.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/behavior-policies/
+/content-services/7.2/develop/repo-ext-points/behavior-policies/

--- a/redirects/7.2/references/API-JS-removeAspect.html
+++ b/redirects/7.2/references/API-JS-removeAspect.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-removeAssoc.html
+++ b/redirects/7.2/references/API-JS-removeAssoc.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-removeAuthority.html
+++ b/redirects/7.2/references/API-JS-removeAuthority.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-removeNode.html
+++ b/redirects/7.2/references/API-JS-removeNode.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/API-JS-removePermission.html
+++ b/redirects/7.2/references/API-JS-removePermission.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/API-JS-rootscoped.html
+++ b/redirects/7.2/references/API-JS-rootscoped.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/API-JS-searchGroups.html
+++ b/redirects/7.2/references/API-JS-searchGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-searchGroupsInZone.html
+++ b/redirects/7.2/references/API-JS-searchGroupsInZone.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-searchRootGroups.html
+++ b/redirects/7.2/references/API-JS-searchRootGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-searchRootGroupsInZone.html
+++ b/redirects/7.2/references/API-JS-searchRootGroupsInZone.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-searchUsers.html
+++ b/redirects/7.2/references/API-JS-searchUsers.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-selectNodes.html
+++ b/redirects/7.2/references/API-JS-selectNodes.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/references/API-JS-setFeedControl.html
+++ b/redirects/7.2/references/API-JS-setFeedControl.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-setInheritsPermissions.html
+++ b/redirects/7.2/references/API-JS-setInheritsPermissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/API-JS-setPassword.html
+++ b/redirects/7.2/references/API-JS-setPassword.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-setPermission.html
+++ b/redirects/7.2/references/API-JS-setPermission.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/API-JS-setQuota.html
+++ b/redirects/7.2/references/API-JS-setQuota.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-specializeType.html
+++ b/redirects/7.2/references/API-JS-specializeType.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/API-JS-tagSearch.html
+++ b/redirects/7.2/references/API-JS-tagSearch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/API-JS-takeOwnership.html
+++ b/redirects/7.2/references/API-JS-takeOwnership.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/patches/
+/content-services/7.2/develop/repo-ext-points/patches/

--- a/redirects/7.2/references/API-JS-toJSON.html
+++ b/redirects/7.2/references/API-JS-toJSON.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/API-JS-unsetFeedControl.html
+++ b/redirects/7.2/references/API-JS-unsetFeedControl.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/API-JS-write.html
+++ b/redirects/7.2/references/API-JS-write.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/API-JS-xpathSearch.html
+++ b/redirects/7.2/references/API-JS-xpathSearch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/APISurf-App-app.html
+++ b/redirects/7.2/references/APISurf-App-app.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/APISurf-App-include.html
+++ b/redirects/7.2/references/APISurf-App-include.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/APISurf-Remote-connect.html
+++ b/redirects/7.2/references/APISurf-Remote-connect.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/authentication/
+/content-services/7.2/develop/repo-ext-points/authentication/

--- a/redirects/7.2/references/APISurf-Remote-isEndpointPersistent.html
+++ b/redirects/7.2/references/APISurf-Remote-isEndpointPersistent.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/references/APISurf-Remote-remote.html
+++ b/redirects/7.2/references/APISurf-Remote-remote.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/references/APISurf-Response-response.html
+++ b/redirects/7.2/references/APISurf-Response-response.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/references/APISurf-ResponseStatus-responsestatus.html
+++ b/redirects/7.2/references/APISurf-ResponseStatus-responsestatus.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/references/APISurf-ScriptModelObject-modelobjects.html
+++ b/redirects/7.2/references/APISurf-ScriptModelObject-modelobjects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/APISurf-ScriptRemoteConnector-connectors.html
+++ b/redirects/7.2/references/APISurf-ScriptRemoteConnector-connectors.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/references/APISurf-ScriptRemoteConnector-post.html
+++ b/redirects/7.2/references/APISurf-ScriptRemoteConnector-post.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptRemoteConnector-put.html
+++ b/redirects/7.2/references/APISurf-ScriptRemoteConnector-put.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-Helper-getComponent.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-Helper-getComponent.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-Helper-helper.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-Helper-helper.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-findChildPageAssociations.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-findChildPageAssociations.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-findComponents.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-findComponents.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-findConfiguration.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-findConfiguration.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-findContentAssociations.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-findContentAssociations.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-findPageAssociations.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-findPageAssociations.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-findTemplate.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-findTemplate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-newComponent.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-newComponent.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-newConfiguration.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-newConfiguration.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-newPage.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-newPage.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-newPreset.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-newPreset.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-newTemplate.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-newTemplate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-ScriptSiteData-removeTemplate.html
+++ b/redirects/7.2/references/APISurf-ScriptSiteData-removeTemplate.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/references/APISurf-components.html
+++ b/redirects/7.2/references/APISurf-components.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-config.html
+++ b/redirects/7.2/references/APISurf-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/APISurf-content.html
+++ b/redirects/7.2/references/APISurf-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/APISurf-context.html
+++ b/redirects/7.2/references/APISurf-context.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-head.html
+++ b/redirects/7.2/references/APISurf-head.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-htmlid.html
+++ b/redirects/7.2/references/APISurf-htmlid.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-instance.html
+++ b/redirects/7.2/references/APISurf-instance.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/APISurf-renderingobjects.html
+++ b/redirects/7.2/references/APISurf-renderingobjects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/APISurf-returntypes.html
+++ b/redirects/7.2/references/APISurf-returntypes.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/APISurf-rootscoped.html
+++ b/redirects/7.2/references/APISurf-rootscoped.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-sitedata.html
+++ b/redirects/7.2/references/APISurf-sitedata.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/APISurf-templates.html
+++ b/redirects/7.2/references/APISurf-templates.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/APISurf-url.html
+++ b/redirects/7.2/references/APISurf-url.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/APISurf-user.html
+++ b/redirects/7.2/references/APISurf-user.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/APISurfPlatform-intro.html
+++ b/redirects/7.2/references/APISurfPlatform-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/api-ws-freemarker.html
+++ b/redirects/7.2/references/api-ws-freemarker.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-ws-obj-cache.html
+++ b/redirects/7.2/references/api-ws-obj-cache.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/api-ws-obj-config.html
+++ b/redirects/7.2/references/api-ws-obj-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/references/api-ws-obj-formdata.html
+++ b/redirects/7.2/references/api-ws-obj-formdata.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/api-ws-obj-json.html
+++ b/redirects/7.2/references/api-ws-obj-json.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/api-ws-obj-jsonUtils.html
+++ b/redirects/7.2/references/api-ws-obj-jsonUtils.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/javascript-root-objects/
+/content-services/7.2/develop/repo-ext-points/javascript-root-objects/

--- a/redirects/7.2/references/api-ws-obj-requestbody.html
+++ b/redirects/7.2/references/api-ws-obj-requestbody.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-ws-obj-status.html
+++ b/redirects/7.2/references/api-ws-obj-status.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/api-ws-obj-webscript.html
+++ b/redirects/7.2/references/api-ws-obj-webscript.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/api-ws-root-ref.html
+++ b/redirects/7.2/references/api-ws-root-ref.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/api-ws-root-repository.html
+++ b/redirects/7.2/references/api-ws-root-repository.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/api-ws-root-template-repository.html
+++ b/redirects/7.2/references/api-ws-root-template-repository.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/repo-root-objects-ref/
+/content-services/7.2/develop/reference/repo-root-objects-ref/

--- a/redirects/7.2/references/api-ws-root-template.html
+++ b/redirects/7.2/references/api-ws-root-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-ws-root.html
+++ b/redirects/7.2/references/api-ws-root.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-wsdl-args.html
+++ b/redirects/7.2/references/api-wsdl-args.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/api-wsdl-authentication.html
+++ b/redirects/7.2/references/api-wsdl-authentication.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-wsdl-cache.html
+++ b/redirects/7.2/references/api-wsdl-cache.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/api-wsdl-family.html
+++ b/redirects/7.2/references/api-wsdl-family.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-wsdl-format.html
+++ b/redirects/7.2/references/api-wsdl-format.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/references/api-wsdl-formdata.html
+++ b/redirects/7.2/references/api-wsdl-formdata.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/api-wsdl-lifecycle.html
+++ b/redirects/7.2/references/api-wsdl-lifecycle.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-wsdl-negotiate.html
+++ b/redirects/7.2/references/api-wsdl-negotiate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/api-wsdl-responses.html
+++ b/redirects/7.2/references/api-wsdl-responses.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/api-wsdl-transaction.html
+++ b/redirects/7.2/references/api-wsdl-transaction.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/api-wsdl-url.html
+++ b/redirects/7.2/references/api-wsdl-url.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/references/api-wsdl-webscript-descriptor-language-reference.html
+++ b/redirects/7.2/references/api-wsdl-webscript-descriptor-language-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/references/api-wsdl-webscript.html
+++ b/redirects/7.2/references/api-wsdl-webscript.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/bulk-import-table.html
+++ b/redirects/7.2/references/bulk-import-table.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/references/dev-api-func-actions.html
+++ b/redirects/7.2/references/dev-api-func-actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-api-func-files-folders.html
+++ b/redirects/7.2/references/dev-api-func-files-folders.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/references/dev-api-func-nodes.html
+++ b/redirects/7.2/references/dev-api-func-nodes.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-api-func-people.html
+++ b/redirects/7.2/references/dev-api-func-people.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-api-func-search.html
+++ b/redirects/7.2/references/dev-api-func-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-api-func-sites.html
+++ b/redirects/7.2/references/dev-api-func-sites.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-api-func-tags.html
+++ b/redirects/7.2/references/dev-api-func-tags.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/dev-api-func-workflow.html
+++ b/redirects/7.2/references/dev-api-func-workflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/evaluators/
+/content-services/7.2/develop/share-ext-points/evaluators/

--- a/redirects/7.2/references/dev-extension-points-actions.html
+++ b/redirects/7.2/references/dev-extension-points-actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-extension-points-audit.html
+++ b/redirects/7.2/references/dev-extension-points-audit.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/content-services/7.2/develop/repo-ext-points/audit-log/

--- a/redirects/7.2/references/dev-extension-points-authentication.html
+++ b/redirects/7.2/references/dev-extension-points-authentication.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/authentication/
+/content-services/7.2/develop/repo-ext-points/authentication/

--- a/redirects/7.2/references/dev-extension-points-behaviors.html
+++ b/redirects/7.2/references/dev-extension-points-behaviors.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/behavior-policies/
+/content-services/7.2/develop/repo-ext-points/behavior-policies/

--- a/redirects/7.2/references/dev-extension-points-bootstrap.html
+++ b/redirects/7.2/references/dev-extension-points-bootstrap.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/references/dev-extension-points-content-model-configure-ui.html
+++ b/redirects/7.2/references/dev-extension-points-content-model-configure-ui.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/references/dev-extension-points-content-model-define-and-deploy.html
+++ b/redirects/7.2/references/dev-extension-points-content-model-define-and-deploy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-model/
+/content-services/7.2/develop/repo-ext-points/content-model/

--- a/redirects/7.2/references/dev-extension-points-content-model-multi-tenancy.html
+++ b/redirects/7.2/references/dev-extension-points-content-model-multi-tenancy.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/references/dev-extension-points-content-model.html
+++ b/redirects/7.2/references/dev-extension-points-content-model.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-extension-points-content-transformer.html
+++ b/redirects/7.2/references/dev-extension-points-content-transformer.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-transformers-renditions/
+/content-services/7.2/develop/repo-ext-points/content-transformers-renditions/

--- a/redirects/7.2/references/dev-extension-points-custom-admin-console.html
+++ b/redirects/7.2/references/dev-extension-points-custom-admin-console.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/admin-console-components/
+/content-services/7.2/develop/repo-ext-points/admin-console-components/

--- a/redirects/7.2/references/dev-extension-points-custom-content-store.html
+++ b/redirects/7.2/references/dev-extension-points-custom-content-store.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-stores/
+/content-services/7.2/develop/repo-ext-points/content-stores/

--- a/redirects/7.2/references/dev-extension-points-custom-metadata-extractor.html
+++ b/redirects/7.2/references/dev-extension-points-custom-metadata-extractor.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/metadata-extractors/
+/content-services/7.2/develop/repo-ext-points/metadata-extractors/

--- a/redirects/7.2/references/dev-extension-points-custom-subsystem.html
+++ b/redirects/7.2/references/dev-extension-points-custom-subsystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/subsystems/
+/content-services/7.2/develop/repo-ext-points/subsystems/

--- a/redirects/7.2/references/dev-extension-points-data-lists.html
+++ b/redirects/7.2/references/dev-extension-points-data-lists.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/data-lists/
+/content-services/7.2/develop/repo-ext-points/data-lists/

--- a/redirects/7.2/references/dev-extension-points-form-processors.html
+++ b/redirects/7.2/references/dev-extension-points-form-processors.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/dev-extension-points-javascript-root-objects.html
+++ b/redirects/7.2/references/dev-extension-points-javascript-root-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/javascript-root-objects/
+/content-services/7.2/develop/repo-ext-points/javascript-root-objects/

--- a/redirects/7.2/references/dev-extension-points-mimetypes.html
+++ b/redirects/7.2/references/dev-extension-points-mimetypes.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/mimetypes/
+/content-services/7.2/develop/repo-ext-points/mimetypes/

--- a/redirects/7.2/references/dev-extension-points-module-component.html
+++ b/redirects/7.2/references/dev-extension-points-module-component.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/module-components/
+/content-services/7.2/develop/repo-ext-points/module-components/

--- a/redirects/7.2/references/dev-extension-points-patch.html
+++ b/redirects/7.2/references/dev-extension-points-patch.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/patches/
+/content-services/7.2/develop/repo-ext-points/patches/

--- a/redirects/7.2/references/dev-extension-points-permissions.html
+++ b/redirects/7.2/references/dev-extension-points-permissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/permissions/
+/content-services/7.2/develop/repo-ext-points/permissions/

--- a/redirects/7.2/references/dev-extension-points-public-java-api.html
+++ b/redirects/7.2/references/dev-extension-points-public-java-api.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-extension-points-ratings.html
+++ b/redirects/7.2/references/dev-extension-points-ratings.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/ratings/
+/content-services/7.2/develop/repo-ext-points/ratings/

--- a/redirects/7.2/references/dev-extension-points-scheduled-jobs.html
+++ b/redirects/7.2/references/dev-extension-points-scheduled-jobs.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/scheduled-jobs/
+/content-services/7.2/develop/repo-ext-points/scheduled-jobs/

--- a/redirects/7.2/references/dev-extension-points-webscripts.html
+++ b/redirects/7.2/references/dev-extension-points-webscripts.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/references/dev-integration-points-aikau-clients.html
+++ b/redirects/7.2/references/dev-integration-points-aikau-clients.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/
+/content-services/7.2/develop/share-ext-points/

--- a/redirects/7.2/references/dev-integration-points-java-clients.html
+++ b/redirects/7.2/references/dev-integration-points-java-clients.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/dev-integration-points-rest-clients.html
+++ b/redirects/7.2/references/dev-integration-points-rest-clients.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-services-action.html
+++ b/redirects/7.2/references/dev-services-action.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/references/dev-services-activity.html
+++ b/redirects/7.2/references/dev-services-activity.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-services-attribute.html
+++ b/redirects/7.2/references/dev-services-attribute.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/evaluators/
+/content-services/7.2/develop/share-ext-points/evaluators/

--- a/redirects/7.2/references/dev-services-authentication.html
+++ b/redirects/7.2/references/dev-services-authentication.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/references/dev-services-authority.html
+++ b/redirects/7.2/references/dev-services-authority.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-services-category.html
+++ b/redirects/7.2/references/dev-services-category.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/references/dev-services-checkoutcheckin.html
+++ b/redirects/7.2/references/dev-services-checkoutcheckin.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/references/dev-services-content.html
+++ b/redirects/7.2/references/dev-services-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-services-copy.html
+++ b/redirects/7.2/references/dev-services-copy.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processors/
+/content-services/7.2/develop/share-ext-points/form-processors/

--- a/redirects/7.2/references/dev-services-dictionary.html
+++ b/redirects/7.2/references/dev-services-dictionary.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-services-filefolder.html
+++ b/redirects/7.2/references/dev-services-filefolder.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/references/dev-services-joblock.html
+++ b/redirects/7.2/references/dev-services-joblock.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/content-services/7.2/develop/sdk/

--- a/redirects/7.2/references/dev-services-lock.html
+++ b/redirects/7.2/references/dev-services-lock.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/references/dev-services-message.html
+++ b/redirects/7.2/references/dev-services-message.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/evaluators/
+/content-services/7.2/develop/share-ext-points/evaluators/

--- a/redirects/7.2/references/dev-services-mimetype.html
+++ b/redirects/7.2/references/dev-services-mimetype.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/web-scripts/
+/content-services/7.2/develop/share-ext-points/web-scripts/

--- a/redirects/7.2/references/dev-services-module.html
+++ b/redirects/7.2/references/dev-services-module.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/evaluators/
+/content-services/7.2/develop/share-ext-points/evaluators/

--- a/redirects/7.2/references/dev-services-namespace.html
+++ b/redirects/7.2/references/dev-services-namespace.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/references/dev-services-node.html
+++ b/redirects/7.2/references/dev-services-node.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-services-nodelocator.html
+++ b/redirects/7.2/references/dev-services-nodelocator.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/dev-services-permission.html
+++ b/redirects/7.2/references/dev-services-permission.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/references/dev-services-person.html
+++ b/redirects/7.2/references/dev-services-person.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/repo-actions/
+/content-services/7.2/develop/repo-ext-points/repo-actions/

--- a/redirects/7.2/references/dev-services-rendition.html
+++ b/redirects/7.2/references/dev-services-rendition.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-processor-filters/
+/content-services/7.2/develop/share-ext-points/form-processor-filters/

--- a/redirects/7.2/references/dev-services-retrying-transaction-helper.html
+++ b/redirects/7.2/references/dev-services-retrying-transaction-helper.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/javascript-root-objects/
+/content-services/7.2/develop/share-ext-points/javascript-root-objects/

--- a/redirects/7.2/references/dev-services-site.html
+++ b/redirects/7.2/references/dev-services-site.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/javascript-root-objects/
+/content-services/7.2/develop/repo-ext-points/javascript-root-objects/

--- a/redirects/7.2/references/dev-services-tagging.html
+++ b/redirects/7.2/references/dev-services-tagging.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/dev-services-template.html
+++ b/redirects/7.2/references/dev-services-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/references/dev-services-tenant.html
+++ b/redirects/7.2/references/dev-services-tenant.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/admin-console-components/
+/content-services/7.2/develop/repo-ext-points/admin-console-components/

--- a/redirects/7.2/references/dev-services-version.html
+++ b/redirects/7.2/references/dev-services-version.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/patches/
+/content-services/7.2/develop/repo-ext-points/patches/

--- a/redirects/7.2/references/dev-services-workflow.html
+++ b/redirects/7.2/references/dev-services-workflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/doclib/
+/content-services/7.2/develop/share-ext-points/doclib/

--- a/redirects/7.2/references/forms-reference.html
+++ b/redirects/7.2/references/forms-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/references/library-content-gdocs-troubleshooting.html
+++ b/redirects/7.2/references/library-content-gdocs-troubleshooting.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/references/metadata-extraction-mapping.html
+++ b/redirects/7.2/references/metadata-extraction-mapping.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/metadata-extraction/
+/content-services/7.2/admin/metadata-extraction/

--- a/redirects/7.2/references/mobile-config-access.html
+++ b/redirects/7.2/references/mobile-config-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-features.html
+++ b/redirects/7.2/references/mobile-config-features.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/references/mobile-config-file.html
+++ b/redirects/7.2/references/mobile-config-file.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/references/mobile-config-info.html
+++ b/redirects/7.2/references/mobile-config-info.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/references/mobile-config-profiles.html
+++ b/redirects/7.2/references/mobile-config-profiles.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-view-groups.html
+++ b/redirects/7.2/references/mobile-config-view-groups.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/searching/
+/content-services/7.2/develop/rest-api-guide/searching/

--- a/redirects/7.2/references/mobile-config-views-activities.html
+++ b/redirects/7.2/references/mobile-config-views-activities.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-views-favorites.html
+++ b/redirects/7.2/references/mobile-config-views-favorites.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-views-local.html
+++ b/redirects/7.2/references/mobile-config-views-local.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/header/
+/content-services/7.2/tutorial/share/header/

--- a/redirects/7.2/references/mobile-config-views-nodes.html
+++ b/redirects/7.2/references/mobile-config-views-nodes.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-views-search.html
+++ b/redirects/7.2/references/mobile-config-views-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-views-sites.html
+++ b/redirects/7.2/references/mobile-config-views-sites.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-views-sync.html
+++ b/redirects/7.2/references/mobile-config-views-sync.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/mobile/
+/content-services/7.2/config/mobile/

--- a/redirects/7.2/references/mobile-config-views-tasks.html
+++ b/redirects/7.2/references/mobile-config-views-tasks.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/references/mobile-config-views-users.html
+++ b/redirects/7.2/references/mobile-config-views-users.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/
+/content-services/7.2/develop/rest-api-guide/

--- a/redirects/7.2/references/mobile-config-views.html
+++ b/redirects/7.2/references/mobile-config-views.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/header/
+/content-services/7.2/tutorial/share/header/

--- a/redirects/7.2/references/permissions_share.html
+++ b/redirects/7.2/references/permissions_share.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/references/permissions_share_components.html
+++ b/redirects/7.2/references/permissions_share_components.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/references/permissions_share_other.html
+++ b/redirects/7.2/references/permissions_share_other.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/references/rule-actions.html
+++ b/redirects/7.2/references/rule-actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/references/surf-object-xml-reference-component.html
+++ b/redirects/7.2/references/surf-object-xml-reference-component.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-pages/
+/content-services/7.2/develop/share-ext-points/surf-pages/

--- a/redirects/7.2/references/surf-object-xml-reference-configuration.html
+++ b/redirects/7.2/references/surf-object-xml-reference-configuration.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/web-scripts/
+/content-services/7.2/develop/share-ext-points/web-scripts/

--- a/redirects/7.2/references/surf-object-xml-reference-page.html
+++ b/redirects/7.2/references/surf-object-xml-reference-page.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/surf-object-xml-reference-template-instance.html
+++ b/redirects/7.2/references/surf-object-xml-reference-template-instance.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/surf-object-xml-reference-template-type.html
+++ b/redirects/7.2/references/surf-object-xml-reference-template-type.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/surf-object-xml-reference-theme.html
+++ b/redirects/7.2/references/surf-object-xml-reference-theme.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/surf-object-xml-reference.html
+++ b/redirects/7.2/references/surf-object-xml-reference.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/surf-framework-ref/
+/content-services/7.2/develop/reference/surf-framework-ref/

--- a/redirects/7.2/references/valid-transformations-preview.html
+++ b/redirects/7.2/references/valid-transformations-preview.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/transformations/
+/content-services/7.2/admin/transformations/

--- a/redirects/7.2/references/valid-transformations.html
+++ b/redirects/7.2/references/valid-transformations.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/transformations/
+/content-services/7.2/admin/transformations/

--- a/redirects/7.2/references/whats-new.html
+++ b/redirects/7.2/references/whats-new.html
@@ -1,1 +1,1 @@
-/content-services/latest/
+/content-services/7.2/

--- a/redirects/7.2/reuse/conv-syspaths.html
+++ b/redirects/7.2/reuse/conv-syspaths.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/reuse/copyright.html
+++ b/redirects/7.2/reuse/copyright.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/
+/content-services/7.2/admin/

--- a/redirects/7.2/tasks/FSTR-running.html
+++ b/redirects/7.2/tasks/FSTR-running.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/FSTR-transfertarget.html
+++ b/redirects/7.2/tasks/FSTR-transfertarget.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/tasks/OOo-props-config.html
+++ b/redirects/7.2/tasks/OOo-props-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/OOo-subsystems-config.html
+++ b/redirects/7.2/tasks/OOo-subsystems-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/activemq-install.html
+++ b/redirects/7.2/tasks/activemq-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/tasks/adding-alfresco-repository.html
+++ b/redirects/7.2/tasks/adding-alfresco-repository.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/tasks/adminconsole-IMAPservice.html
+++ b/redirects/7.2/tasks/adminconsole-IMAPservice.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-activitiesfeed.html
+++ b/redirects/7.2/tasks/adminconsole-activitiesfeed.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/support-tools/
+/content-services/7.2/admin/support-tools/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-ac.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-ac.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-ad.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-ad.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-external.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-external.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-internal.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-internal.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-kerberos.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-kerberos.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-openldap.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-openldap.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-ss.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-ss.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-directorymgt-sso.html
+++ b/redirects/7.2/tasks/adminconsole-directorymgt-sso.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-exportsystemsettings.html
+++ b/redirects/7.2/tasks/adminconsole-exportsystemsettings.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/adminconsole-fileservers.html
+++ b/redirects/7.2/tasks/adminconsole-fileservers.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-inboundemail.html
+++ b/redirects/7.2/tasks/adminconsole-inboundemail.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/adminconsole-modelconsole.html
+++ b/redirects/7.2/tasks/adminconsole-modelconsole.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-nodebrowser.html
+++ b/redirects/7.2/tasks/adminconsole-nodebrowser.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/adminconsole-open.html
+++ b/redirects/7.2/tasks/adminconsole-open.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-outboundemail.html
+++ b/redirects/7.2/tasks/adminconsole-outboundemail.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-processengines.html
+++ b/redirects/7.2/tasks/adminconsole-processengines.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/tasks/adminconsole-replication-lockedcontent.html
+++ b/redirects/7.2/tasks/adminconsole-replication-lockedcontent.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/content-services/7.2/develop/repo-ext-points/audit-log/

--- a/redirects/7.2/tasks/adminconsole-repoinfo.html
+++ b/redirects/7.2/tasks/adminconsole-repoinfo.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/adminconsole-reposerverclustering.html
+++ b/redirects/7.2/tasks/adminconsole-reposerverclustering.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/tasks/adminconsole-subscriptionservice.html
+++ b/redirects/7.2/tasks/adminconsole-subscriptionservice.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/adminconsole-systemsettings.html
+++ b/redirects/7.2/tasks/adminconsole-systemsettings.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/adminconsole-workflowconsole.html
+++ b/redirects/7.2/tasks/adminconsole-workflowconsole.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/tasks/admintools-catmanager.html
+++ b/redirects/7.2/tasks/admintools-catmanager.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/share-admin-tools/
+/content-services/7.2/admin/share-admin-tools/

--- a/redirects/7.2/tasks/admintools-ct-properties-create.html
+++ b/redirects/7.2/tasks/admintools-ct-properties-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/tasks/admintools-ct-properties-delete.html
+++ b/redirects/7.2/tasks/admintools-ct-properties-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/tasks/admintools-ct-properties-edit.html
+++ b/redirects/7.2/tasks/admintools-ct-properties-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/admintools-custom-model-activate.html
+++ b/redirects/7.2/tasks/admintools-custom-model-activate.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/admintools-custom-model-create.html
+++ b/redirects/7.2/tasks/admintools-custom-model-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/tasks/admintools-custom-model-deactivate.html
+++ b/redirects/7.2/tasks/admintools-custom-model-deactivate.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/admintools-custom-model-view.html
+++ b/redirects/7.2/tasks/admintools-custom-model-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/admintools-custom-type-create.html
+++ b/redirects/7.2/tasks/admintools-custom-type-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/admintools-custom-type-delete.html
+++ b/redirects/7.2/tasks/admintools-custom-type-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/models/
+/content-services/7.2/config/models/

--- a/redirects/7.2/tasks/admintools-custom-type-edit.html
+++ b/redirects/7.2/tasks/admintools-custom-type-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/admintools-form-builder.html
+++ b/redirects/7.2/tasks/admintools-form-builder.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/admintools-group-browse.html
+++ b/redirects/7.2/tasks/admintools-group-browse.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-group-delete.html
+++ b/redirects/7.2/tasks/admintools-group-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-group-edit.html
+++ b/redirects/7.2/tasks/admintools-group-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-group-membership.html
+++ b/redirects/7.2/tasks/admintools-group-membership.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-group-new.html
+++ b/redirects/7.2/tasks/admintools-group-new.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-group-search.html
+++ b/redirects/7.2/tasks/admintools-group-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-logo.html
+++ b/redirects/7.2/tasks/admintools-logo.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/admintools-modules.html
+++ b/redirects/7.2/tasks/admintools-modules.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/tasks/admintools-open.html
+++ b/redirects/7.2/tasks/admintools-open.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/admintools-replication-cancel.html
+++ b/redirects/7.2/tasks/admintools-replication-cancel.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-create.html
+++ b/redirects/7.2/tasks/admintools-replication-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-delete.html
+++ b/redirects/7.2/tasks/admintools-replication-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-edit.html
+++ b/redirects/7.2/tasks/admintools-replication-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-reports.html
+++ b/redirects/7.2/tasks/admintools-replication-reports.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-run.html
+++ b/redirects/7.2/tasks/admintools-replication-run.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-transfertarget.html
+++ b/redirects/7.2/tasks/admintools-replication-transfertarget.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-replication-view.html
+++ b/redirects/7.2/tasks/admintools-replication-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/admintools-tagbrowser.html
+++ b/redirects/7.2/tasks/admintools-tagbrowser.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/admintools-theme.html
+++ b/redirects/7.2/tasks/admintools-theme.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-themes/
+/content-services/7.2/develop/share-ext-points/share-themes/

--- a/redirects/7.2/tasks/admintools-upload-users.html
+++ b/redirects/7.2/tasks/admintools-upload-users.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-create.html
+++ b/redirects/7.2/tasks/admintools-user-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-delete.html
+++ b/redirects/7.2/tasks/admintools-user-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-disable.html
+++ b/redirects/7.2/tasks/admintools-user-disable.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-edit.html
+++ b/redirects/7.2/tasks/admintools-user-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-group-membership.html
+++ b/redirects/7.2/tasks/admintools-user-group-membership.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-password.html
+++ b/redirects/7.2/tasks/admintools-user-password.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/admintools-user-view.html
+++ b/redirects/7.2/tasks/admintools-user-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/alf-sso-client-certificate.html
+++ b/redirects/7.2/tasks/alf-sso-client-certificate.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/alf-tomcat-install.html
+++ b/redirects/7.2/tasks/alf-tomcat-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/alf-war-install.html
+++ b/redirects/7.2/tasks/alf-war-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/alf-win-regedit.html
+++ b/redirects/7.2/tasks/alf-win-regedit.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/tasks/alfresco-start.html
+++ b/redirects/7.2/tasks/alfresco-start.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/alfresco-stop.html
+++ b/redirects/7.2/tasks/alfresco-stop.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/amazon-aurora-config.html
+++ b/redirects/7.2/tasks/amazon-aurora-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/amazon-mysql-config.html
+++ b/redirects/7.2/tasks/amazon-mysql-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/amazon-oracledb-config.html
+++ b/redirects/7.2/tasks/amazon-oracledb-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/amazon-postgresql-config.html
+++ b/redirects/7.2/tasks/amazon-postgresql-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/amazon-sqlserver-config.html
+++ b/redirects/7.2/tasks/amazon-sqlserver-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/amp-install.html
+++ b/redirects/7.2/tasks/amp-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/content-services/7.2/install/zip/amp/

--- a/redirects/7.2/tasks/aps-action-details.html
+++ b/redirects/7.2/tasks/aps-action-details.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/tasks/aps-action-install.html
+++ b/redirects/7.2/tasks/aps-action-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/content-services/7.2/install/zip/amp/

--- a/redirects/7.2/tasks/at-adminconsole-license.html
+++ b/redirects/7.2/tasks/at-adminconsole-license.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/license/
+/content-services/7.2/admin/license/

--- a/redirects/7.2/tasks/audit-pathmappings.html
+++ b/redirects/7.2/tasks/audit-pathmappings.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/tasks/audit-post-method-call.html
+++ b/redirects/7.2/tasks/audit-post-method-call.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/tasks/auth-alfrescoexternal-sso.html
+++ b/redirects/7.2/tasks/auth-alfrescoexternal-sso.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/tasks/auth-example-ldap-addemo.html
+++ b/redirects/7.2/tasks/auth-example-ldap-addemo.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/auth-example-oneldap-ad.html
+++ b/redirects/7.2/tasks/auth-example-oneldap-ad.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/auth-example-twoldap-ad.html
+++ b/redirects/7.2/tasks/auth-example-twoldap-ad.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm-examples/
+/content-services/7.2/install/containers/helm-examples/

--- a/redirects/7.2/tasks/auth-kerberos-ADconfig.html
+++ b/redirects/7.2/tasks/auth-kerberos-ADconfig.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/auth-kerberos-cross-domain.html
+++ b/redirects/7.2/tasks/auth-kerberos-cross-domain.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm/
+/content-services/7.2/install/containers/helm/

--- a/redirects/7.2/tasks/auth-kerberos-shareSSO.html
+++ b/redirects/7.2/tasks/auth-kerberos-shareSSO.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/activemq/
+/content-services/7.2/config/activemq/

--- a/redirects/7.2/tasks/auth-ldap-sasl.html
+++ b/redirects/7.2/tasks/auth-ldap-sasl.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/auth-subsystem-chain-config.html
+++ b/redirects/7.2/tasks/auth-subsystem-chain-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/autoversion-disable.html
+++ b/redirects/7.2/tasks/autoversion-disable.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/security/
+/content-services/7.2/admin/security/

--- a/redirects/7.2/tasks/backup-cold.html
+++ b/redirects/7.2/tasks/backup-cold.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/content-services/7.2/admin/backup-restore/

--- a/redirects/7.2/tasks/backup-hot-database.html
+++ b/redirects/7.2/tasks/backup-hot-database.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/content-services/7.2/admin/backup-restore/

--- a/redirects/7.2/tasks/backup-hot-filesystem.html
+++ b/redirects/7.2/tasks/backup-hot-filesystem.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/backup-hot.html
+++ b/redirects/7.2/tasks/backup-hot.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/backup-restore/
+/content-services/7.2/admin/backup-restore/

--- a/redirects/7.2/tasks/bean-config.html
+++ b/redirects/7.2/tasks/bean-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-model/
+/content-services/7.2/develop/repo-ext-points/content-model/

--- a/redirects/7.2/tasks/bean-override.html
+++ b/redirects/7.2/tasks/bean-override.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/become-owner.html
+++ b/redirects/7.2/tasks/become-owner.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/blog-browse.html
+++ b/redirects/7.2/tasks/blog-browse.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-comment-add.html
+++ b/redirects/7.2/tasks/blog-comment-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-comment-delete.html
+++ b/redirects/7.2/tasks/blog-comment-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-comment-edit.html
+++ b/redirects/7.2/tasks/blog-comment-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-page-access.html
+++ b/redirects/7.2/tasks/blog-page-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-post-create.html
+++ b/redirects/7.2/tasks/blog-post-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-post-delete.html
+++ b/redirects/7.2/tasks/blog-post-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-post-edit.html
+++ b/redirects/7.2/tasks/blog-post-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/blog-post-view.html
+++ b/redirects/7.2/tasks/blog-post-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/cache-config.html
+++ b/redirects/7.2/tasks/cache-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/tasks/calendar-event-add.html
+++ b/redirects/7.2/tasks/calendar-event-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/calendar-event-delete.html
+++ b/redirects/7.2/tasks/calendar-event-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/calendar-event-edit-datetime.html
+++ b/redirects/7.2/tasks/calendar-event-edit-datetime.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/calendar-event-edit.html
+++ b/redirects/7.2/tasks/calendar-event-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/calendar-event-view.html
+++ b/redirects/7.2/tasks/calendar-event-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/calendar-page-access.html
+++ b/redirects/7.2/tasks/calendar-page-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/calendar-page-browse.html
+++ b/redirects/7.2/tasks/calendar-page-browse.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/ccs-config.html
+++ b/redirects/7.2/tasks/ccs-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/tasks/cifs-add-file-outside-alfresco.html
+++ b/redirects/7.2/tasks/cifs-add-file-outside-alfresco.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/tasks/cifs-using-checkinout-exe.html
+++ b/redirects/7.2/tasks/cifs-using-checkinout-exe.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/cifs-using-share-exe.html
+++ b/redirects/7.2/tasks/cifs-using-share-exe.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/tasks/cifs-usingshowdetails-exe.html
+++ b/redirects/7.2/tasks/cifs-usingshowdetails-exe.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/tasks/cluster-setup.html
+++ b/redirects/7.2/tasks/cluster-setup.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/cluster/
+/content-services/7.2/admin/cluster/

--- a/redirects/7.2/tasks/cluster-share-config.html
+++ b/redirects/7.2/tasks/cluster-share-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/cluster-test.html
+++ b/redirects/7.2/tasks/cluster-test.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/admin-console/
+/content-services/7.2/admin/admin-console/

--- a/redirects/7.2/tasks/clustering-upgrade.html
+++ b/redirects/7.2/tasks/clustering-upgrade.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/tasks/config-config.html
+++ b/redirects/7.2/tasks/config-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/config-guestGroups.html
+++ b/redirects/7.2/tasks/config-guestGroups.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/configfiles-change-path.html
+++ b/redirects/7.2/tasks/configfiles-change-path.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/configure-ssl-prod.html
+++ b/redirects/7.2/tasks/configure-ssl-prod.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/audit-log/
+/content-services/7.2/develop/repo-ext-points/audit-log/

--- a/redirects/7.2/tasks/configure-ssl-test.html
+++ b/redirects/7.2/tasks/configure-ssl-test.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/tasks/configuring-aps-acs.html
+++ b/redirects/7.2/tasks/configuring-aps-acs.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/action/
+/content-services/7.2/config/action/

--- a/redirects/7.2/tasks/contenttrans-customize.html
+++ b/redirects/7.2/tasks/contenttrans-customize.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/create-filter.html
+++ b/redirects/7.2/tasks/create-filter.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/share-admin-tools/
+/content-services/7.2/admin/share-admin-tools/

--- a/redirects/7.2/tasks/cron-defer.html
+++ b/redirects/7.2/tasks/cron-defer.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/tasks/customize-savedsearch.html
+++ b/redirects/7.2/tasks/customize-savedsearch.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/dashboard-customize.html
+++ b/redirects/7.2/tasks/dashboard-customize.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/dashboard-site-enter.html
+++ b/redirects/7.2/tasks/dashboard-site-enter.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/dashlet-rssfeed.html
+++ b/redirects/7.2/tasks/dashlet-rssfeed.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/dashlet-webview-configure.html
+++ b/redirects/7.2/tasks/dashlet-webview-configure.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/datalists-item-create.html
+++ b/redirects/7.2/tasks/datalists-item-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/datalists-item-delete.html
+++ b/redirects/7.2/tasks/datalists-item-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-item-duplicate.html
+++ b/redirects/7.2/tasks/datalists-item-duplicate.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-item-edit.html
+++ b/redirects/7.2/tasks/datalists-item-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-item-multiple-actions.html
+++ b/redirects/7.2/tasks/datalists-item-multiple-actions.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-item-multiple-select.html
+++ b/redirects/7.2/tasks/datalists-item-multiple-select.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-list-create.html
+++ b/redirects/7.2/tasks/datalists-list-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-list-delete.html
+++ b/redirects/7.2/tasks/datalists-list-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-list-edit.html
+++ b/redirects/7.2/tasks/datalists-list-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-list-view.html
+++ b/redirects/7.2/tasks/datalists-list-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/datalists-page-access.html
+++ b/redirects/7.2/tasks/datalists-page-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/debug-installation.html
+++ b/redirects/7.2/tasks/debug-installation.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/delete-alf-war.html
+++ b/redirects/7.2/tasks/delete-alf-war.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/tomcat/
+/content-services/7.2/install/zip/tomcat/

--- a/redirects/7.2/tasks/delete-share-war.html
+++ b/redirects/7.2/tasks/delete-share-war.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/tomcat/
+/content-services/7.2/install/zip/tomcat/

--- a/redirects/7.2/tasks/deploy-bootstrap.html
+++ b/redirects/7.2/tasks/deploy-bootstrap.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/software-architecture/
+/content-services/7.2/develop/software-architecture/

--- a/redirects/7.2/tasks/deploy-contextpath.html
+++ b/redirects/7.2/tasks/deploy-contextpath.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/tasks/deploy-docker-compose.html
+++ b/redirects/7.2/tasks/deploy-docker-compose.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/docker-compose/
+/content-services/7.2/install/containers/docker-compose/

--- a/redirects/7.2/tasks/deploy-dynamic.html
+++ b/redirects/7.2/tasks/deploy-dynamic.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/deploy-helm-aws.html
+++ b/redirects/7.2/tasks/deploy-helm-aws.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/tasks/deploy-helm-minikube.html
+++ b/redirects/7.2/tasks/deploy-helm-minikube.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-aspect.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-aspect.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-association.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-association.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-custom-property.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-custom-property.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-mandatory-aspect.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-add-mandatory-aspect.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-create-custom-content.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-create-custom-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-deploy-model.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-deploy-model.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/dev-extensions-content-models-tutorials-share-config.html
+++ b/redirects/7.2/tasks/dev-extensions-content-models-tutorials-share-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-add-action-doclib.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-add-action-doclib.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-add-content.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-add-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-add-menuitem-create-menu.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-add-menuitem-create-menu.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-add-metadata-template-doclib.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-add-metadata-template-doclib.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-add-page.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-add-page.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-add-theme.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-add-theme.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/style/
+/content-services/7.2/tutorial/share/style/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-amd-packages-via-extension.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-amd-packages-via-extension.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/amd/
+/content-services/7.2/tutorial/share/amd/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-evaluator.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-evaluator.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-header-admin-menu.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-header-admin-menu.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/amd/
+/content-services/7.2/tutorial/share/amd/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-header-menu-item-removal.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-header-menu-item-removal.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/web-scripts/
+/content-services/7.2/develop/repo-ext-points/web-scripts/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-header-sites-menu.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-header-sites-menu.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/header/
+/content-services/7.2/tutorial/share/header/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-share-header-menu.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-custom-share-header-menu.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-customize-header-style.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-customize-header-style.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/style/
+/content-services/7.2/tutorial/share/style/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-customizing-widget-instantiation.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-customizing-widget-instantiation.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-debugging.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-debugging.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/debug/
+/content-services/7.2/tutorial/share/debug/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-fm-temp-customize.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-fm-temp-customize.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-hide-content.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-hide-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-i18n-customize.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-i18n-customize.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-js-customize.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-js-customize.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-make-default.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-make-default.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-override-login-page.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-override-login-page.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/doclib/
+/content-services/7.2/develop/share-ext-points/doclib/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-select-evaluator.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-select-evaluator.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/tools/
+/content-services/7.2/develop/tools/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-subcomponent-evals-improving.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-subcomponent-evals-improving.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/tasks/dev-extensions-share-tutorials-subcomponent-evals.html
+++ b/redirects/7.2/tasks/dev-extensions-share-tutorials-subcomponent-evals.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/rendering/
+/content-services/7.2/tutorial/share/rendering/

--- a/redirects/7.2/tasks/discussions-page-access.html
+++ b/redirects/7.2/tasks/discussions-page-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-reply-edit.html
+++ b/redirects/7.2/tasks/discussions-reply-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-topic-create.html
+++ b/redirects/7.2/tasks/discussions-topic-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-topic-delete.html
+++ b/redirects/7.2/tasks/discussions-topic-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-topic-edit.html
+++ b/redirects/7.2/tasks/discussions-topic-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-topic-reply.html
+++ b/redirects/7.2/tasks/discussions-topic-reply.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-topic-view.html
+++ b/redirects/7.2/tasks/discussions-topic-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/discussions-topics-browse.html
+++ b/redirects/7.2/tasks/discussions-topics-browse.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/docker-system-startup.html
+++ b/redirects/7.2/tasks/docker-system-startup.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/sdk/
+/content-services/7.2/develop/sdk/

--- a/redirects/7.2/tasks/email-templates-config.html
+++ b/redirects/7.2/tasks/email-templates-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm/
+/content-services/7.2/install/containers/helm/

--- a/redirects/7.2/tasks/encrypted-contentstore-install.html
+++ b/redirects/7.2/tasks/encrypted-contentstore-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/encrypted-jmx.html
+++ b/redirects/7.2/tasks/encrypted-jmx.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/content-stores/
+/content-services/7.2/admin/content-stores/

--- a/redirects/7.2/tasks/encryption-process-flow.html
+++ b/redirects/7.2/tasks/encryption-process-flow.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/ext-file-activities-config.html
+++ b/redirects/7.2/tasks/ext-file-activities-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/tasks/ext-file-config.html
+++ b/redirects/7.2/tasks/ext-file-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/fileserv-ftp-adv.html
+++ b/redirects/7.2/tasks/fileserv-ftp-adv.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/debug/
+/content-services/7.2/tutorial/share/debug/

--- a/redirects/7.2/tasks/filtered-search-custom.html
+++ b/redirects/7.2/tasks/filtered-search-custom.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/finding-version-number.html
+++ b/redirects/7.2/tasks/finding-version-number.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/forms-aspect-display.html
+++ b/redirects/7.2/tasks/forms-aspect-display.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/forms-config.html
+++ b/redirects/7.2/tasks/forms-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/extension-packaging/
+/content-services/7.2/develop/extension-packaging/

--- a/redirects/7.2/tasks/forms-controls-custom.html
+++ b/redirects/7.2/tasks/forms-controls-custom.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/tasks/forms-custom-formcontrol.html
+++ b/redirects/7.2/tasks/forms-custom-formcontrol.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/tasks/forms-custom-formtemplate.html
+++ b/redirects/7.2/tasks/forms-custom-formtemplate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/data-lists/
+/content-services/7.2/develop/repo-ext-points/data-lists/

--- a/redirects/7.2/tasks/forms-fieldlable-change.html
+++ b/redirects/7.2/tasks/forms-fieldlable-change.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/tasks/forms-formcontrol-config.html
+++ b/redirects/7.2/tasks/forms-formcontrol-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/content-services/7.2/admin/db-cleanup/

--- a/redirects/7.2/tasks/forms-grouping-fields.html
+++ b/redirects/7.2/tasks/forms-grouping-fields.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/rest-api-guide/folders-files/
+/content-services/7.2/develop/rest-api-guide/folders-files/

--- a/redirects/7.2/tasks/forms-setlabel-change.html
+++ b/redirects/7.2/tasks/forms-setlabel-change.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/tasks/forms-type-display.html
+++ b/redirects/7.2/tasks/forms-type-display.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/tasks/forms-valhandler.html
+++ b/redirects/7.2/tasks/forms-valhandler.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/form-field-validation-handlers/
+/content-services/7.2/develop/share-ext-points/form-field-validation-handlers/

--- a/redirects/7.2/tasks/global-props-composite.html
+++ b/redirects/7.2/tasks/global-props-composite.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/share-document-library-ref/
+/content-services/7.2/develop/reference/share-document-library-ref/

--- a/redirects/7.2/tasks/global-props-config.html
+++ b/redirects/7.2/tasks/global-props-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/gs-content-add.html
+++ b/redirects/7.2/tasks/gs-content-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/tasks/gs-content-update.html
+++ b/redirects/7.2/tasks/gs-content-update.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/gs-customize-dashboard.html
+++ b/redirects/7.2/tasks/gs-customize-dashboard.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/gs-customize-site.html
+++ b/redirects/7.2/tasks/gs-customize-site.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/gs-dashboard-setup.html
+++ b/redirects/7.2/tasks/gs-dashboard-setup.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/gs-engage-content.html
+++ b/redirects/7.2/tasks/gs-engage-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/gs-engage-users.html
+++ b/redirects/7.2/tasks/gs-engage-users.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/gs-intro-create.html
+++ b/redirects/7.2/tasks/gs-intro-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/gs-login.html
+++ b/redirects/7.2/tasks/gs-login.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/gs-members-invite.html
+++ b/redirects/7.2/tasks/gs-members-invite.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/gs-publish-credentials.html
+++ b/redirects/7.2/tasks/gs-publish-credentials.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/gs-site-create.html
+++ b/redirects/7.2/tasks/gs-site-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/gs-webinar-schedule.html
+++ b/redirects/7.2/tasks/gs-webinar-schedule.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/imagemagick-config.html
+++ b/redirects/7.2/tasks/imagemagick-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/additions/
+/content-services/7.2/install/zip/additions/

--- a/redirects/7.2/tasks/imap-enable.html
+++ b/redirects/7.2/tasks/imap-enable.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/imap-site-fav.html
+++ b/redirects/7.2/tasks/imap-site-fav.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/install-config-alf.html
+++ b/redirects/7.2/tasks/install-config-alf.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/install-config-solr.html
+++ b/redirects/7.2/tasks/install-config-solr.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/tasks/jmx-access.html
+++ b/redirects/7.2/tasks/jmx-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/jmx-activate.html
+++ b/redirects/7.2/tasks/jmx-activate.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/jmx-jconsole-example.html
+++ b/redirects/7.2/tasks/jmx-jconsole-example.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/kerberos-AD-config.html
+++ b/redirects/7.2/tasks/kerberos-AD-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/kerberos-alfresco-config.html
+++ b/redirects/7.2/tasks/kerberos-alfresco-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/
+/content-services/7.2/admin/auth-sync/

--- a/redirects/7.2/tasks/library-access.html
+++ b/redirects/7.2/tasks/library-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/tasks/library-add-content.html
+++ b/redirects/7.2/tasks/library-add-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-browse.html
+++ b/redirects/7.2/tasks/library-browse.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/tasks/library-comment-add.html
+++ b/redirects/7.2/tasks/library-comment-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-comment-delete.html
+++ b/redirects/7.2/tasks/library-comment-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/library-comment-edit.html
+++ b/redirects/7.2/tasks/library-comment-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/library-create-content-googledocs.html
+++ b/redirects/7.2/tasks/library-create-content-googledocs.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-create-content.html
+++ b/redirects/7.2/tasks/library-create-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-create-folder.html
+++ b/redirects/7.2/tasks/library-create-folder.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-create-template.html
+++ b/redirects/7.2/tasks/library-create-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/tasks/library-edit-content-googledocs.html
+++ b/redirects/7.2/tasks/library-edit-content-googledocs.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-folder-dragdrop.html
+++ b/redirects/7.2/tasks/library-folder-dragdrop.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-folder-rules-break-link.html
+++ b/redirects/7.2/tasks/library-folder-rules-break-link.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-change-link.html
+++ b/redirects/7.2/tasks/library-folder-rules-change-link.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-define-create.html
+++ b/redirects/7.2/tasks/library-folder-rules-define-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-define-link.html
+++ b/redirects/7.2/tasks/library-folder-rules-define-link.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-define.html
+++ b/redirects/7.2/tasks/library-folder-rules-define.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-delete.html
+++ b/redirects/7.2/tasks/library-folder-rules-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-edit.html
+++ b/redirects/7.2/tasks/library-folder-rules-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-inherited.html
+++ b/redirects/7.2/tasks/library-folder-rules-inherited.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-new.html
+++ b/redirects/7.2/tasks/library-folder-rules-new.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-reorder.html
+++ b/redirects/7.2/tasks/library-folder-rules-reorder.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-run.html
+++ b/redirects/7.2/tasks/library-folder-rules-run.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-rules-simpleworkflow.html
+++ b/redirects/7.2/tasks/library-folder-rules-simpleworkflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-folder-template.html
+++ b/redirects/7.2/tasks/library-folder-template.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/tasks/library-folder-viewdetails.html
+++ b/redirects/7.2/tasks/library-folder-viewdetails.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/library-gdocs-share.html
+++ b/redirects/7.2/tasks/library-gdocs-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-assign-workflow.html
+++ b/redirects/7.2/tasks/library-item-assign-workflow.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/tasks/library-item-category.html
+++ b/redirects/7.2/tasks/library-item-category.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/share-admin-tools/
+/content-services/7.2/admin/share-admin-tools/

--- a/redirects/7.2/tasks/library-item-change-type.html
+++ b/redirects/7.2/tasks/library-item-change-type.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/library-item-copy.html
+++ b/redirects/7.2/tasks/library-item-copy.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-create-link.html
+++ b/redirects/7.2/tasks/library-item-create-link.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-delete-final.html
+++ b/redirects/7.2/tasks/library-item-delete-final.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-delete-retrieve.html
+++ b/redirects/7.2/tasks/library-item-delete-retrieve.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-delete.html
+++ b/redirects/7.2/tasks/library-item-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-download.html
+++ b/redirects/7.2/tasks/library-item-download.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-edit-inline.html
+++ b/redirects/7.2/tasks/library-item-edit-inline.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/mimetypes/
+/content-services/7.2/develop/repo-ext-points/mimetypes/

--- a/redirects/7.2/tasks/library-item-edit-metadata.html
+++ b/redirects/7.2/tasks/library-item-edit-metadata.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-edit-offline.html
+++ b/redirects/7.2/tasks/library-item-edit-offline.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-edit-online.html
+++ b/redirects/7.2/tasks/library-item-edit-online.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-favourites.html
+++ b/redirects/7.2/tasks/library-item-favourites.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-manage-aspects.html
+++ b/redirects/7.2/tasks/library-item-manage-aspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/tasks/library-item-move-dragndrop.html
+++ b/redirects/7.2/tasks/library-item-move-dragndrop.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-move.html
+++ b/redirects/7.2/tasks/library-item-move.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-permissions.html
+++ b/redirects/7.2/tasks/library-item-permissions.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/rules/
+/content-services/7.2/using/content/rules/

--- a/redirects/7.2/tasks/library-item-rename.html
+++ b/redirects/7.2/tasks/library-item-rename.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-share.html
+++ b/redirects/7.2/tasks/library-item-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-tag-inline.html
+++ b/redirects/7.2/tasks/library-item-tag-inline.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-item-unshare.html
+++ b/redirects/7.2/tasks/library-item-unshare.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-upload.html
+++ b/redirects/7.2/tasks/library-item-upload.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/library-item-view-browser.html
+++ b/redirects/7.2/tasks/library-item-view-browser.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/tasks/library-item-view-googlemaps.html
+++ b/redirects/7.2/tasks/library-item-view-googlemaps.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/tasks/library-item-view.html
+++ b/redirects/7.2/tasks/library-item-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-items-multiple-select.html
+++ b/redirects/7.2/tasks/library-items-multiple-select.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/library-locate-content.html
+++ b/redirects/7.2/tasks/library-locate-content.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/manage/
+/content-services/7.2/using/content/manage/

--- a/redirects/7.2/tasks/license-authorize.html
+++ b/redirects/7.2/tasks/license-authorize.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/license/
+/content-services/7.2/admin/license/

--- a/redirects/7.2/tasks/license-deauthorize.html
+++ b/redirects/7.2/tasks/license-deauthorize.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/links-browse.html
+++ b/redirects/7.2/tasks/links-browse.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-comment-add.html
+++ b/redirects/7.2/tasks/links-comment-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-comment-delete.html
+++ b/redirects/7.2/tasks/links-comment-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-comment-edit.html
+++ b/redirects/7.2/tasks/links-comment-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-create.html
+++ b/redirects/7.2/tasks/links-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-delete-multiple.html
+++ b/redirects/7.2/tasks/links-delete-multiple.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-delete.html
+++ b/redirects/7.2/tasks/links-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-edit.html
+++ b/redirects/7.2/tasks/links-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-page-access.html
+++ b/redirects/7.2/tasks/links-page-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/links-view.html
+++ b/redirects/7.2/tasks/links-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/lo-install.html
+++ b/redirects/7.2/tasks/lo-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/log-levels-set.html
+++ b/redirects/7.2/tasks/log-levels-set.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/tasks/members-add-moderated.html
+++ b/redirects/7.2/tasks/members-add-moderated.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-become-manager.html
+++ b/redirects/7.2/tasks/members-become-manager.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-change-role.html
+++ b/redirects/7.2/tasks/members-change-role.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-invite-groups.html
+++ b/redirects/7.2/tasks/members-invite-groups.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-invite.html
+++ b/redirects/7.2/tasks/members-invite.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-remove.html
+++ b/redirects/7.2/tasks/members-remove.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-view-groups.html
+++ b/redirects/7.2/tasks/members-view-groups.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-view-invited.html
+++ b/redirects/7.2/tasks/members-view-invited.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/members-view.html
+++ b/redirects/7.2/tasks/members-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/metadata-config.html
+++ b/redirects/7.2/tasks/metadata-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/import-transfer/
+/content-services/7.2/admin/import-transfer/

--- a/redirects/7.2/tasks/migrate-backup-server.html
+++ b/redirects/7.2/tasks/migrate-backup-server.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/content-services/7.2/admin/migration/

--- a/redirects/7.2/tasks/migrate-restore-server.html
+++ b/redirects/7.2/tasks/migrate-restore-server.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/content-services/7.2/admin/migration/

--- a/redirects/7.2/tasks/mimetype-add.html
+++ b/redirects/7.2/tasks/mimetype-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/content-model/
+/content-services/7.2/tutorial/platform/content-model/

--- a/redirects/7.2/tasks/mobile-config-install.html
+++ b/redirects/7.2/tasks/mobile-config-install.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/mobile-config-locale.html
+++ b/redirects/7.2/tasks/mobile-config-locale.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/tasks/more-menu-mytasks-edit.html
+++ b/redirects/7.2/tasks/more-menu-mytasks-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/tasks/more-menu-mytasks-view.html
+++ b/redirects/7.2/tasks/more-menu-mytasks-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/tasks/more-menu-myworkflows-cancel.html
+++ b/redirects/7.2/tasks/more-menu-myworkflows-cancel.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/tasks/more-menu-myworkflows-delete.html
+++ b/redirects/7.2/tasks/more-menu-myworkflows-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/tasks/more-menu-myworkflows-view.html
+++ b/redirects/7.2/tasks/more-menu-myworkflows-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/tasks/
+/content-services/7.2/using/tasks/

--- a/redirects/7.2/tasks/mt-config.html
+++ b/redirects/7.2/tasks/mt-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/multi-tenancy/
+/content-services/7.2/admin/multi-tenancy/

--- a/redirects/7.2/tasks/mysql-config.html
+++ b/redirects/7.2/tasks/mysql-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/oracledb-config.html
+++ b/redirects/7.2/tasks/oracledb-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/page-select.html
+++ b/redirects/7.2/tasks/page-select.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/people-search.html
+++ b/redirects/7.2/tasks/people-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/tasks/postgresql-config.html
+++ b/redirects/7.2/tasks/postgresql-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/prep-filesys-db.html
+++ b/redirects/7.2/tasks/prep-filesys-db.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/tasks/profile-disable-activities.html
+++ b/redirects/7.2/tasks/profile-disable-activities.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/profile-edit.html
+++ b/redirects/7.2/tasks/profile-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/profile-follow.html
+++ b/redirects/7.2/tasks/profile-follow.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/profile-notifications.html
+++ b/redirects/7.2/tasks/profile-notifications.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/profile-password.html
+++ b/redirects/7.2/tasks/profile-password.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/users-groups/
+/content-services/7.2/admin/users-groups/

--- a/redirects/7.2/tasks/profile-view.html
+++ b/redirects/7.2/tasks/profile-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/props-set.html
+++ b/redirects/7.2/tasks/props-set.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/audit/
+/content-services/7.2/admin/audit/

--- a/redirects/7.2/tasks/replication-setup.html
+++ b/redirects/7.2/tasks/replication-setup.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/tasks/replication-share.html
+++ b/redirects/7.2/tasks/replication-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/replication/
+/content-services/7.2/admin/replication/

--- a/redirects/7.2/tasks/restore-prod-data.html
+++ b/redirects/7.2/tasks/restore-prod-data.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/migration/
+/content-services/7.2/admin/migration/

--- a/redirects/7.2/tasks/search-advanced.html
+++ b/redirects/7.2/tasks/search-advanced.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/tasks/serv-runtimetransformer-extend.html
+++ b/redirects/7.2/tasks/serv-runtimetransformer-extend.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/content-transformers-renditions/
+/content-services/7.2/develop/repo-ext-points/content-transformers-renditions/

--- a/redirects/7.2/tasks/set-homepage.html
+++ b/redirects/7.2/tasks/set-homepage.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/dashboard/
+/content-services/7.2/using/dashboard/

--- a/redirects/7.2/tasks/sf-config-examples.html
+++ b/redirects/7.2/tasks/sf-config-examples.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/
+/content-services/7.2/config/smart-folders/

--- a/redirects/7.2/tasks/sf-tutorial-add.html
+++ b/redirects/7.2/tasks/sf-tutorial-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial-cmm.html
+++ b/redirects/7.2/tasks/sf-tutorial-cmm.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial-configure.html
+++ b/redirects/7.2/tasks/sf-tutorial-configure.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial-create-rule.html
+++ b/redirects/7.2/tasks/sf-tutorial-create-rule.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial-create.html
+++ b/redirects/7.2/tasks/sf-tutorial-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial-multi.html
+++ b/redirects/7.2/tasks/sf-tutorial-multi.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial-policy.html
+++ b/redirects/7.2/tasks/sf-tutorial-policy.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-tutorial.html
+++ b/redirects/7.2/tasks/sf-tutorial.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/smart/
+/content-services/7.2/tutorial/smart/

--- a/redirects/7.2/tasks/sf-using-aspects.html
+++ b/redirects/7.2/tasks/sf-using-aspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/smart-folders/
+/content-services/7.2/using/smart-folders/

--- a/redirects/7.2/tasks/share-change-password.html
+++ b/redirects/7.2/tasks/share-change-password.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/helm-examples/
+/content-services/7.2/install/containers/helm-examples/

--- a/redirects/7.2/tasks/share-change-port.html
+++ b/redirects/7.2/tasks/share-change-port.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/site-presets/
+/content-services/7.2/develop/share-ext-points/site-presets/

--- a/redirects/7.2/tasks/share-customizing-cookies.html
+++ b/redirects/7.2/tasks/share-customizing-cookies.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/doclib/
+/content-services/7.2/tutorial/share/doclib/

--- a/redirects/7.2/tasks/share-enable-external-user.html
+++ b/redirects/7.2/tasks/share-enable-external-user.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/activemq/
+/content-services/7.2/config/activemq/

--- a/redirects/7.2/tasks/share-repodoclib-aspects.html
+++ b/redirects/7.2/tasks/share-repodoclib-aspects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/permissions/
+/content-services/7.2/develop/repo-ext-points/permissions/

--- a/redirects/7.2/tasks/share-repodoclib-config.html
+++ b/redirects/7.2/tasks/share-repodoclib-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/tasks/site-addremove-dashboard.html
+++ b/redirects/7.2/tasks/site-addremove-dashboard.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/site-content-tag.html
+++ b/redirects/7.2/tasks/site-content-tag.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/search/
+/content-services/7.2/using/search/

--- a/redirects/7.2/tasks/site-creation-permission.html
+++ b/redirects/7.2/tasks/site-creation-permission.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/patches/
+/content-services/7.2/develop/repo-ext-points/patches/

--- a/redirects/7.2/tasks/site-customize-dashboard.html
+++ b/redirects/7.2/tasks/site-customize-dashboard.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/site-customize-notice.html
+++ b/redirects/7.2/tasks/site-customize-notice.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/site-customize-wiki.html
+++ b/redirects/7.2/tasks/site-customize-wiki.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/site-customize.html
+++ b/redirects/7.2/tasks/site-customize.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/site-subscribe-rss-feed.html
+++ b/redirects/7.2/tasks/site-subscribe-rss-feed.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/share/
+/content-services/7.2/using/share/

--- a/redirects/7.2/tasks/sites-create.html
+++ b/redirects/7.2/tasks/sites-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/sites-delete.html
+++ b/redirects/7.2/tasks/sites-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/sites-edit-details.html
+++ b/redirects/7.2/tasks/sites-edit-details.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/sites-favourites-menu.html
+++ b/redirects/7.2/tasks/sites-favourites-menu.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/sites-leave.html
+++ b/redirects/7.2/tasks/sites-leave.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/sites-manage.html
+++ b/redirects/7.2/tasks/sites-manage.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/sites-search.html
+++ b/redirects/7.2/tasks/sites-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/
+/content-services/7.2/using/sites/

--- a/redirects/7.2/tasks/space-nodes-create.html
+++ b/redirects/7.2/tasks/space-nodes-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/tasks/sqlserver-config.html
+++ b/redirects/7.2/tasks/sqlserver-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/databases/
+/content-services/7.2/config/databases/

--- a/redirects/7.2/tasks/start-share.html
+++ b/redirects/7.2/tasks/start-share.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/tasks/store-filestore-define.html
+++ b/redirects/7.2/tasks/store-filestore-define.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/scheduled-jobs/
+/content-services/7.2/develop/repo-ext-points/scheduled-jobs/

--- a/redirects/7.2/tasks/subsystem-classpath.html
+++ b/redirects/7.2/tasks/subsystem-classpath.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/tasks/subsystem-mount-comp.html
+++ b/redirects/7.2/tasks/subsystem-mount-comp.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/scheduled-jobs/
+/content-services/7.2/develop/repo-ext-points/scheduled-jobs/

--- a/redirects/7.2/tasks/subsystem-mount.html
+++ b/redirects/7.2/tasks/subsystem-mount.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/subsystems/
+/content-services/7.2/config/subsystems/

--- a/redirects/7.2/tasks/surf-page-view.html
+++ b/redirects/7.2/tasks/surf-page-view.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/share/pages/
+/content-services/7.2/tutorial/share/pages/

--- a/redirects/7.2/tasks/surf-tutorials-create-surf-project.html
+++ b/redirects/7.2/tasks/surf-tutorials-create-surf-project.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/tools/
+/content-services/7.2/develop/tools/

--- a/redirects/7.2/tasks/surf-tutorials-exploring-root-objects.html
+++ b/redirects/7.2/tasks/surf-tutorials-exploring-root-objects.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/repo-ext-points/bootstrap-content/
+/content-services/7.2/develop/repo-ext-points/bootstrap-content/

--- a/redirects/7.2/tasks/templated-nodes-create.html
+++ b/redirects/7.2/tasks/templated-nodes-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/templates/
+/content-services/7.2/admin/templates/

--- a/redirects/7.2/tasks/themes-select.html
+++ b/redirects/7.2/tasks/themes-select.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-themes/
+/content-services/7.2/develop/share-ext-points/share-themes/

--- a/redirects/7.2/tasks/tiny-lang.html
+++ b/redirects/7.2/tasks/tiny-lang.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/repository/
+/content-services/7.2/config/repository/

--- a/redirects/7.2/tasks/troubleshoot-openoffice.html
+++ b/redirects/7.2/tasks/troubleshoot-openoffice.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/troubleshoot/
+/content-services/7.2/admin/troubleshoot/

--- a/redirects/7.2/tasks/troubleshoot-upgrade.html
+++ b/redirects/7.2/tasks/troubleshoot-upgrade.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/tasks/uninstall-amp.html
+++ b/redirects/7.2/tasks/uninstall-amp.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/amp/
+/content-services/7.2/install/zip/amp/

--- a/redirects/7.2/tasks/unzip-files.html
+++ b/redirects/7.2/tasks/unzip-files.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/files-folders/
+/content-services/7.2/using/content/files-folders/

--- a/redirects/7.2/tasks/upgrade-process.html
+++ b/redirects/7.2/tasks/upgrade-process.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/tasks/upgrade-validate.html
+++ b/redirects/7.2/tasks/upgrade-validate.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/tasks/usernametypes-mix-config.html
+++ b/redirects/7.2/tasks/usernametypes-mix-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/share-config/
+/content-services/7.2/develop/share-ext-points/share-config/

--- a/redirects/7.2/tasks/versionable-make.html
+++ b/redirects/7.2/tasks/versionable-make.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/aikau-menus/
+/content-services/7.2/develop/share-ext-points/aikau-menus/

--- a/redirects/7.2/tasks/wf-install-activiti-designer.html
+++ b/redirects/7.2/tasks/wf-install-activiti-designer.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/model/
+/content-services/7.2/tutorial/model/

--- a/redirects/7.2/tasks/wf-install-eclipse.html
+++ b/redirects/7.2/tasks/wf-install-eclipse.html
@@ -1,1 +1,1 @@
-/content-services/latest/upgrade/
+/content-services/7.2/upgrade/

--- a/redirects/7.2/tasks/wiki-browse-pages.html
+++ b/redirects/7.2/tasks/wiki-browse-pages.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-access.html
+++ b/redirects/7.2/tasks/wiki-page-access.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-create.html
+++ b/redirects/7.2/tasks/wiki-page-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-delete.html
+++ b/redirects/7.2/tasks/wiki-page-delete.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-edit.html
+++ b/redirects/7.2/tasks/wiki-page-edit.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-main-create.html
+++ b/redirects/7.2/tasks/wiki-page-main-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-rename.html
+++ b/redirects/7.2/tasks/wiki-page-rename.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/wiki-page-view-details.html
+++ b/redirects/7.2/tasks/wiki-page-view-details.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/sites/features/
+/content-services/7.2/using/sites/features/

--- a/redirects/7.2/tasks/ws-I18N-german.html
+++ b/redirects/7.2/tasks/ws-I18N-german.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-I18N.html
+++ b/redirects/7.2/tasks/ws-I18N.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-cache-using.html
+++ b/redirects/7.2/tasks/ws-cache-using.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-config.html
+++ b/redirects/7.2/tasks/ws-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-content-negotiation.html
+++ b/redirects/7.2/tasks/ws-content-negotiation.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-controller-create.html
+++ b/redirects/7.2/tasks/ws-controller-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-controller-debug.html
+++ b/redirects/7.2/tasks/ws-controller-debug.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-curl.html
+++ b/redirects/7.2/tasks/ws-curl.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-desc-doc-create.html
+++ b/redirects/7.2/tasks/ws-desc-doc-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-folderListing-Java-components.html
+++ b/redirects/7.2/tasks/ws-folderListing-Java-components.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-folderListing-Java-controller.html
+++ b/redirects/7.2/tasks/ws-folderListing-Java-controller.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-folderListing-Java-scripting.html
+++ b/redirects/7.2/tasks/ws-folderListing-Java-scripting.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-forms-process.html
+++ b/redirects/7.2/tasks/ws-forms-process.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-forms-test.html
+++ b/redirects/7.2/tasks/ws-forms-test.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-hello-user-create.html
+++ b/redirects/7.2/tasks/ws-hello-user-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-hello-world-create.html
+++ b/redirects/7.2/tasks/ws-hello-world-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-hello-world-locate.html
+++ b/redirects/7.2/tasks/ws-hello-world-locate.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-json-add.html
+++ b/redirects/7.2/tasks/ws-json-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-json-callbacks-explain.html
+++ b/redirects/7.2/tasks/ws-json-callbacks-explain.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-json-callbacks-using.html
+++ b/redirects/7.2/tasks/ws-json-callbacks-using.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/tasks/ws-new-kind-create.html
+++ b/redirects/7.2/tasks/ws-new-kind-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-new-kind-using.html
+++ b/redirects/7.2/tasks/ws-new-kind-using.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-photo-search.html
+++ b/redirects/7.2/tasks/ws-photo-search.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/share-ext-points/surf-widgets/
+/content-services/7.2/develop/share-ext-points/surf-widgets/

--- a/redirects/7.2/tasks/ws-prebuilt-list.html
+++ b/redirects/7.2/tasks/ws-prebuilt-list.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-register.html
+++ b/redirects/7.2/tasks/ws-register.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-request-process-extend.html
+++ b/redirects/7.2/tasks/ws-request-process-extend.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-request-process.html
+++ b/redirects/7.2/tasks/ws-request-process.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-respTemp-create.html
+++ b/redirects/7.2/tasks/ws-respTemp-create.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-response-format-select.html
+++ b/redirects/7.2/tasks/ws-response-format-select.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-response-format.html
+++ b/redirects/7.2/tasks/ws-response-format.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/platform/web-scripts/
+/content-services/7.2/tutorial/platform/web-scripts/

--- a/redirects/7.2/tasks/ws-responseCode-add.html
+++ b/redirects/7.2/tasks/ws-responseCode-add.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-specify-user-identity.html
+++ b/redirects/7.2/tasks/ws-specify-user-identity.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-tutorials.html
+++ b/redirects/7.2/tasks/ws-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/tasks/ws-uri-parse.html
+++ b/redirects/7.2/tasks/ws-uri-parse.html
@@ -1,1 +1,1 @@
-/content-services/latest/develop/reference/web-scripts-ref/
+/content-services/7.2/develop/reference/web-scripts-ref/

--- a/redirects/7.2/topics/alfresco-video-tutorials.html
+++ b/redirects/7.2/topics/alfresco-video-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/tutorial/video/
+/content-services/7.2/tutorial/video/

--- a/redirects/7.2/topics/enabling-aps-review-processes.html
+++ b/redirects/7.2/topics/enabling-aps-review-processes.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/
+/content-services/7.2/config/

--- a/redirects/7.2/topics/mobile-config.html
+++ b/redirects/7.2/topics/mobile-config.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/topics/outside-alfresco.html
+++ b/redirects/7.2/topics/outside-alfresco.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/
+/content-services/7.2/using/

--- a/redirects/7.2/topics/prod-setup.html
+++ b/redirects/7.2/topics/prod-setup.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/zip/
+/content-services/7.2/install/zip/

--- a/redirects/7.2/topics/prop-tables-alt.html
+++ b/redirects/7.2/topics/prop-tables-alt.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/db-cleanup/
+/content-services/7.2/admin/db-cleanup/

--- a/redirects/7.2/topics/sh-uh-welcome.html
+++ b/redirects/7.2/topics/sh-uh-welcome.html
@@ -1,1 +1,1 @@
-/content-services/latest/using/content/
+/content-services/7.2/using/content/

--- a/redirects/7.2/topics/smart-video-tutorials.html
+++ b/redirects/7.2/topics/smart-video-tutorials.html
@@ -1,1 +1,1 @@
-/content-services/latest/config/smart-folders/sf-faq/
+/content-services/7.2/config/smart-folders/sf-faq/

--- a/redirects/7.2/topics/wf-activiti-designer-setup.html
+++ b/redirects/7.2/topics/wf-activiti-designer-setup.html
@@ -1,1 +1,1 @@
-/content-services/latest/install/containers/
+/content-services/7.2/install/containers/

--- a/redirects/7.2/topics/wf-deploy-taskmodel.html
+++ b/redirects/7.2/topics/wf-deploy-taskmodel.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/topics/wf-howto.html
+++ b/redirects/7.2/topics/wf-howto.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/

--- a/redirects/7.2/topics/wf-intro-deploy-pd.html
+++ b/redirects/7.2/topics/wf-intro-deploy-pd.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/workflows/
+/content-services/7.2/admin/workflows/


### PR DESCRIPTION
This PR switches the redirects from `content-services/latest/` to `content-services/7.2/`. 

**Impact:** Affects docs links from the Admin Console and Alfresco Share when running Alfresco Content Services 7.2 (Enterprise and Community Editions).