### PR TITLE
[DOCS-7583] Drop secret key from adw example json config

### DIFF
--- a/identity-service/latest/tutorial/sso/ldap.md
+++ b/identity-service/latest/tutorial/sso/ldap.md
@@ -148,7 +148,6 @@ The following is an example `app.config.json` file excerpt. By default this file
         "host": "https://ids.example.com/auth/realms/alfresco",
         "clientId": "alfresco",        
         "scope": "openid",
-        "secret": "",
         "implicitFlow": true,
         "silentLogin": true,
         "redirectSilentIframeUri": "https://adw.example.com/workspace/assets/silent-refresh.html",

--- a/identity-service/latest/tutorial/sso/saml.md
+++ b/identity-service/latest/tutorial/sso/saml.md
@@ -210,7 +210,6 @@ The following is an example `app.config.json` file excerpt. By default this file
         "host": "https://ids.example.com/auth/realms/alfresco",
         "clientId": "alfresco",        
         "scope": "openid",
-        "secret": "",
         "implicitFlow": true,
         "silentLogin": true,
         "redirectSilentIframeUri": "https://adw.example.com/workspace/assets/silent-refresh.html",


### PR DESCRIPTION
Providing the secret field inside the oauth config example of a webapp is not suggesting a good security practice

related PR https://github.com/Alfresco/alfresco-applications/pull/496