### PR TITLE
[DOCS-7511] Fix versions in Content Accelerator and Enterprise Viewer 3.6 docs

### DIFF
--- a/content-accelerator/latest/install/install-guide.md
+++ b/content-accelerator/latest/install/install-guide.md
@@ -20,7 +20,7 @@ You will need to download the following distribution zips in order to install AC
 * (HR Only) alfresco-content-accelerator-sehr-accelerator-3.6.x.zip
 * (HR Tier-2 Only) alfresco-content-accelerator-sehr-rm-accelerator-3.6.x.zip
 
-> **Note:** If you're installing the HR Employee File Management (HR EFM) solution, you will need to get the HR EFM pre-release artifacts from [Hyland Confluence](https://hyland.atlassian.net/wiki/spaces/SESS/pages/687540729/Alfresco+HR+Employee+File+Management){:target="blank"} rather than using the distribution zips in Hyland Community.
+> **Note:**  If you’re installing the HR Employee File Management (HR EFM) solution, the HR EFM artifacts (solution AMPs and configurations) are stored in [Hyland Confluence](https://hyland.atlassian.net/wiki/spaces/SESS/pages/687540729/Alfresco+HR+Employee+File+Management){:target="blank"}. The rest of the solution deployment resources are in distribution zips in Hyland Community.
 
 ### Java
 

--- a/content-accelerator/latest/install/install-guide.md
+++ b/content-accelerator/latest/install/install-guide.md
@@ -14,11 +14,11 @@ The Content Accelerator can be installed using distribution zips. These zips can
 
 You will need to download the following distribution zips in order to install ACA:
 
-* alfresco-content-accelerator-base-package-3.5.x.zip
-* (Claims Only) alfresco-content-accelerator-claims-accelerator-3.5.x.zip
-* (PnP Only) alfresco-content-accelerator-policy-and-procedure-accelerator-3.5.x.zip
-* (HR Only) alfresco-content-accelerator-sehr-accelerator-3.5.x.zip
-* (HR Tier-2 Only) alfresco-content-accelerator-sehr-rm-accelerator-3.5.x.zip
+* alfresco-content-accelerator-base-package-3.6.x.zip
+* (Claims Only) alfresco-content-accelerator-claims-accelerator-3.6.x.zip
+* (PnP Only) alfresco-content-accelerator-policy-and-procedure-accelerator-3.6.x.zip
+* (HR Only) alfresco-content-accelerator-sehr-accelerator-3.6.x.zip
+* (HR Tier-2 Only) alfresco-content-accelerator-sehr-rm-accelerator-3.6.x.zip
 
 > **Note:** If you're installing the HR Employee File Management (HR EFM) solution, you will need to get the HR EFM pre-release artifacts from [Hyland Confluence](https://hyland.atlassian.net/wiki/spaces/SESS/pages/687540729/Alfresco+HR+Employee+File+Management){:target="blank"} rather than using the distribution zips in Hyland Community.
 

--- a/enterprise-viewer/latest/install/index.md
+++ b/enterprise-viewer/latest/install/index.md
@@ -12,7 +12,7 @@ Use this information to install the Enterprise Viewer. If you're installing both
 
 You can install the Enterprise Viewer using a distribution ZIP. Download the following ZIP file from [Hyland Community](https://community.hyland.com/products/alfresco){:target="_blank"}:
 
-* `alfresco-enterprise-viewer-package-3.5.x.zip`
+* `alfresco-enterprise-viewer-package-3.6.x.zip`
 
 ### Java
 
@@ -255,9 +255,9 @@ You only need to follow these steps if installing AEV without ACA:
 
    > **Note:** Make sure you are using the correct `tsgrp-opencontent.amp` for your version of Alfresco.
 
-   * If using Alfresco Content Services 7.1.x, use the `tsgrp-opencontent-3.5-for-acs7.1.amp`.
-   * If using Alfresco Content Services 7.2.x, use the `tsgrp-opencontent-3.5-for-acs7.2.amp`.
-   * If using Alfresco Content Services 7.3.x, use the `tsgrp-opencontent-3.5-for-acs7.3.amp`.
+   * If using Alfresco Content Services 7.2.x, use the `tsgrp-opencontent-3.6-for-acs7.2.amp`.
+   * If using Alfresco Content Services 7.3.x, use the `tsgrp-opencontent-3.6-for-acs7.3.amp`.
+   * If using Alfresco Content Services 7.4.x, use the `tsgrp-opencontent-3.6-for-acs7.4.amp`.
 
 3. From the directory where your Alfresco Tomcat server is installed, run the following command to apply the AMP:
 


### PR DESCRIPTION
This PR also updates references to the deployment resources required in the Alfresco Content Accelerator 3.6 installation guide