### PR TITLE
[DOCS-6952][DOCS-6696] Update Federation Services compatibility with Content Services

### DIFF
--- a/content-services/7.0/support/index.md
+++ b/content-services/7.0/support/index.md
@@ -84,6 +84,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Document Transformation Engine 2.3 | |
 | Alfresco Search and Insight Engine 2.0 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0 | |
+| Alfresco Federation Services 2.1 | |
 | Alfresco Federation Services 2.0 | |
 | Identity Service 1.5 | Alfresco Content Services 7.0 supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
 | Identity Service 1.4 | Alfresco Content Services 7.0 supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
@@ -201,6 +202,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Transform Service 1.3.2 | |
 | Alfresco Search and Insight Engine 2.0 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. Nb. Java 11.0.9.1 and other four part Java versions are not currently compatible due to a bug in Jetty. |
 | Alfresco Search Services 2.0 | |
+| Alfresco Federation Services 2.1 | |
 | Alfresco Federation Services 2.0 | |
 | Identity Service 1.4 | Alfresco Content Services 7.0 supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
 | SAML Module for Alfresco Content Services 1.2.1 | |

--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -82,7 +82,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Search Enterprise 3.0 | For information about migrating from Alfresco Search and Insight Engine 2.0 or Alfresco Search Services 2.0, see the [Alfresco Search Enterprise 3.0 upgrade page]({% link search-enterprise/3.0/upgrade/index.md %}). |
 | Alfresco Search and Insight Engine 2.0 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0 | |
-| Alfresco Federation Services 2.0 | |
+| Alfresco Federation Services 2.1 | |
 | Identity Service 1.7 | |
 | Identity Service 1.6 | |
 | SAML Module for Alfresco Content Services 1.2.2 | |
@@ -196,7 +196,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Search Enterprise 3.0 | For information about migrating from Alfresco Search and Insight Engine 2.0 or Alfresco Search Services 2.0, see the [Alfresco Search Enterprise 3.0 upgrade page]({% link search-enterprise/3.0/upgrade/index.md %}). |
 | Alfresco Search and Insight Engine 2.0 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0 | |
-| Alfresco Federation Services 2.0 | |
+| Alfresco Federation Services 2.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
 | Identity Service 1.6 | |

--- a/content-services/7.2/support/index.md
+++ b/content-services/7.2/support/index.md
@@ -83,7 +83,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Search Enterprise 3.1 | For information about migrating from Alfresco Search and Insight Engine 2.0 or Alfresco Search Services 2.0, see the [Alfresco Search Enterprise 3.x upgrade page]({% link search-enterprise/latest/upgrade/index.md %}). |
 | Alfresco Search and Insight Engine 2.0.3 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0.3 | |
-| Alfresco Federation Services 1.1 | |
+| Alfresco Federation Services 2.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
 | SAML Module for Alfresco Content Services 1.2.3 | |
@@ -198,7 +198,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Search Enterprise 3.1 | For information about migrating from Alfresco Search and Insight Engine 2.0 or Alfresco Search Services 2.0, see the [Alfresco Search Enterprise 3.x upgrade page]({% link search-enterprise/latest/upgrade/index.md %}). |
 | Alfresco Search and Insight Engine 2.0.3 | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0.3 | |
-| Alfresco Federation Services 1.1 | |
+| Alfresco Federation Services 2.1 | |
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
 | SAML Module for Alfresco Content Services 1.2.2 | |


### PR DESCRIPTION
This PR corrects the Alfresco Federation Services (AFS) compatibility with Alfresco Content Services 7.0 - 7.2