### PR TITLE
[DOCS-7089] Download Document Enhancement

### DIFF
--- a/content-accelerator/latest/configure/actions.md
+++ b/content-accelerator/latest/configure/actions.md
@@ -155,13 +155,35 @@ The Download Document (sometimes also referred to as the Export Native Content) 
 
 ### Configuration Options for Download Document
 
-#### Available Rendition Types
-
-The action can be configured to download either the native content or the PDF rendition of the document being viewed in the stage. This configuration applies to all document types.
-
 #### Downloaded File Name
 
 The action can be configured to use a pattern for the downloaded file name based on object type. Each document object type may have its own pattern of its attribute and constant characters to use for the downloaded file name.
+
+#### Configuration Options for Download Document
+
+In the Download Type section, the following settings are available:
+Allow End User to specify Rendition/Native Content on Download
+If you enable this setting using the toggle switch, you can specify the download type every time you download a document.
+
+#### Available Rendition Type default
+
+You can configure the default rendition type to download files in the set rendition by default. You can set the default rendition type to any of the rendition types available in the drop-down, including PDF rendition and native client. 
+
+#### Allow End User to specify whether to include annotations on Download of a pdf
+
+If you enable this setting using the toggle switch, you are prompted to specify whether you want to include annotations every time you download a PDF document.
+
+#### Download with Annotations Default
+
+If you enable this setting using the toggle switch, annotations are included in PDF downloads by default. 
+
+#### Allow End User to specify whether to include overlays on Download of a pdf
+
+If you enable this setting using the toggle switch, you are prompted to specify whether you want to include overlays every time you download a PDF document.
+
+#### Download with Overlays Default
+
+If you enable this setting using the toggle switch, overlays are included in PDF downloads by default. 
 
 ## Export folder
 

--- a/content-accelerator/latest/install/install-guide.md
+++ b/content-accelerator/latest/install/install-guide.md
@@ -679,25 +679,15 @@ This section walks through how to install the web applications on Alfresco Tomca
 
    Obtain the `default-{accelerator}.zip` for your accelerator and rename the zip to `default.zip`.
 
-5. Import default configuration. There are two ways you can do this.
+5. Import default configuration using config import tool.
 
-   OPTION 1 - use the config import tool (This may not be available on initial install):
+      1. In a browser, navigate to {Application Base URL}/ocms and login to the application as the Alfresco Administrator. The screen displays a message that no configurations exist for the application yet.
 
-      * In a browser navigate to `{Application Base URL}/ocms/admin/ConfigArchiver` and login to the application as the Alfresco Administrator.
+      2. Click the button that is included in the message to navigate to the administration interface.
 
-      * Use the *Import Config* function to import the `default.zip` from the last step.
+      3. Navigate to **Tools** > **Config Archiver** from the left menu.
 
-   OPTION 2 - upload the configs via share:
-
-      * In a browser navigate to `{Application Base URL}/share` and login to the application as the Alfresco Administrator.
-
-      * Navigate to the repository and into the folder `hpi`
-
-      * Drag and drop the `default.zip` into this location
-
-      * Delete all contents of the current `default` folder
-
-      * Click on the `default.zip` and choose the "unzip to" action, select the `repository> hpi> default` folder
+      4. Use the Import Config function to import the default.zip from the previous step.
 
 6. (OPTIONAL) This step is only required if **NOT** using the Alfresco Enterprise Viewer:
 


### PR DESCRIPTION
This commit is intended for _[DOCS-7089] Download Document Enhancement_ and review for this commit is required. _[DOCS-7124] Update Content Accelerator install configuration steps_ has appeared in this commit due to an error and has been reviewed in another commit. 

Regarding DOCS-7089, in the **Configuration Options for Download Document** section, I have removed the **Available Rendition Types** topic but retained the **Downloaded File Name** topic before adding the new settings. 

[DOCS-7089]: https://alfresco.atlassian.net/browse/DOCS-7089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-7124]: https://alfresco.atlassian.net/browse/DOCS-7124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ