### PR TITLE
[DOCS-7540] Remove Internet Explorer 11 from supported browsers

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -46,7 +46,6 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Browsers** | |
 | Mozilla Firefox 86 | |
 | Microsoft Edge Latest| |
-| MS Internet Explorer 11 | |
 | Chrome 89 | Includes Chromium edition. |
 | Safari 15 | |
 | | |


### PR DESCRIPTION
Internet Explorer 11 is not supported in ACS 23.1 - deleted from a list of supported browsers