### PR TITLE
[DOCS-7031] Fix Supported platforms page for Identity Service 1.8

### DIFF
--- a/identity-service/latest/support/index.md
+++ b/identity-service/latest/support/index.md
@@ -6,12 +6,14 @@ The following are the supported platforms for the Identity Service version 1.8:
 
 | Version | Notes |
 | ------- | ----- |
-| Content Services 7.2.0 | Content Services supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
-| Content Services 7.1.0 | Content Services supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
-| Digital Workspace 1.7 | |
-| Office Services 1.4 | |
-| Sync Service 3.3 | Not currently supported with Kerberos |
-| Desktop Sync 1.5 | Not currently supported with Kerberos |
+| Content Services 7.3 | Content Services supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
+| Content Services 7.2 | Content Services supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
+| Content Services 7.1 | Content Services supports the use of CMIS and authentication with the v1 REST APIs using the Identity Service. ADF and other modules are not currently supported for authentication. |
+| | |
+| **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Digital Workspace 3.1 | |
+| Office Services 1.5 | |
+| Sync Service 3.8 | Not currently supported with Kerberos |
+| Desktop Sync 1.13.1 | Not currently supported with Kerberos |
 | Process Services 2.3 | |
-| Process Workspace 1.3.4 | |
 | Alfresco iOS APS Mobile App | Not currently supported with Kerberos |


### PR DESCRIPTION
Update page based on the components tested with Alfresco Content Services 7.3