### PR TITLE
[DOCS-7722] Typos in index.md

### DIFF
--- a/search-enterprise/latest/config/index.md
+++ b/search-enterprise/latest/config/index.md
@@ -188,22 +188,22 @@ mediation:
      - nodeType1
      - nodeType2
      - ...
-     . nodeTypeN
+     - nodeTypeN
   contentNodeTypes:
      - nodeType1
      - nodeType2
      - ...
-     . nodeTypeN
+     - nodeTypeN
   nodeAspects:
      - nodeAspect1
      - nodeAspect2
-     - …
+     - ...
      - nodeAspectN
   fields:
      - field1
      - field2
      - ...
-     . fieldN
+     - fieldN
 ```
 
 Where:


### PR DESCRIPTION
In the mediation-filter.yml example some typo may mislead the reader