### PR TITLE
[DOCS-7372] Support Case 01623221 - Update Hazelcast Share Cluster example configuration SchemaLocation

### DIFF
--- a/content-services/7.2/admin/cluster.md
+++ b/content-services/7.2/admin/cluster.md
@@ -177,7 +177,7 @@ To enable Hazelcast clustering between Share instances, configure the `custom-sl
 
 > **Note:** An example file which includes this configuration is provided in the distribution.zip and is located at
 > `web-server/shared/classes/alfresco/web-extension/web-extension/custom-slingshot-application-context.xml.sample`
-> as well as in the extracted share.war under
+> as well as in the extracted `share.war` under
 > `web-server/webapps/share/WEB-INF/classes/alfresco/web-extension/custom-slingshot-application-context.xml.sample`.
 
 To enable the Hazelcast cluster messaging, edit this section on each Share Tomcat instance:
@@ -265,11 +265,11 @@ The message shows that the configuration has successfully initialized Hazelcast 
 
 ### Share Cluster Troubleshooting
 
-In case share cluster does not start, check `share.log` for details.
+In case the Share cluster does not start, check the `share.log` for details.
 
-> *Note*: To setup an acs share cluster without internet connection, make sure to check the hazelcast
->  `xsi:schemaLocation=http://www.hazelcast.com/schema/spring/hazelcast-spring-<versionstring>.xsd` is the same hazelcast version as in the corresponding share lib
-> `share/WEB-INF/lib/hazelcast-spring-<version>.jar`
+> **Note**: To setup an ACS Share cluster without internet connection, make sure to check the Hazelcast
+>  `xsi:schemaLocation=http://www.hazelcast.com/schema/spring/hazelcast-spring-<version-string>.xsd` is the same Hazelcast version as in the corresponding Share lib
+> `share/WEB-INF/lib/hazelcast-spring-<version>.jar`.
 
 ### Configure Alfresco Share clustering
 

--- a/content-services/7.2/admin/cluster.md
+++ b/content-services/7.2/admin/cluster.md
@@ -173,9 +173,12 @@ This information describes the configuration of Hazelcast clustering between ins
 
 In a load balanced environment, Share now uses Hazelcast to provide multicast messaging between the web-tier nodes. As a result, Share caches no longer need to be disabled for any node, simple cache invalidation message are sent to all nodes when appropriate. Each node functions practically as fast as a single Share instance, enhancing the overall performance of Share.
 
-To enable Hazelcast clustering between Share instances, configure the `custom-slingshot-application-context.xml` file found at `<TOMCAT-HOME>/shared/classes/alfresco/web-extension`. This file is used to override the Spring application context beans for Share.
+To enable Hazelcast clustering between Share instances, configure the `custom-slingshot-application-context.xml` file and place it in the `<TOMCAT-HOME>/shared/classes/alfresco/web-extension` folder. This file is used to override the Spring application context beans for Share.
 
-> **Note:** An example `custom-slingshot-application-context.xml.sample` file is provided in the distribution, which now includes this configuration.
+> **Note:** An example file which includes this configuration is provided in the distribution.zip and is located at
+> `web-server/shared/classes/alfresco/web-extension/web-extension/custom-slingshot-application-context.xml.sample`
+> as well as in the extracted share.war under
+> `web-server/webapps/share/WEB-INF/classes/alfresco/web-extension/custom-slingshot-application-context.xml.sample`.
 
 To enable the Hazelcast cluster messaging, edit this section on each Share Tomcat instance:
 
@@ -185,13 +188,13 @@ To enable the Hazelcast cluster messaging, edit this section on each Share Tomca
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
                 http://www.hazelcast.com/schema/spring
-                http://www.hazelcast.com/schema/spring/hazelcast-spring-2.4.xsd">
+                http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
    <!--
         Hazelcast distributed messaging configuration - Share web-tier cluster config
         - see http://www.hazelcast.com/docs.jsp
-        - and specifically http://docs.hazelcast.org/docs/2.4/manual/html-single/#SpringIntegration
+        - and specifically https://docs.hazelcast.org/docs/3.12/manual/html-single/#SpringIntegration
    -->
    <!-- Configure cluster to use either Multicast or direct TCP-IP messaging - multicast is default -->
    <!-- Optionally specify network interfaces - server machines likely to have more than one interface -->
@@ -202,11 +205,11 @@ To enable the Hazelcast cluster messaging, edit this section on each Share Tomca
          <hz:group name="slingshot" password="alfresco"/>
          <hz:network port="5801" port-auto-increment="true">
             <hz:join>
-               <hz:multicast enabled="true"
+               <hz:multicast enabled="false"
                      multicast-group="224.2.2.5"
                      multicast-port="54327"/>
-               <hz:tcp-ip enabled="false">
-                  <hz:members></hz:members>
+               <hz:tcp-ip enabled="true">
+                  <hz:members>192.168.15,192.168.16</hz:members>
                </hz:tcp-ip>
             </hz:join>
             <hz:interfaces enabled="false">
@@ -259,6 +262,14 @@ INFO: /127.0.0.1]:5801 [slingshot] Address[127.0.0.1]:5801 is STARTED
 ```
 
 The message shows that the configuration has successfully initialized Hazelcast between Share instances.
+
+### Share Cluster Troubleshooting
+
+In case share cluster does not start, check `share.log` for details.
+
+> *Note*: To setup an acs share cluster without internet connection, make sure to check the hazelcast
+>  `xsi:schemaLocation=http://www.hazelcast.com/schema/spring/hazelcast-spring-<versionstring>.xsd` is the same hazelcast version as in the corresponding share lib
+> `share/WEB-INF/lib/hazelcast-spring-<version>.jar`
 
 ### Configure Alfresco Share clustering
 


### PR DESCRIPTION
This PullRequest commit updates to custom-slingshot-application-context.xml for acs 7.2.x to correct the xsi:schemaLocation to point to the correct hazelcast-spring<versionstring>.md.
PullRequest is related to the internal support cases
00951842 - Alfresco 6.2.1 - Share Cluster - Documentation and sample file not up to date
01623221 - Hazelcast Share Cluster example configuration is outdated and prevents acs startup

The custom-slingshot-application-context.xml example on
https://docs.alfresco.com/content-services/7.2/admin/cluster/#setting-up-an-alfresco-share-cluster
is outdated. If you use an acs 7.2 cluster server without internet connection, you'll end up with the following message in the share.log which prevents acs/tomcat to start up:

```
15:57:30,836 WARN  [org.springframework.beans.factory.xml.XmlBeanDefinitionReader] [main] Ignored XML validation warning
org.xml.sax.SAXParseException; lineNumber: 19; columnNumber: 95; schema_reference.4: Schemadokument 'https://hazelcast.com/schema/spring/hazelcast-spring-2.4.xsd' konnte nicht gelesen werden, da 1) das Dokument nicht gefunden werden konnte; 2) das Dokument nicht gelesen werden konnte; 3) das Root-Element des Dokuments nicht <xsd:schema> ist.
        at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:204)
        at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.warning(ErrorHandlerWrapper.java:100)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:392)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:306)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.reportSchemaErr(XSDHandler.java:4257)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.reportSchemaWarning(XSDHandler.java:4248)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.getSchemaDocument1(XSDHandler.java:2542)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.getSchemaDocument(XSDHandler.java:2238)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.traversers.XSDHandler.parseSchema(XSDHandler.java:588)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaLoader.loadSchema(XMLSchemaLoader.java:617)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.findSchemaGrammar(XMLSchemaValidator.java:2710)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.getGlobalElementDecl(XMLSchemaValidator.java:1639)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.SubstitutionGroupHandler.getMatchingElemDecl(SubstitutionGroupHandler.java:77)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.models.XSDFACM.oneTransition(XSDFACM.java:302)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.handleStartElement(XMLSchemaValidator.java:1934)
        at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.emptyElement(XMLSchemaValidator.java:849)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.scanStartElement(XMLNSDocumentScannerImpl.java:351)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2710)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:605)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:112)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:534)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:888)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:824)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:246)
        at java.xml/com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:339)
        at org.springframework.beans.factory.xml.DefaultDocumentLoader.loadDocument(DefaultDocumentLoader.java:77)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadDocument(XmlBeanDefinitionReader.java:432)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:390)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:338)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:310)
        at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:196)
        at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:232)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.importBeanDefinitionResource(DefaultBeanDefinitionDocumentReader.java:234)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseDefaultElement(DefaultBeanDefinitionDocumentReader.java:191)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:176)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:149)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:96)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:511)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:391)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:338)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:310)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.importBeanDefinitionResource(DefaultBeanDefinitionDocumentReader.java:250)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseDefaultElement(DefaultBeanDefinitionDocumentReader.java:191)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:176)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:149)
        at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:96)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:511)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:391)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:338)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:310)
        at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:196)
        at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:232)
        at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:203)
        at org.springframework.web.context.support.XmlWebApplicationContext.loadBeanDefinitions(XmlWebApplicationContext.java:125)
        at org.springframework.web.context.support.XmlWebApplicationContext.loadBeanDefinitions(XmlWebApplicationContext.java:94)
        at org.springframework.context.support.AbstractRefreshableApplicationContext.refreshBeanFactory(AbstractRefreshableApplicationContext.java:130)
        at org.springframework.context.support.AbstractApplicationContext.obtainFreshBeanFactory(AbstractApplicationContext.java:671)
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:553)
        at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:401)
        at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:292)
        at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:103)
        at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4764)
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5222)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:726)
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:698)
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:696)
        at org.apache.catalina.startup.HostConfig.deployDescriptor(HostConfig.java:689)
        at org.apache.catalina.startup.HostConfig$DeployDescriptor.run(HostConfig.java:1888)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
        at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:118)
        at org.apache.catalina.startup.HostConfig.deployDescriptors(HostConfig.java:582)
        at org.apache.catalina.startup.HostConfig.deployApps(HostConfig.java:472)
        at org.apache.catalina.startup.HostConfig.start(HostConfig.java:1617)
        at org.apache.catalina.startup.HostConfig.lifecycleEvent(HostConfig.java:318)
        at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
        at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:423)
        at org.apache.catalina.util.LifecycleBase.setState(LifecycleBase.java:366)
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:943)
        at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:835)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1393)
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1383)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
        at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:140)
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:916)
        at org.apache.catalina.core.StandardEngine.startInternal(StandardEngine.java:265)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.StandardService.startInternal(StandardService.java:430)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.StandardServer.startInternal(StandardServer.java:930)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.startup.Catalina.start(Catalina.java:772)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.catalina.startup.Bootstrap.start(Bootstrap.java:347)
        at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:478)
Caused by: java.net.ConnectException: Connection timed out (Connection timed out)
        at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
 ```

### Reason:
The ACS servers cannot access the internet to download the hazelcast schema version and can't find the outdated hazelcast schema hazelcast-spring-2.4.xsd inside the provided hazelcast library in share.

### Solution:
First check the corresponding hazelcast version in the share version:
```
/home/alfresco01/content-services/tomcat/webapps/share/WEB-INF/lib$ ls -al | grep hazelcast
-rw-rw-r-- 1 alfresco01 alfresco 11931842 25. Jul 2022  hazelcast-3.12.6.jar
-rw-rw-r-- 1 alfresco01 alfresco   288895 25. Jul 2022  hazelcast-spring-3.12.6.jar
```

Then update the schemaLocation in the custom-slingshot-application-context.xml from

```
<?xml version='1.0' encoding='UTF-8'?>
<beans xmlns="http://www.springframework.org/schema/beans"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:hz="http://www.hazelcast.com/schema/spring"
       xsi:schemaLocation="http://www.springframework.org/schema/beans
                http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
                http://www.hazelcast.com/schema/spring
                http://www.hazelcast.com/schema/spring/hazelcast-spring-2.4.xsd">
```               

to the correct hazelcast-spring<version>.xsd  which is include in your corresponding hazelcast-spring-<version>.jar
for example:
```
<?xml version='1.0' encoding='UTF-8'?>
<beans xmlns="http://www.springframework.org/schema/beans"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:hz="http://www.hazelcast.com/schema/spring"
       xsi:schemaLocation="http://www.springframework.org/schema/beans
                http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
                http://www.hazelcast.com/schema/spring
                http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd"> 
```


