### PR TITLE
ACS-4369 Support for path features.

### DIFF
--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -73,7 +73,7 @@ Alfresco Search Enterprise has a focus on the most commonly used features and of
 | NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
 | ANAME:'0/cdefb3a9-8f55-4771-a9e3-06fa370250f6' | PARENT:'cdefb3a9-8f55-4771-a9e3-06fa370250f6' |
 
-However secondary paths and secondary parents are not yet supported, so there may still be some differences if these are in use.
+However secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -74,7 +74,7 @@ The following are examples of how to use different fields for queries:
 | PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                            |
 | NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
 
-> **Note:** Secondary paths are not supported, which means there may be some differences if these are in use.
+> **Note:** However secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -74,7 +74,7 @@ The following are examples of how to use different fields for queries:
 | PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                            |
 | NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
 
-> **Note:** However secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
+> **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -2,7 +2,7 @@
 title: Unsupported features
 ---
 
-The following features, which were supported with Search and Insight Engine 2.x and Search Services 2.x (Solr) are not supported in the latest release for Search Enterprise 3.x (Elasticsearch).
+The following features, which were supported with Search and Insight Engine 2.x and Search Services 2.x (Solr) are not supported in the latest release for Search Enterprise 3.x.
 
 ## Indexing
 
@@ -61,11 +61,12 @@ The following features, which were supported with Search and Insight Engine 2.x 
 
 * Secondary paths (paths including secondary parents)
 
-## Behaviour of Unsupported fields
+## Behavior of unsupported fields
 
-Supplying an unsupported or non-existent field will cause the query to fail. This is a change in behaviour compared with the Search and Insight Engine and Search Services, which silently ignore these issues.
+Supplying an unsupported or non-existent field will cause a query to fail. This is a change in behavior from Search and Insight Engine and Search Services, which silently ignore these issues.
 
-Alfresco Search Enterprise has a focus on the most commonly used features and often it is possible to work around unsupported features. Here are a few examples of how to use a different field for queries:
+Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
+The following are examples of how to use a different fields for queries:
 
 | Old Query                                      | Replacement Query                             |
 | ---------------------------------------------- | --------------------------------------------- |
@@ -73,7 +74,7 @@ Alfresco Search Enterprise has a focus on the most commonly used features and of
 | PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                            |
 | NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
 
-However secondary paths are not supported at this time, so there may still be some differences if these are in use.
+> **Note:** Secondary paths are not supported, which means there may be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -32,10 +32,7 @@ The following features, which were supported with Search and Insight Engine 2.x 
 * PNAME
 * ANAME
 * NPATH
-* PARENT
-* PRIMARYPARENT
 * QNAME
-* ANCESTOR
 * PRIMARYASSOCQNAME
 * PRIMARYASSOCTYPEQNAME
 * FINGERPRINT
@@ -58,18 +55,25 @@ The following features, which were supported with Search and Insight Engine 2.x 
 * DENYSET
 * FTSSTATUS
 
-## Alfresco Digital Workspace
+### Path Indexing
 
-To ensure ADW basic functionality the part of a query that contains an unsupported field will be ignored and the REST API will return a 200 HTTP code. A warning message will be produced in the Alfresco Repository log.
+* Secondary parents
+* Secondary paths (paths including secondary parents)
 
-All unsupported fields will be ignored in queries and filters following the schema below:
+## Behaviour of Unsupported fields
 
-* The query contains only an unsupported field, for example `QNAME:hello` returns an empty result.
-* The query contains a supported field, for example `hello AND QNAME:goodbye` returns only documents containing “hello”.
-* A filter contains only an unsupported field, for example `query=banana`, `filter=QNAME:hello` returns only documents containing “banana”.
-* A filter contains two filters or a filter with a supported field and an unsupported field. For example, `query=banana filter=[QNAME:hello, cm:name:test]`, returns all documents containing “test” and “banana”. Another example, `query=banana filter=QNAME:hello OR cm:name:test`, returns all documents containing “test” and “banana”.
+Supplying an unsupported or non-existent field will cause the query to fail. This is a change in behaviour compared with the Search and Insight Engine and Search Services, which silently ignore these issues.
 
-In the examples above, filter queries must be executed using the REST API and not using Alfresco Digital Workspace or Alfresco Share.
+Alfresco Search Enterprise has a focus on the most commonly used features and often it is possible to work around unsupported features. Here are a few examples of how to use a different field for queries:
+
+| Old Query                                      | Replacement Query                             |
+| ---------------------------------------------- | --------------------------------------------- |
+| QNAME:'comment'                                | TYPE:'fm:post'                                |
+| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                            |
+| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
+| ANAME:'0/cdefb3a9-8f55-4771-a9e3-06fa370250f6' | PARENT:'cdefb3a9-8f55-4771-a9e3-06fa370250f6' |
+
+However secondary paths and secondary parents are not yet supported, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -32,6 +32,8 @@ The following features, which were supported with Search and Insight Engine 2.x 
 * PNAME
 * ANAME
 * NPATH
+* PARENT
+* PRIMARYPARENT
 * QNAME
 * PRIMARYASSOCQNAME
 * PRIMARYASSOCTYPEQNAME
@@ -57,7 +59,6 @@ The following features, which were supported with Search and Insight Engine 2.x 
 
 ### Path Indexing
 
-* Secondary parents
 * Secondary paths (paths including secondary parents)
 
 ## Behaviour of Unsupported fields
@@ -71,9 +72,8 @@ Alfresco Search Enterprise has a focus on the most commonly used features and of
 | QNAME:'comment'                                | TYPE:'fm:post'                                |
 | PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                            |
 | NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
-| ANAME:'0/cdefb3a9-8f55-4771-a9e3-06fa370250f6' | PARENT:'cdefb3a9-8f55-4771-a9e3-06fa370250f6' |
 
-However secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
+However secondary paths are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -66,7 +66,7 @@ The following features, which were supported with Search and Insight Engine 2.x 
 Supplying an unsupported or non-existent field will cause a query to fail. This is a change in behavior from Search and Insight Engine and Search Services, which silently ignore these issues.
 
 Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
-The following are examples of how to use a different fields for queries:
+The following are examples of how to use different fields for queries:
 
 | Old Query                                      | Replacement Query                             |
 | ---------------------------------------------- | --------------------------------------------- |


### PR DESCRIPTION
PARENT, PRIMARYPARENT and ANCESTOR are now all supported. There is no support for secondary parent-child relationships yet.

Add examples of how to rewrite certain unsupported queries to work around issues.