### PR TITLE
[DOCS-7283] Update ACS 7.4 Download Trial details

### DIFF
--- a/content-services/7.4/admin/control-center.md
+++ b/content-services/7.4/admin/control-center.md
@@ -59,7 +59,7 @@ To deploy Content Services using Docker Compose, download and install [Docker](h
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
 
-    > **Note:** The Download Trial is usually updated for *major.minor* versions of Content Services. The latest published version on our website is labelled *Version 7.3 - March 2022*.
+    > **Note:** The Download Trial is usually updated for *major.minor* versions of Content Services. The latest published version on our website is labelled *Version 7.4 - May 2023*.
 
 2. Save the `docker-compose.yml` file in a local folder.
 

--- a/content-services/7.4/install/containers/docker-compose.md
+++ b/content-services/7.4/install/containers/docker-compose.md
@@ -14,7 +14,7 @@ To deploy Content Services using Docker Compose, download and install [Docker](h
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
 
-    > **Note:** The Download Trial is usually updated for *major.minor* versions of Content Services. The latest published version on our website is labelled *Version 7.3 - December 2022)*.
+    > **Note:** The Download Trial is usually to the most recent version of Content Services. The latest published version on our website is labelled *Version 7.4 - May 2023*.
 
 2. Save the `docker-compose.yml` file in a local folder.
 

--- a/content-services/7.4/install/containers/docker-compose.md
+++ b/content-services/7.4/install/containers/docker-compose.md
@@ -14,7 +14,7 @@ To deploy Content Services using Docker Compose, download and install [Docker](h
 
     > **Note:** Make sure that exposed ports are open on your host computer. Check the `docker-compose.yml` file to determine the exposed ports - refer to the `host:container` port definitions. You'll see they include 5432, 8080, 8083 and others.
 
-    > **Note:** The Download Trial is usually to the most recent version of Content Services. The latest published version on our website is labelled *Version 7.4 - May 2023*.
+    > **Note:** The Download Trial is usually updated for *major.minor* versions of Content Services. The latest published version on our website is labelled *Version 7.4 - May 2023*.
 
 2. Save the `docker-compose.yml` file in a local folder.
 


### PR DESCRIPTION
This PR updates the current ACS Download Trial  in the Alfresco Content Services 7.4 and Alfresco Governance Services 7.4 docs to *Version 7.4 - May 2023*. 