### PR TITLE
[DOCS-5888] Resolve incorrect JDBC URL

### DIFF
--- a/insight-engine/latest/using/sql/jdbc.md
+++ b/insight-engine/latest/using/sql/jdbc.md
@@ -15,13 +15,13 @@ The connection string's host and port should point to the Alfresco Content Servi
 The JDBC connection string uses the following format:
 
 ```bash
-jdbc:alfresco://<alfresco-server-name>:<alfresco-server-port>?collection=alfresco
+jdbc:solr://<alfresco-server-name>:<alfresco-server-port>?collection=alfresco
 ```
 
 For example, this database URL property value:
 
 ```bash
-jdbc:alfresco://localhost:8080?collection=alfresco
+jdbc:solr://localhost:8080?collection=alfresco
 ```
 
 Will generate the following request:

--- a/search-enterprise/3.3/install/index.md
+++ b/search-enterprise/3.3/install/index.md
@@ -225,7 +225,7 @@ Deploy the Docker compose file you created.
     $ docker login https://quay.io
     ```
 
-2. Deploy Alfresco Content Services. The `docker-compose.yml` you generated includes the Repository, ADW, Postgres, Transform Service, ActiveMQ, Alfresco Elasticsearch Connector, Elasticsearch, and Kibana.
+2. Deploy Alfresco Content Services. The `docker-compose.yml` you generated includes the Repository, ADW, database, Transform Service, ActiveMQ, Alfresco Elasticsearch Connector, Elasticsearch, and Kibana.
 
     ```bash
     $ docker-compose up --build --force-recreate

--- a/search-enterprise/3.3/install/index.md
+++ b/search-enterprise/3.3/install/index.md
@@ -48,7 +48,7 @@ Use this information to install the Elasticsearch connector on the same machine 
 
 * Alfresco ActiveMQ, by default `nio://activemq:61616`
 * Alfresco Shared FileStore endpoint, by default http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file/
-* Alfresco Database using PostgresSQL engine, by default `localhost:5432`
+* Alfresco Database, by default `localhost:5432`
 * Elasticsearch server, by default http://elasticsearch:9200
 
 Once you have extracted the Elasticsearch connector zip file you install the Alfresco re-indexing app, and then the Alfresco live indexing app.

--- a/search-enterprise/3.3/support/index.md
+++ b/search-enterprise/3.3/support/index.md
@@ -6,10 +6,10 @@ The following are the supported platforms for Search Enterprise 3.3.x:
 
 | Version | Notes |
 | ------- | ----- |
-| Content Services 7.4.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1 and PostgreSQL 11.7 |
-| Content Services 7.3.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1 and PostgreSQL 11.7 |
-| Content Services 7.2.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1 and PostgreSQL 11.7 |
-| Content Services 7.1.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1 and PostgreSQL 11.7 |
+| Content Services 7.4.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1, and the database |
+| Content Services 7.3.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1, and the database |
+| Content Services 7.2.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1, and the database |
+| Content Services 7.1.x | Including Alfresco ActiveMQ 5.15.8, Alfresco Transform Service 1.4.1, and the database |
 | JDK 11 or OpenJDK 11 | |
 | Elasticsearch server 7.17.x | |
 | Elasticsearch server 7.16.x | |

--- a/search-enterprise/latest/install/index.md
+++ b/search-enterprise/latest/install/index.md
@@ -225,7 +225,7 @@ Deploy the Docker compose file you created.
     $ docker login https://quay.io
     ```
 
-2. Deploy Alfresco Content Services. The `docker-compose.yml` you generated includes the Repository, ADW, Postgres, Transform Service, ActiveMQ, Alfresco Elasticsearch Connector, Elasticsearch, and Kibana.
+2. Deploy Alfresco Content Services. The `docker-compose.yml` you generated includes the Repository, ADW, database, Transform Service, ActiveMQ, Alfresco Elasticsearch Connector, Elasticsearch, and Kibana.
 
     ```bash
     $ docker-compose up --build --force-recreate

--- a/search-enterprise/latest/install/index.md
+++ b/search-enterprise/latest/install/index.md
@@ -48,7 +48,7 @@ Use this information to install the Elasticsearch connector on the same machine 
 
 * Alfresco ActiveMQ, by default `nio://activemq:61616`
 * Alfresco Shared FileStore endpoint, by default http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file/
-* Alfresco Database using PostgresSQL engine, by default `localhost:5432`
+* Alfresco Database, by default `localhost:5432`
 * Elasticsearch server, by default http://elasticsearch:9200
 
 Once you have extracted the Elasticsearch connector zip file you install the Alfresco re-indexing app, and then the Alfresco live indexing app.

--- a/search-enterprise/latest/support/index.md
+++ b/search-enterprise/latest/support/index.md
@@ -6,7 +6,7 @@ The following are the supported platforms for Search Enterprise 4.0.x:
 
 | Version | Notes |
 | ------- | ----- |
-| Content Services 23.1.x | Including ActiveMQ, Alfresco Transform Service, and PostgreSQL |
+| Content Services 23.1.x | Including ActiveMQ, Alfresco Transform Service, and the database |
 | | Check the [Alfresco Content Services Supported platforms]({% link content-services/latest/support/index.md %}) page for specific versions of the individual components. |
 | | |
 | **Java** | |


### PR DESCRIPTION
Replaced ```jdbc:alfresco://<alfresco-server-name>:<alfresco-server-port>?collection=alfresco``` with ```jdbc:solr://<alfresco-server-name>:<alfresco-server-port>?collection=alfresco```. 
Also replaced ```jdbc:solr://localhost:8080?collection=alfresco``` (This change was not mentioned in the JIRA ticket. Hope this is fine. 

The changes are done to the https://docs.alfresco.com/insight-engine/latest/using/sql/jdbc/ page. 