### PR TITLE
[DOCS-7239] Add Rocky Linux to updated supported ACS stack

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -11,15 +11,16 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Version | Notes |
 | ------- | ----- |
 | **Operating systems** | |
+| Red Hat Enterprise Linux 8.7 x64 | |
 | Red Hat Enterprise Linux 8.6 x64 | |
-| Red Hat Enterprise Linux 8.5 x64 | |
 | Windows Server 2022 | |
 | Windows Server 2019 | |
 | Amazon Linux | v2 |
-| CentOS 7.9 x64 | |
 | CentOS 8.3 x64 | |
+| CentOS 7.9 x64 | |
 | Ubuntu 22.04 | |
 | Ubuntu 20.04 | |
+| Rocky Linux 8.7 | |
 |  |  |
 | **Databases** | |
 | MySQL 8 | `mysql-connector-java-8.0.27.jar` |


### PR DESCRIPTION
This PR adds Rocky Linux 8.7 and updates Red Hat Enterprise Linux versions.