### PR TITLE
[DOCS-7069] Java ReST API artifact changed name in SDK 5.2.0

### DIFF
--- a/content-services/latest/develop/oop-sdk.md
+++ b/content-services/latest/develop/oop-sdk.md
@@ -1285,7 +1285,7 @@ Make sure you have completed [prerequisites](#prereq) and created a [starter pro
         <!-- Alfresco Java SDK 5 Java ReST API wrapper Spring Boot Starter -->
         <dependency>
         <groupId>org.alfresco</groupId>
-        <artifactId>alfresco-java-rest-api-spring-boot-starter</artifactId>
+        <artifactId>alfresco-acs-java-rest-api-spring-boot-starter</artifactId>
         <version>5.2.0</version>
         </dependency>
     </dependencies>
@@ -1815,7 +1815,7 @@ search.service.path=/alfresco/api/-default-/public/search/versions/1
         <!-- Alfresco Java SDK 5 Java ReST API wrapper Spring Boot Starter -->
         <dependency>
         <groupId>org.alfresco</groupId>
-        <artifactId>alfresco-java-rest-api-spring-boot-starter</artifactId>
+        <artifactId>alfresco-acs-java-rest-api-spring-boot-starter</artifactId>
         <version>5.2.0</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Documentation was updated to reflect the change in the artifact name for the ACS Java ReST API.  I noticed these is also an APA artifact as well so I don't know if this documentation needs to be updated to reflect that or not (I am assuming not since neither workflow or APA are mentioned on this page).