### PR TITLE
[DOCS-7710][DOCS-7708] Add & update compatibility in ACS 23.x

### DIFF
--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -75,6 +75,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 3.2 | |
 | Keycloak 21.1.2 | Use this Keycloak version and Alfresco Keycloak Theme 0.3.5 as an alternative to Identity Service 2.0.0. |
 | Identity Service 2.0 | |
+| Alfresco Intelligence Services 3.1.3 | |
 | Alfresco Intelligence Services 3.1 | |
 | Alfresco Content Connector for AWS S3 6.1 | Adds support for AWS Glacier using Cloud storage layer. |
 | Alfresco Content Connector for Azure 5.0 | |
@@ -176,6 +177,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Alfresco Federation Services 3.1 | |
 | Keycloak 21.1.2 | Use this Keycloak version and Alfresco Keycloak Theme 0.3.5 as an alternative to Identity Service 2.0.0. |
 | Identity Service 2.0 | |
+| Alfresco Intelligence Services 3.1.3 | |
 | Alfresco Intelligence Services 3.1 | |
 | Alfresco Content Connector for AWS S3 6.0 | Adds support for AWS Glacier using Cloud storage layer. |
 | Alfresco Content Connector for Azure 4.0 | |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -65,6 +65,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 5.0 | |
 | Alfresco Sync Service 4.0 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Transform Service 4.1 | |
 | Alfresco Document Transformation Engine 2.4 | |
@@ -162,6 +163,7 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | **Integrations** | Check the individual documentation on prerequisites and supported platforms for each integration. |
 | Alfresco Sync Service 5.0 | |
 | Alfresco Sync Service 4.0 | |
+| Alfresco Desktop Sync 1.18 | |
 | Alfresco Desktop Sync 1.17 | |
 | Alfresco Desktop Sync 1.16 | |
 | Alfresco Transform Service 4.1 | |


### PR DESCRIPTION
This PR includes compatibility changes in Alfresco Content Services 23.x for:

- Alfresco Desktop Sync 1.18 
- Alfresco Intelligence Services 3.1.3
