### PR TITLE
[DOCS-7710][DOCS-7723] Add & update compatibility in ACS 7.3

### DIFF
--- a/content-services/7.3/support/index.md
+++ b/content-services/7.3/support/index.md
@@ -58,6 +58,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Process Services 2.3 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.11.3 | |
 | Alfresco Sync Service 3.11.1 | Additional compatibility testing was done with ACS 7.1, 7.2, 7.3, and 7.4. |
 | Alfresco Sync Service 3.8 | |
 | Alfresco Desktop Sync 1.18 | |

--- a/content-services/7.3/support/index.md
+++ b/content-services/7.3/support/index.md
@@ -60,6 +60,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.11.1 | Additional compatibility testing was done with ACS 7.1, 7.2, 7.3, and 7.4. |
 | Alfresco Sync Service 3.8 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Desktop Sync 1.15 | |
@@ -170,6 +171,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.11.1 | Additional compatibility testing was done with ACS 7.1, 7.2, 7.3, and 7.4. |
 | Alfresco Sync Service 3.8 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Desktop Sync 1.15 | |
@@ -279,6 +281,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 3.11.1 | Additional compatibility testing was done with ACS 7.1, 7.2, 7.3, and 7.4. |
 | Alfresco Sync Service 3.8 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Desktop Sync 1.15 | |

--- a/content-services/7.3/support/index.md
+++ b/content-services/7.3/support/index.md
@@ -82,12 +82,14 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Content Connector for Azure 3.1 | |
 | Alfresco Content Connector for SAP applications 5.3 | |
 | Alfresco Content Connector for SAP applications 5.2.1 | |
+| Alfresco Content Connector for Salesforce 2.4 | |
 | Alfresco Content Connector for Salesforce 2.3.7 and later | |
 | Alfresco Content Connector for SAP Cloud 1.2 | |
 | Alfresco Collaboration Connector for Microsoft 365 1.1.3 | |
 | Alfresco Collaboration Connector for Teams 1.1 | |
 | Alfresco Outlook Integration 2.9 | *Partial support*. Only basic authentication is supported |
 | Alfresco Office Services 1.5 | |
+| Alfresco Google Docs Integration 3.4 | |
 | Alfresco Google Docs Integration 3.3 | |
 | Alfresco Content Services SDK 5.2 | |
 | Alfresco Content Services SDK 4.5 | |

--- a/content-services/7.3/support/index.md
+++ b/content-services/7.3/support/index.md
@@ -77,6 +77,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Keycloak 21.1.2 | Use this Keycloak version and Alfresco Keycloak Theme 0.3.5 as an alternative to Identity Service 2.0.0. |
 | Identity Service 2.0 | |
 | Identity Service 1.8 | |
+| Alfresco Intelligence Services 3.1.3 | |
 | Alfresco Intelligence Services 1.4.5 | |
 | Alfresco Content Connector for AWS S3 5.1 | Adds support for AWS Glacier using Cloud storage layer. |
 | Alfresco Content Connector for Azure 3.1 | |


### PR DESCRIPTION
This PR includes compatibility changes in Alfresco Content Services 7.3 for:

- Alfresco Desktop Sync 1.18 
- Alfresco Sync Service 3.11.3
- Alfresco Salesforce Connector 2.4
- Alfresco Google Docs Integration 3.4
- Alfresco Intelligence Services 3.1.3
