### PR TITLE
[DOCS-7512] Drop deprecated centos 8 and minor version in RHEL

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -11,11 +11,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Version | Notes |
 | ------- | ----- |
 | **Operating systems** | |
-| Red Hat Enterprise Linux 9.0 x64 | |
+| Red Hat Enterprise Linux 9.x x64 | |
 | Red Hat Enterprise Linux 8.8 x64 | |
 | Windows Server 2022 | |
 | Amazon Linux | v2 |
-| CentOS 8.3 x64 | |
 | CentOS 7.9 x64 | |
 | Ubuntu 22.04 | |
 | Rocky Linux 9.0 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -17,7 +17,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Amazon Linux | v2 |
 | CentOS 7.9 x64 | |
 | Ubuntu 22.04 | |
-| Rocky Linux 9.0 | |
+| Rocky Linux 9.x | |
 | Rocky Linux 8.8 | |
 |  |  |
 | **Databases** | |


### PR DESCRIPTION
As per current [ACS supported platforms](https://alfresco.atlassian.net/wiki/spaces/PO/pages/1074790451/ACS+Supported+Platforms+Roadmap)