### PR TITLE
[DOCS-7441] Update Supported Platforms for Alfresco Enterprise Viewer…

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -89,6 +89,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Mobile Workspace 1.8 | |
 | Alfresco Control Center 8.3 | |
 | Alfresco Application Development Framework (ADF) 6.x | Some API functionality may be available only in the latest Alfresco Content Services release. |
+| Alfresco Enterprise Viewer 4.0 | |
 | | |
 | **Components** | |
 | ImageMagick v7.1.0-16 | |

--- a/enterprise-viewer/latest/support/index.md
+++ b/enterprise-viewer/latest/support/index.md
@@ -2,12 +2,10 @@
 title: Supported platforms
 ---
 
-The following are the supported platforms for the Alfresco Enterprise Viewer 3.6:
+The following are the supported platforms for the Alfresco Enterprise Viewer 4.0:
 
 | Version | Notes |
 | ------- | ----- |
-| Content Services 7.4 | Requires Enterprise Viewer 3.5.1 and later |
-| Content Services 7.3.x | |
-| Content Services 7.2.x | |
+| Content Services 23.1 | |
 | Search Services 2.x | |
-| Search Enterprise 3.x | |
+| Search Enterprise 4.x | |

--- a/search-enterprise/latest/support/index.md
+++ b/search-enterprise/latest/support/index.md
@@ -22,5 +22,8 @@ The following are the supported platforms for Search Enterprise 4.0.x:
 | Elasticsearch server 7.10.x | |
 | Opensearch server 1.3.x | |
 | Alfresco Elasticsearch Connector 4.0.x | |
+| | |
+| **Applications** | |
+| Alfresco Enterprise Viewer 4.0 | |
 
 > **Note:** Elasticsearch/Opensearch does not require any additional software from Alfresco in order to be used by Alfresco Search Enterprise 4.0.

--- a/search-services/latest/support/index.md
+++ b/search-services/latest/support/index.md
@@ -13,3 +13,4 @@ The following are the supported platforms for Search Services:
 | Content Services 7.0.x | |
 | Content Services 6.2.2 | |
 | Content Services 6.2.1 | |
+| Alfresco Enterprise Viewer 4.0 | |


### PR DESCRIPTION
… 4.0
This involves Supported platforms page in AEV 4.0: ACS 23.1, Search Services 2.x and Search Enterprise 4.x
Supported Platforms page for Search Services 2.x and Search Enterprise 4.x: added Alfresco Enterprise Viewer 4.0