### PR TITLE
[ACS-4914] Alfresco Search Enterprise does not support the member keyword for categories

### DIFF
--- a/search-enterprise/3.0/using/unsupported.md
+++ b/search-enterprise/3.0/using/unsupported.md
@@ -82,11 +82,11 @@ Supplying an unsupported or non-existent field will cause a query to fail. This 
 Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
 The following are examples of how to use different fields for queries:
 
-| Old Query                                      | Replacement Query                                |
-| ---------------------------------------------- | ------------------------------------------------ |
-| QNAME:'comment'                                | TYPE:'fm:post'                                   |
-| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
-| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+| Old Query | Replacement Query |
+| --------- | --------------- |
+| QNAME:'comment' | TYPE:'fm:post' |
+| PNAME:'0/wiki' | PATH:'//cm:wiki/*' |
+| NPATH:'2/Company Home/Sites/swsdp' | PATH: '/app:company_home/st:sites/cm:swsdp//*' |
 
 > **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 

--- a/search-enterprise/3.0/using/unsupported.md
+++ b/search-enterprise/3.0/using/unsupported.md
@@ -71,18 +71,24 @@ The following features, which were supported with Search and Insight Engine 2.x 
 * DENYSET
 * FTSSTATUS
 
-## Alfresco Digital Workspace
+### Path Indexing
 
-To ensure ADW basic functionality the part of a query that contains an unsupported field will be ignored and the REST API will return a 200 HTTP code. A warning message will be produced in the Alfresco Repository log.
+* Secondary paths (paths including secondary parents)
 
-All unsupported fields will be ignored in queries and filters following the schema below:
+## Behavior of unsupported fields
 
-* The query contains only an unsupported field, for example `QNAME:hello` returns an empty result.
-* The query contains a supported field, for example `hello AND QNAME:goodbye` returns only documents containing “hello”.
-* A filter contains only an unsupported field, for example `query=banana`, `filter=QNAME:hello` returns only documents containing “banana”.
-* A filter contains two filters or a filter with a supported field and an unsupported field. For example, `query=banana filter=[QNAME:hello, cm:name:test]`, returns all documents containing “test” and “banana”. Another example, `query=banana filter=QNAME:hello OR cm:name:test`, returns all documents containing “test” and “banana”.
+Supplying an unsupported or non-existent field will cause a query to fail. This is a change in behavior from Search and Insight Engine and Search Services, which silently ignore these issues.
 
-In the examples above, filter queries must be executed using the REST API and not using Alfresco Digital Workspace or Alfresco Share.
+Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
+The following are examples of how to use different fields for queries:
+
+| Old Query                                      | Replacement Query                                |
+| ---------------------------------------------- | ------------------------------------------------ |
+| QNAME:'comment'                                | TYPE:'fm:post'                                   |
+| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
+| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+
+> **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/3.1/using/unsupported.md
+++ b/search-enterprise/3.1/using/unsupported.md
@@ -74,11 +74,11 @@ Supplying an unsupported or non-existent field will cause a query to fail. This 
 Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
 The following are examples of how to use different fields for queries:
 
-| Old Query                                      | Replacement Query                                |
-| ---------------------------------------------- | ------------------------------------------------ |
-| QNAME:'comment'                                | TYPE:'fm:post'                                   |
-| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
-| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+| Old Query | Replacement Query |
+| --------- | --------------- |
+| QNAME:'comment' | TYPE:'fm:post' |
+| PNAME:'0/wiki' | PATH:'//cm:wiki/*' |
+| NPATH:'2/Company Home/Sites/swsdp' | PATH: '/app:company_home/st:sites/cm:swsdp//*' |
 
 > **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 

--- a/search-enterprise/3.1/using/unsupported.md
+++ b/search-enterprise/3.1/using/unsupported.md
@@ -63,18 +63,24 @@ The following features, which were supported with Search and Insight Engine 2.x 
 * DENYSET
 * FTSSTATUS
 
-## Alfresco Digital Workspace
+### Path Indexing
 
-To ensure ADW basic functionality the part of a query that contains an unsupported field will be ignored and the REST API will return a 200 HTTP code. A warning message will be produced in the Alfresco Repository log.
+* Secondary paths (paths including secondary parents)
 
-All unsupported fields will be ignored in queries and filters following the schema below:
+## Behavior of unsupported fields
 
-* The query contains only an unsupported field, for example `QNAME:hello` returns an empty result.
-* The query contains a supported field, for example `hello AND QNAME:goodbye` returns only documents containing “hello”.
-* A filter contains only an unsupported field, for example `query=banana`, `filter=QNAME:hello` returns only documents containing “banana”.
-* A filter contains two filters or a filter with a supported field and an unsupported field. For example, `query=banana filter=[QNAME:hello, cm:name:test]`, returns all documents containing “test” and “banana”. Another example, `query=banana filter=QNAME:hello OR cm:name:test`, returns all documents containing “test” and “banana”.
+Supplying an unsupported or non-existent field will cause a query to fail. This is a change in behavior from Search and Insight Engine and Search Services, which silently ignore these issues.
 
-In the examples above, filter queries must be executed using the REST API and not using Alfresco Digital Workspace or Alfresco Share.
+Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
+The following are examples of how to use different fields for queries:
+
+| Old Query                                      | Replacement Query                                |
+| ---------------------------------------------- | ------------------------------------------------ |
+| QNAME:'comment'                                | TYPE:'fm:post'                                   |
+| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
+| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+
+> **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/3.2/using/unsupported.md
+++ b/search-enterprise/3.2/using/unsupported.md
@@ -70,11 +70,11 @@ Supplying an unsupported or non-existent field will cause a query to fail. This 
 Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
 The following are examples of how to use different fields for queries:
 
-| Old Query                                      | Replacement Query                                |
-| ---------------------------------------------- | ------------------------------------------------ |
-| QNAME:'comment'                                | TYPE:'fm:post'                                   |
-| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
-| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+| Old Query | Replacement Query |
+| --------- | --------------- |
+| QNAME:'comment' | TYPE:'fm:post' |
+| PNAME:'0/wiki' | PATH:'//cm:wiki/*' |
+| NPATH:'2/Company Home/Sites/swsdp' | PATH: '/app:company_home/st:sites/cm:swsdp//*' |
 
 > **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 

--- a/search-enterprise/3.2/using/unsupported.md
+++ b/search-enterprise/3.2/using/unsupported.md
@@ -31,6 +31,7 @@ The following features, which were supported with Search and Insight Engine 2.x 
 
 * PATHWITHREPEATS
 * PNAME
+* ANAME
 * NPATH
 * PARENT
 * PRIMARYPARENT
@@ -58,18 +59,24 @@ The following features, which were supported with Search and Insight Engine 2.x 
 * DENYSET
 * FTSSTATUS
 
-## Alfresco Digital Workspace
+### Path Indexing
 
-To ensure ADW basic functionality the part of a query that contains an unsupported field will be ignored and the REST API will return a 200 HTTP code. A warning message will be produced in the Alfresco Repository log.
+* Secondary paths (paths including secondary parents)
 
-All unsupported fields will be ignored in queries and filters following the schema below:
+## Behavior of unsupported fields
 
-* The query contains only an unsupported field, for example `QNAME:hello` returns an empty result.
-* The query contains a supported field, for example `hello AND QNAME:goodbye` returns only documents containing “hello”.
-* A filter contains only an unsupported field, for example `query=banana`, `filter=QNAME:hello` returns only documents containing “banana”.
-* A filter contains two filters or a filter with a supported field and an unsupported field. For example, `query=banana filter=[QNAME:hello, cm:name:test]`, returns all documents containing “test” and “banana”. Another example, `query=banana filter=QNAME:hello OR cm:name:test`, returns all documents containing “test” and “banana”.
+Supplying an unsupported or non-existent field will cause a query to fail. This is a change in behavior from Search and Insight Engine and Search Services, which silently ignore these issues.
 
-In the examples above, filter queries must be executed using the REST API and not using Alfresco Digital Workspace or Alfresco Share.
+Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
+The following are examples of how to use different fields for queries:
+
+| Old Query                                      | Replacement Query                                |
+| ---------------------------------------------- | ------------------------------------------------ |
+| QNAME:'comment'                                | TYPE:'fm:post'                                   |
+| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
+| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+
+> **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 
 ## Query languages
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -58,6 +58,7 @@ The following features, which were supported with Search and Insight Engine 2.x 
 ### Path Indexing
 
 * Secondary paths (paths including secondary parents)
+* The "member" keyword for category paths
 
 ## Behavior of unsupported fields
 
@@ -66,11 +67,12 @@ Supplying an unsupported or non-existent field will cause a query to fail. This 
 Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
 The following are examples of how to use different fields for queries:
 
-| Old Query                                      | Replacement Query                             |
-| ---------------------------------------------- | --------------------------------------------- |
-| QNAME:'comment'                                | TYPE:'fm:post'                                |
-| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                            |
-| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp/*' |
+| Old Query                                      | Replacement Query                                |
+| ---------------------------------------------- | ------------------------------------------------ |
+| QNAME:'comment'                                | TYPE:'fm:post'                                   |
+| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
+| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
+| PATH:'//cm:CategoryA/member'                   | PATH: '//cm:CategoryA/*' AND !TYPE:'cm:category' |
 
 > **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 

--- a/search-enterprise/latest/using/unsupported.md
+++ b/search-enterprise/latest/using/unsupported.md
@@ -67,12 +67,12 @@ Supplying an unsupported or non-existent field will cause a query to fail. This 
 Search Enterprise focuses on the most commonly used features, and in some cases allows you to work around unsupported features.
 The following are examples of how to use different fields for queries:
 
-| Old Query                                      | Replacement Query                                |
-| ---------------------------------------------- | ------------------------------------------------ |
-| QNAME:'comment'                                | TYPE:'fm:post'                                   |
-| PNAME:'0/wiki'                                 | PATH:'//cm:wiki/*'                               |
-| NPATH:'2/Company Home/Sites/swsdp'             | PATH: '/app:company_home/st:sites/cm:swsdp//*'   |
-| PATH:'//cm:CategoryA/member'                   | PATH: '//cm:CategoryA/*' AND !TYPE:'cm:category' |
+| Old Query | Replacement Query |
+| -------- | ----------------- |
+| QNAME:'comment' | TYPE:'fm:post' |
+| PNAME:'0/wiki' | PATH:'//cm:wiki/*' |
+| NPATH:'2/Company Home/Sites/swsdp' | PATH: '/app:company_home/st:sites/cm:swsdp//*' |
+| PATH:'//cm:CategoryA/member' | PATH: '//cm:CategoryA/*' AND !TYPE:'cm:category' |
 
 > **Note:** Secondary paths and secondary parents are not supported at this time, so there may still be some differences if these are in use.
 


### PR DESCRIPTION
SEARCH-2794 Backport documentation of lack of support for ANAME to Alfresco Search Enterprise (ASE) 3.2.

Fix description about behaviour with unsupported fields in ASE 3.0, 3.1 and 3.2.