### PR TITLE
[DOCS-6579] Remove statement about embedded videos in ACS Using docs

### DIFF
--- a/content-services/5.2/using/content/manage.md
+++ b/content-services/5.2/using/content/manage.md
@@ -203,8 +203,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
   
 
 

--- a/content-services/5.2/using/dashboard.md
+++ b/content-services/5.2/using/dashboard.md
@@ -146,8 +146,6 @@ When you click on your name at the top of the screen a menu opens where you can 
 
 When your colleagues view your profile they'll see all the details you've entered and know exactly what you're working on.
 
-This video show you how to edit your user profile.
-
 ## Following people {#following-people}
 
 You can follow users you're interested in so that you can easily keep track of what they've been working on.

--- a/content-services/6.0/using/content/manage.md
+++ b/content-services/6.0/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/6.0/using/content/manage.md
+++ b/content-services/6.0/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/6.1/using/content/manage.md
+++ b/content-services/6.1/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/6.1/using/content/manage.md
+++ b/content-services/6.1/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/6.2/using/content/manage.md
+++ b/content-services/6.2/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/6.2/using/content/manage.md
+++ b/content-services/6.2/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/7.0/using/content/manage.md
+++ b/content-services/7.0/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/7.0/using/content/manage.md
+++ b/content-services/7.0/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/7.1/using/content/manage.md
+++ b/content-services/7.1/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/7.1/using/content/manage.md
+++ b/content-services/7.1/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/7.2/using/content/manage.md
+++ b/content-services/7.2/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/7.2/using/content/manage.md
+++ b/content-services/7.2/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/7.3/using/content/manage.md
+++ b/content-services/7.3/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/7.3/using/content/manage.md
+++ b/content-services/7.3/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/community/using/content/manage.md
+++ b/content-services/community/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.

--- a/content-services/community/using/content/manage.md
+++ b/content-services/community/using/content/manage.md
@@ -184,8 +184,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/latest/using/content/manage.md
+++ b/content-services/latest/using/content/manage.md
@@ -182,8 +182,6 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-See the video tutorial on [how to create contents]({% link content-services/latest/tutorial/video/content/index.md %}).
-
 ### Creating files from a template {#createfilefromtemplate}
 
 As well as creating files from scratch, you can also create files from templates.

--- a/content-services/latest/using/content/manage.md
+++ b/content-services/latest/using/content/manage.md
@@ -118,8 +118,6 @@ You can upload files in two ways: drag and drop files from your computer directl
 
 The document library displays the uploaded content.
 
-This video show you how to add content.
-
 ### Creating files
 
 With the **Create** feature you can create plain text, HTML, and XML files directly in Alfresco Share.
@@ -184,7 +182,7 @@ Files you edit are temporarily stored in Google Docs, then removed from Google D
 
 6. In Share, click **More** then **Check In Google Doc**.
 
-This video shows you how to create content.
+See the video tutorial on [how to create contents]({% link content-services/latest/tutorial/video/content/index.md %}).
 
 ### Creating files from a template {#createfilefromtemplate}
 


### PR DESCRIPTION
This PR removes the sentence “This video shows ... “

This statement no longer applies as the videos are no longer embedded in these pages - they were moved to the **Tutorials** section a long while ago.