### PR TITLE
[DOCS-7107] Remove leftover content from SSO Guide for ACS 7.3 and above

### DIFF
--- a/identity-service/latest/tutorial/sso/ldap.md
+++ b/identity-service/latest/tutorial/sso/ldap.md
@@ -27,7 +27,7 @@ The following are the prerequisites needed to configure SSO with LDAP:
 
 ## Configuration
 
-There are elevn steps to configuring SSO using an LDAP directory with Alfresco products. The following are the host names used as examples throughout the configuration:
+There are eleven steps to configuring SSO using an LDAP directory with Alfresco products. The following are the host names used as examples throughout the configuration:
 
 * Alfresco Content Services: `repo.example.com`
 * Alfresco Share: `share.example.com`
@@ -108,43 +108,13 @@ The properties listed that need to be set for Alfresco Content Services (ACS) ar
     |csrf.filter.referer | The referer value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com`|
     |csrf.filter.origin | The origin value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com/*`|
 
-2. Update the `share-config-custom.xml` file located by default in `$ALFRESCO_HOME/tomcat/shared/classes/alfresco/web-extension/`:
+2. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
 
-    * Set the `CSRFPolicy` to true as in the following example:
+3. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
 
-        ```xml
-        <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
-        ```
+4. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
 
-    * Add the following two rules to allow for signing out via SAML:
-
-        ```xml
-        <rule>
-          <request>
-            <method>GET</method>
-            <path>/res/.*</path>
-          </request>
-        </rule>
-        ```
-
-        ```xml
-        <rule>
-          <request>
-            <method>POST</method>
-            <path>/page/saml-authnresponse|/page/saml-logoutresponse|/page/saml-logoutrequest</path>
-          </request>
-        </rule>
-        ```
-
-        > **Note**: Incoming public GET requests will be caught avoiding them being evaluated by other rules. Incoming POST requests from identity providers do not need a token.
-
-3. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
-
-4. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
-
-5. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
-
-6. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
+5. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
 
 ## Step 4: Configure Alfresco Digital Workspace
 

--- a/identity-service/latest/tutorial/sso/ldap.md
+++ b/identity-service/latest/tutorial/sso/ldap.md
@@ -108,13 +108,21 @@ The properties listed that need to be set for Alfresco Content Services (ACS) ar
     |csrf.filter.referer | The referer value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com`|
     |csrf.filter.origin | The origin value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com/*`|
 
-2. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
+2. Update the `share-config-custom.xml` file located by default in `$ALFRESCO_HOME/tomcat/shared/classes/alfresco/web-extension/`:
 
-3. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
+    * Set the `CSRFPolicy` to true as in the following example:
 
-4. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
+        ```xml
+        <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+        ```
 
-5. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
+3. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
+
+4. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
+
+5. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
+
+6. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
 
 ## Step 4: Configure Alfresco Digital Workspace
 

--- a/identity-service/latest/tutorial/sso/saml.md
+++ b/identity-service/latest/tutorial/sso/saml.md
@@ -161,7 +161,15 @@ The properties listed that need to be set for Alfresco Content Services (ACS) ar
     |csrf.filter.referer | The referer value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com`|
     |csrf.filter.origin | The origin value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com/*`|
 
-2. Set a session timeout in both web.xml files located by default in `$ALFRESCO_HOME/tomcat/webapps/share/WEB-INF` and `$ALFRESCO_HOME/tomcat/webapps/alfresco/WEB-INF`. This should match the value [configured for the realm](#step-1-configure-a-realm-and-clients).
+2. Update the `share-config-custom.xml` file located by default in `$ALFRESCO_HOME/tomcat/shared/classes/alfresco/web-extension/`:
+
+    * Set the `CSRFPolicy` to true as in the following example:
+
+        ```xml
+        <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+        ```
+
+3. Set a session timeout in both `web.xml` files located by default in `$ALFRESCO_HOME/tomcat/webapps/share/WEB-INF` and `$ALFRESCO_HOME/tomcat/webapps/alfresco/WEB-INF`. This should match the value [configured for the realm](#step-1-configure-a-realm-and-clients).
 
     The following is an example of the property to add:
 
@@ -173,13 +181,10 @@ The properties listed that need to be set for Alfresco Content Services (ACS) ar
 
     > **Note:** This example sets a session time of 12 hours.
 
-3. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
-
-4. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
-
-5. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
-
-6. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
+4. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
+5. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
+6. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
+7. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
 
 ## Step 7: Configure Alfresco Digital Workspace
 

--- a/identity-service/latest/tutorial/sso/saml.md
+++ b/identity-service/latest/tutorial/sso/saml.md
@@ -161,37 +161,7 @@ The properties listed that need to be set for Alfresco Content Services (ACS) ar
     |csrf.filter.referer | The referer value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com`|
     |csrf.filter.origin | The origin value of ACS to prevent Cross Site Request Forgery (CSRF), for example `https://repo.example.com/*`|
 
-2. Update the `share-config-custom.xml` file located by default in `$ALFRESCO_HOME/tomcat/shared/classes/alfresco/web-extension/`:
-
-    * Set the `CSRFPolicy` to true as in the following example:
-
-        ```xml
-        <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
-        ```
-
-    * Add the following two rules to allow for signing out via SAML:
-
-        ```xml
-        <rule>
-          <request>
-            <method>GET</method>
-            <path>/res/.*</path>
-          </request>
-        </rule>
-        ```
-
-        ```xml
-        <rule>
-          <request>
-            <method>POST</method>
-            <path>/page/saml-authnresponse|/page/saml-logoutresponse|/page/saml-logoutrequest</path>
-          </request>
-        </rule>
-        ```
-
-        > **Note:** Incoming public GET requests will be caught avoiding them being evaluated by other rules. Incoming POST requests from identity providers do not need a token.
-
-3. Set a session timeout in both web.xml files located by default in `$ALFRESCO_HOME/tomcat/webapps/share/WEB-INF` and `$ALFRESCO_HOME/tomcat/webapps/alfresco/WEB-INF`. This should match the value [configured for the realm](#step-1-configure-a-realm-and-clients).
+2. Set a session timeout in both web.xml files located by default in `$ALFRESCO_HOME/tomcat/webapps/share/WEB-INF` and `$ALFRESCO_HOME/tomcat/webapps/alfresco/WEB-INF`. This should match the value [configured for the realm](#step-1-configure-a-realm-and-clients).
 
     The following is an example of the property to add:
 
@@ -203,10 +173,13 @@ The properties listed that need to be set for Alfresco Content Services (ACS) ar
 
     > **Note:** This example sets a session time of 12 hours.
 
-4. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
-5. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
-6. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
-7. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
+3. Sign in to the administrator console of ACS as an administrator. The URL of the administrator console is `https://repo.example.com:443/alfresco/service/enterprise/admin`.
+
+4. Navigate to **Directories** > **Directory Management** and click **Run Synchronize** to perform a manual LDAP sync.
+
+5. Sign into Share as an administrator. The URL for Share is `https://share.example.com/share`.
+
+6. Navigate to **Admin Tools** > **Users** to verify that all user accounts have been synchronized correctly.
 
 ## Step 7: Configure Alfresco Digital Workspace
 


### PR DESCRIPTION
This PR removes some leftover content from the second bullet point in the SAML (Step 6) and LDAP (Step 3) pages. Affects the SSO Guide v2 for ACS 7.3 and above