### PR TITLE
[DOCS-7365] Fix redirects for APS licensing links

### DIFF
--- a/redirects/process-services1.10/topics/licensing.html
+++ b/redirects/process-services1.10/topics/licensing.html
@@ -1,1 +1,1 @@
-/process-services/1.10/install/manual/
+/process-services/1.10/install/manual/#license

--- a/redirects/process-services1.11/topics/licensing.html
+++ b/redirects/process-services1.11/topics/licensing.html
@@ -1,1 +1,1 @@
-/process-services/latest/config/content/
+/process-services/1.11/install/manual/#license

--- a/redirects/process-services1.6/topics/licensing.html
+++ b/redirects/process-services1.6/topics/licensing.html
@@ -1,1 +1,1 @@
-/process-services/latest/using/share-connector/
+/process-services/latest/install/manual/#license

--- a/redirects/process-services1.7/topics/licensing.html
+++ b/redirects/process-services1.7/topics/licensing.html
@@ -1,1 +1,1 @@
-/process-services/latest/using/share-connector/
+/process-services/latest/install/manual/#license

--- a/redirects/process-services1.8/topics/licensing.html
+++ b/redirects/process-services1.8/topics/licensing.html
@@ -1,1 +1,1 @@
-/process-services/latest/using/share-connector/
+/process-services/latest/install/manual/#license

--- a/redirects/process-services1.9/topics/licensing.html
+++ b/redirects/process-services1.9/topics/licensing.html
@@ -1,1 +1,1 @@
-/process-services/1.9/using/share-connector/
+/process-services/1.9/install/manual/#license


### PR DESCRIPTION
Fixes the redirects from the old Alfresco Docs site links, like `process-services1.11/topics/licensing.html`.

⚠️ Need to test if the anchor links in staging or production.