### PR TITLE
[DOCS-7322] ACS 7.3+ Kerberos Fix

### DIFF
--- a/identity-service/latest/tutorial/sso/kerberos.md
+++ b/identity-service/latest/tutorial/sso/kerberos.md
@@ -90,6 +90,8 @@ The following table explains the values used to generate the `keytab` and `krb5.
     default_realm = <REALM>
     default_tkt_enctypes = rc4-hmac
     default_tgs_enctypes = rc4-hmac
+    permitted_enctypes = rc4-hmac aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+    allow_weak_crypto = true
 
     [realms]
     <REALM> = {
@@ -109,6 +111,8 @@ The following table explains the values used to generate the `keytab` and `krb5.
     default_realm = EXAMPLE.COM
     default_tkt_enctypes = rc4-hmac
     default_tgs_enctypes = rc4-hmac
+    permitted_enctypes = rc4-hmac aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+    allow_weak_crypto = true
 
     [realms]
     EXAMPLE.COM = {


### PR DESCRIPTION
Due to rc4-hmac deprecation in JDK17 (see: https://bugs.openjdk.org/browse/JDK-8262273) two additional lines have to be added to krb5.conf to enable rc4-hmac encryption and fix Kerberos authentication in ACS 7.3+ running OpenJDK 17. The change is backwards compatible and can be also applied in pre-ACS 7.3 versions running OpenJDK 11.