### PR TITLE
[DOCS-7110] Remove trailing space in redirect path

### DIFF
--- a/redirects/7.3/concepts/auth-alfrescontlm-intro.html
+++ b/redirects/7.3/concepts/auth-alfrescontlm-intro.html
@@ -1,1 +1,1 @@
-/content-services/latest/admin/auth-sync/ 
+/content-services/latest/admin/auth-sync/


### PR DESCRIPTION
Since there's a space at the end of the redirect path in the source file, the redirect only goes to the ACS docs root (https://docs.alfresco.com/content-services/latest/) instead of `/content-services/latest/admin/auth-sync/`. This ticket removes the trailing space so the redirect will work properly.