### PR TITLE
[DOCS-7041] Fix NGINX container name and what's deployed

### DIFF
--- a/content-services/7.0/install/containers/index.md
+++ b/content-services/7.0/install/containers/index.md
@@ -61,7 +61,7 @@ The following Docker images relate to Content Services:
 * `quay.io/alfresco/alfresco-share` - the Share web interface (i.e. `share.war`) running on Apache Tomcat
 * `alfresco/alfresco-search-services` - the Solr 6 based search service running on Jetty
 * `alfresco/alfresco-activemq` - the Alfresco ActiveMQ image
-* `alfresco/alfresco-acs-ngnix` - web proxy
+* `alfresco/alfresco-acs-nginx` - web proxy
 
 There are also other supporting features available, such as Docker images for image and document transformation:
 

--- a/content-services/7.1/install/containers/index.md
+++ b/content-services/7.1/install/containers/index.md
@@ -61,7 +61,7 @@ The following Docker images relate to Content Services:
 * `quay.io/alfresco/alfresco-share` - the Share web interface (i.e. `share.war`) running on Apache Tomcat
 * `alfresco/alfresco-search-services` - the Solr 6 based search service running on Jetty
 * `alfresco/alfresco-activemq` - the Alfresco ActiveMQ image
-* `alfresco/alfresco-acs-ngnix` - web proxy
+* `alfresco/alfresco-acs-nginx` - web proxy
 
 There are also other supporting features available, such as Docker images for image and document transformation:
 

--- a/content-services/7.2/install/containers/index.md
+++ b/content-services/7.2/install/containers/index.md
@@ -63,7 +63,7 @@ The following Docker images relate to Content Services:
 * `quay.io/alfresco/search-services` - the Solr 6 based search service running on Jetty
 * `quay.io/alfresco/service-sync` - synchronizes files between the desktop and repository using web services
 * `alfresco/alfresco-activemq` - the Alfresco ActiveMQ image
-* `alfresco/alfresco-acs-ngnix` - web proxy
+* `alfresco/alfresco-acs-nginx` - web proxy
 
 There are also supporting features available, such as Docker images for image and document transformation:
 
@@ -96,6 +96,7 @@ When you deploy Content Services, a number of containers are started.
 * [Alfresco Transform Service]({% link transform-service/latest/index.md %})
 * [Alfresco Digital Workspace]({% link digital-workspace/latest/index.md %})
 * [Alfresco Sync Service]({% link sync-service/latest/index.md %})
+* [Alfresco Control Center]({% link content-services/7.2/admin/control-center.md %})
 
 ### GitHub projects
 

--- a/content-services/7.3/install/containers/index.md
+++ b/content-services/7.3/install/containers/index.md
@@ -63,7 +63,7 @@ The following Docker images relate to Content Services:
 * `quay.io/alfresco/search-services` - the Solr 6 based search service running on Jetty
 * `quay.io/alfresco/service-sync` - synchronizes files between the desktop and repository using web services
 * `alfresco/alfresco-activemq` - the Alfresco ActiveMQ image
-* `alfresco/alfresco-acs-ngnix` - web proxy
+* `alfresco/alfresco-acs-nginx` - web proxy
 
 There are also supporting features available, such as Docker images for image and document transformation:
 
@@ -96,6 +96,7 @@ When you deploy Content Services, a number of containers are started.
 * [Alfresco Transform Service]({% link transform-service/latest/index.md %})
 * [Alfresco Digital Workspace]({% link digital-workspace/latest/index.md %})
 * [Alfresco Sync Service]({% link sync-service/latest/index.md %})
+* [Alfresco Control Center]({% link content-services/7.3/admin/control-center.md %})
 
 ### GitHub projects
 

--- a/content-services/latest/install/containers/index.md
+++ b/content-services/latest/install/containers/index.md
@@ -96,6 +96,7 @@ When you deploy Content Services, a number of containers are started.
 * [Alfresco Transform Service]({% link transform-service/latest/index.md %})
 * [Alfresco Digital Workspace]({% link digital-workspace/latest/index.md %})
 * [Alfresco Sync Service]({% link sync-service/latest/index.md %})
+* [Alfresco Control Center]({% link content-services/latest/admin/control-center.md %})
 
 ### GitHub projects
 


### PR DESCRIPTION
Fixes the NGINX container name in Alfresco Content Services 7.0-7.4, following on from #1049. Also fixes what's deployed in Content Services 7.2-7.4. The Community docs will be fixed in a separate PR.