### PR TITLE
[DOCS-7310] Update example release tag for Content Services 7.4

### DIFF
--- a/transform-service/1.3/install/index.md
+++ b/transform-service/1.3/install/index.md
@@ -216,7 +216,7 @@ To check which branch tag corresponds to a specific Content Services release, re
     cd acs-deployment/docker-compose
     ```
 
-    > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to deploy. For example, if you want Content Services 7.0.0, then select tag `5.0.0`.
+    > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to deploy. For example, if you want Content Services 7.0.0, then select tag `v5.0.0`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
 

--- a/transform-service/1.4/install/index.md
+++ b/transform-service/1.4/install/index.md
@@ -253,7 +253,7 @@ To check which branch tag corresponds to a specific Content Services release, re
     cd acs-deployment/docker-compose
     ```
 
-    > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to deploy. For example, if you want Content Services 7.0.0, then select tag `5.0.0`.
+    > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to deploy. For example, if you want Content Services 7.0.0, then select tag `v5.0.0`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
 

--- a/transform-service/1.5/install/index.md
+++ b/transform-service/1.5/install/index.md
@@ -269,7 +269,7 @@ from the left column that corresponds to the required Content Services version y
     ```
 
     > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to 
-    > deploy. For example, if you want Content Services 7.2.0, then select tag `5.2.0`.
+    > deploy. For example, if you want Content Services 7.2.0, then select tag `v5.2.0`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to 
     > determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 

--- a/transform-service/2.0/install/index.md
+++ b/transform-service/2.0/install/index.md
@@ -269,7 +269,7 @@ from the left column that corresponds to the required Content Services version y
     ```
 
     > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to 
-    > deploy. For example, if you want Content Services 7.3.0, then select tag `5.3.0`.
+    > deploy. For example, if you want Content Services 7.3.0, then select tag `v5.3.0`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to 
     > determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 

--- a/transform-service/2.1/install/index.md
+++ b/transform-service/2.1/install/index.md
@@ -269,7 +269,7 @@ from the left column that corresponds to the required Content Services version y
     ```
 
     > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to 
-    > deploy. For example, if you want Content Services 7.4.0, then select tag `6.0.0`.
+    > deploy. For example, if you want Content Services 7.4.0, then select tag `v6.0.0`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to 
     > determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -261,15 +261,9 @@ from the left column that corresponds to the required Content Services version y
 
    > **Note:** Check the prerequisites for your operating system, both for Docker and Docker Compose, using the links provided.
 
-1. Clone the project locally, and then change directory to the project folder:
+1. Download [one of the Docker Compose files](https://github.com/Alfresco/acs-deployment/tree/master/docker-compose/){"target="_blank"} from the `acs-deployment` repository, and navigate to the folder where the file is saved.
 
-   ```bash
-    git clone --branch x.y.z https://github.com/Alfresco/acs-deployment.git
-    cd acs-deployment/docker-compose
-    ```
-
-    > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to 
-    > deploy. For example, if you want Content Services 7.4.0, then select tag `6.0.2`.
+    Alternatively, if you want to contribute to the open source code, you can use one of the options provided in the **Code** dropdown of the [main repository page](https://github.com/Alfresco/acs-deployment/tree/master){:target="_blank"}. These options are **Clone** the repository, **Open with GitHub Desktop**, or **Download ZIP** to save a copy of the code. For example, if you want to see the latest release code for Content Services 7.4.0, then select tag `v6.0.2`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to 
     > determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 

--- a/transform-service/latest/install/index.md
+++ b/transform-service/latest/install/index.md
@@ -269,7 +269,7 @@ from the left column that corresponds to the required Content Services version y
     ```
 
     > **Note:** Replace the version number `x.y.z` with the tag that matches the Content Services version you want to 
-    > deploy. For example, if you want Content Services 7.4.0, then select tag `6.0.1`.
+    > deploy. For example, if you want Content Services 7.4.0, then select tag `6.0.2`.
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to 
     > determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 


### PR DESCRIPTION
The release tag is only mentioned in the Alfresco Transform Service docs.