### PR TITLE
[DOCS-7819] Update authenticate.md

### DIFF
--- a/process-services/latest/config/authenticate.md
+++ b/process-services/latest/config/authenticate.md
@@ -29,7 +29,7 @@ Use this information to configure Process Services to authenticate via Identity 
 
 Configure the `activiti-identity-service.properties` file using the below properties:
 
-> **Note:** A [full list of possible properties](https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config) is also available.
+> **Note:** A [full list of possible properties](https://www.keycloak.org/docs/22.0.5/securing_apps/index.html#_java_adapter_config) is also available.
 
 |Property|Description|
 |--------|-----------|


### PR DESCRIPTION
The external URL points to "latest" documentation that has removed the paragraph. I modified the url to point to a specific version of the documentation.