### PR TITLE
[DOCS-7109] Added AMW 1.6 to ACS 7.3 and 7.3.1

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -90,6 +90,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Applications** | |
 | Alfresco Digital Workspace 3.1 | |
 | Alfresco Application Development Framework (ADF) 5.x | Some API functionality may be available only in the latest Alfresco Content Services release. |
+| Alfresco Mobile Workspace 1.6 | |
 | Alfresco Mobile Workspace 1.5 | |
 | Alfresco Content Accelerator (ACA) 3.5 | |
 | Alfresco Enterprise Viewer (AEV) 3.5 | |
@@ -184,6 +185,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Applications** | |
 | Alfresco Digital Workspace 3.1 | |
 | Alfresco Application Development Framework (ADF) 5.x | Some API functionality may be available only in the latest Alfresco Content Services release. |
+| Alfresco Mobile Workspace 1.6 | |
 | Alfresco Mobile Workspace 1.5 | |
 | Alfresco Content Accelerator (ACA) 3.5 | |
 | Alfresco Enterprise Viewer (AEV) 3.5 | |


### PR DESCRIPTION
I left Mobile Workspace 1.5 and added 1.6 to the supported platform page.