### PR TITLE
[DOCS-7710][DOCS-7723] Add & update compatibility in ACS 7.2

### DIFF
--- a/content-services/7.2/support/index.md
+++ b/content-services/7.2/support/index.md
@@ -69,6 +69,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Process Services 2.3 | |
 | | |
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
+| Alfresco Sync Service 3.11.3 | |
 | Alfresco Sync Service 3.11.1 | Additional compatibility testing was done with ACS 7.1, 7.2, 7.3, and 7.4. |
 | Alfresco Sync Service 3.8 | |
 | Alfresco Sync Service 3.7 | |

--- a/content-services/7.2/support/index.md
+++ b/content-services/7.2/support/index.md
@@ -96,6 +96,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Identity Service 1.8 | |
 | Identity Service 1.7 | |
 | SAML Module for Alfresco Content Services 1.2.3 | |
+| Alfresco Intelligence Services 3.1.3 | |
 | Alfresco Intelligence Services 1.4.4 | |
 | Alfresco Intelligence Services 1.4.2 | |
 | Alfresco Content Connector for AWS S3 5.1 | |

--- a/content-services/7.2/support/index.md
+++ b/content-services/7.2/support/index.md
@@ -73,6 +73,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.8 | |
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Desktop Sync 1.15 | |
@@ -209,6 +210,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.8 | |
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Desktop Sync 1.15 | |
@@ -343,6 +345,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Sync Service 3.8 | |
 | Alfresco Sync Service 3.7 | |
 | Alfresco Sync Service 3.6 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Desktop Sync 1.15 | |


### PR DESCRIPTION
This PR includes compatibility changes in Alfresco Content Services 7.2 for:

- Alfresco Desktop Sync 1.18 
- Alfresco Sync Service 3.11.3
- Alfresco Intelligence Services 3.1.3