### PR TITLE
[DOCS-7474] Revise property name in Enterprise Viewer docs

### DIFF
--- a/enterprise-viewer/latest/config/files.md
+++ b/enterprise-viewer/latest/config/files.md
@@ -548,7 +548,7 @@ Display an annotation modified date instead of the creation date throughout Ente
 
 Default value: `false`
 
-### minPagesToDefaultSectionModeOn
+### minPagesToDefafultSectionModeOn
 
 The minimum number of pages to default into sectioning mode. Set to `0` to prevent sectioning mode.
 


### PR DESCRIPTION
The property (`minPagesToDefafultSectionModeOn`) is misspelled in the code so we need the misspelling to be carried over in the documentation so that the property override to work correctly for customers.