### PR TITLE
[DOCS-7572] Incorrect environment reference in Search Enterprise

### DIFF
--- a/search-enterprise/3.1/upgrade/index.md
+++ b/search-enterprise/3.1/upgrade/index.md
@@ -74,7 +74,7 @@ You can upgrade from Search Services 2.x without experiencing any downtime, to S
 
     ![initial-reindexing]({% link search-enterprise/images/initial-re-indexing.png %})
 
-5. Shutdown the original environment.
+5. Shutdown the mirrored environment.
 
     You are left with an Elasticsearch server with a populated index.
 

--- a/search-enterprise/3.2/upgrade/index.md
+++ b/search-enterprise/3.2/upgrade/index.md
@@ -74,7 +74,7 @@ You can upgrade from Search Services 2.x without experiencing any downtime, to S
 
     ![initial-reindexing]({% link search-enterprise/images/initial-re-indexing.png %})
 
-5. Shutdown the original environment.
+5. Shutdown the mirrored environment.
 
     You are left with an Elasticsearch server with a populated index.
 

--- a/search-enterprise/3.3/upgrade/index.md
+++ b/search-enterprise/3.3/upgrade/index.md
@@ -74,7 +74,7 @@ You can upgrade from Search Services 2.x without experiencing any downtime, to S
 
     ![initial-reindexing]({% link search-enterprise/images/initial-re-indexing.png %})
 
-5. Shutdown the original environment.
+5. Shutdown the mirrored environment.
 
     You are left with an Elasticsearch server with a populated index.
 

--- a/search-enterprise/latest/upgrade/index.md
+++ b/search-enterprise/latest/upgrade/index.md
@@ -74,7 +74,7 @@ You can upgrade from Search Services 2.x without experiencing any downtime, to S
 
     ![initial-reindexing]({% link search-enterprise/images/initial-re-indexing.png %})
 
-5. Shutdown the original environment.
+5. Shutdown the mirrored environment.
 
     You are left with an Elasticsearch server with a populated index.
 


### PR DESCRIPTION
Modified step 5 of **Zero downtime upgrade** heading in the **Upgrade to Search Enterprise** page.