### PR TITLE
[DOCS-7679] Fix missing TOC in SAP Cloud 2.0 docs

### DIFF
--- a/_data/toc/sap-cloud.yaml
+++ b/_data/toc/sap-cloud.yaml
@@ -1,5 +1,5 @@
 # Alfresco Content Connector for SAP Cloud 2.0
-- version: 1.2
+- version: 2.0
   pages:
     - title: 'Introduction'
       path: '/sap-cloud/latest/'


### PR DESCRIPTION
This PR fixes the blank table of contents for the latest SAP Cloud Connector 2.0 documentation