### PR TITLE
[DOCS-7371] Fix build warning in Identity Service 2.0 docs

### DIFF
--- a/identity-service/latest/config/index.md
+++ b/identity-service/latest/config/index.md
@@ -55,7 +55,7 @@ To set the realm file during deployment:
           value: /data/import/realm.json
         - name: JAVA_OPTS_APPEND
           value: >-
-            -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
+            {%raw%}-Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless{%endraw%}
     EOL 
 
     helm install alfresco-stable/alfresco-infrastructure \


### PR DESCRIPTION
This PR fixes the following build warning:

```
docs-alfresco-jekyll-1  |     Liquid Warning: Liquid syntax error (line 54): Expected end_of_string but found string in "{{ include "keycloak.fullname" . }}" in identity-service/latest/config/index.md
```

See [example warning in previous commit](https://github.com/Alfresco/docs-alfresco/actions/runs/6493556670/job/17634746002#step:4:259) in repo