### PR TITLE
[DOCS-7635] Update Supported Platforms for Search Enterprise

### DIFF
--- a/search-enterprise/3.2/support/index.md
+++ b/search-enterprise/3.2/support/index.md
@@ -19,7 +19,6 @@ The following are the supported platforms for Search Enterprise 3.2.x:
 | Elasticsearch server 7.11.x | |
 | Elasticsearch server 7.10.x | |
 | Opensearch server 1.3.x | |
-| Alfresco Elasticsearch Connector 3.2.x | |
 
 > **Note:** Elasticsearch/Opensearch does not require any additional software from Alfresco in order to be used by Alfresco Search Enterprise 3.2.
 

--- a/search-enterprise/3.3/support/index.md
+++ b/search-enterprise/3.3/support/index.md
@@ -17,6 +17,5 @@ The following are the supported platforms for Search Enterprise 3.3.x:
 | Elasticsearch server 7.11.x | |
 | Elasticsearch server 7.10.x | |
 | Opensearch server 1.3.x | |
-| Alfresco Elasticsearch Connector 3.3.x | |
 
 > **Note:** Elasticsearch/Opensearch does not require any additional software from Alfresco in order to be used by Alfresco Search Enterprise 3.3.

--- a/search-enterprise/latest/support/index.md
+++ b/search-enterprise/latest/support/index.md
@@ -21,7 +21,6 @@ The following are the supported platforms for Search Enterprise 4.0.x:
 | Elasticsearch server 7.11.x | |
 | Elasticsearch server 7.10.x | |
 | Opensearch server 1.3.x | |
-| Alfresco Elasticsearch Connector 4.0.x | |
 | | |
 | **Applications** | |
 | Alfresco Enterprise Viewer 4.0.x | |


### PR DESCRIPTION
Removed the Alfresco Elasticsearch Connector instances as it is synonymous to Alfresco Search Enterprise. 
To maintain consistency, I did not modify the Elasticsearch server versioning format as there are other Alfresco component versions listed in the same way in other Supported Platforms pages.