### PR TITLE
OPSEXP-2365 Bump Intelligence Services compatibility for 23.1

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -72,7 +72,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Search and Insight Engine 2.0.8 and later | Search and Insight Engine is compatible with Java 11 as long as you run Zeppelin in a Java 8 runtime. You can do this either in a VM or separate Java 8 based server. |
 | Alfresco Search Services 2.0.8 and later | |
 | Identity Service 2.0 | |
-| Alfresco Intelligence Services 1.5 | |
+| Alfresco Intelligence Services 3.0 | |
 | Alfresco Content Connector for AWS S3 6.0 | Adds support for AWS Glacier using Cloud storage layer. |
 | Alfresco Content Connector for Azure 4.0 | |
 | Alfresco Content Connector for Salesforce 3.0 | |


### PR DESCRIPTION
Base on what I see at https://quay.io/repository/alfresco/alfresco-ai-docker-engine latest available version should be v3.0.0