### PR TITLE
[DOCS-7800] Fix Nexus broken links in ACS 7.0 +

### DIFF
--- a/content-services/7.0/develop/rest-api-guide/index.md
+++ b/content-services/7.0/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.0/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-If you want to know what the API Explorer looks like right now, then have a look at the online version at 
-[https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} 
+To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
 (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version

--- a/content-services/7.0/develop/rest-api-guide/index.md
+++ b/content-services/7.0/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.0/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
-(note that this API Explorer always shows the API for the latest version of ACS).
+If you want to know what the API Explorer looks like right now, then have a look at the online version at [https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version
 

--- a/content-services/7.0/develop/rest-api-guide/install.md
+++ b/content-services/7.0/develop/rest-api-guide/install.md
@@ -18,7 +18,7 @@ If you just want to have a look at the latest API Explorer, then you can use an 
 ## Installing
 
 Most likely you would want to install the API Explorer into your local ACS installation. You can find the
-Alfresco API Explorer WAR file in [Alfresco’s Nexus repository](https://artifacts.alfresco.com/nexus/#nexus-search;quick~api-explorer){:target="_blank"}.
+Alfresco API Explorer WAR file in Alfresco’s Nexus repository by searching for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/.
 Pick the version that closest matches your ACS installation.
 
 To install the WAR file follow one of two approaches. If you are using a trial version of ACS then you follow the first

--- a/content-services/7.0/develop/sdk.md
+++ b/content-services/7.0/develop/sdk.md
@@ -1901,7 +1901,7 @@ If you're using Windows, you'll need to use the `run.bat` script instead of `run
 #### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}.
 
 The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository 
-([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
+([artifacts.alfresco.com](https://nexus.alfresco.com/nexus/){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
 request these credentials opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}. 
 
 Once you have suitable credentials, you need to add support for Alfresco private Maven repository to your configuration. This would typically be done by 

--- a/content-services/7.0/install/ansible.md
+++ b/content-services/7.0/install/ansible.md
@@ -24,7 +24,7 @@ There are two types of installations - local and remote:
 
 ## Prerequisites
 
-If you're using the Content Services (Enterprise), then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+If you're using the Content Services (Enterprise), then you need credentials to access the necessary artifacts from [Nexus](https://nexus.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 >**Note:** If you are using Alfresco Transform Service 1.4 or newer, and you want to do IPTC metadata extraction,
 then you need to [bootstrap the IPTC Content Model]({% link content-services/7.0/install/containers/index.md %}#iptc-model-bootstrap) manually

--- a/content-services/7.1/develop/rest-api-guide/index.md
+++ b/content-services/7.1/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.1/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-If you want to know what the API Explorer looks like right now, then have a look at the online version at 
-[https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} 
+To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
 (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version

--- a/content-services/7.1/develop/rest-api-guide/index.md
+++ b/content-services/7.1/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.1/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
-(note that this API Explorer always shows the API for the latest version of ACS).
+If you want to know what the API Explorer looks like right now, then have a look at the online version at [https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version
 

--- a/content-services/7.1/develop/rest-api-guide/install.md
+++ b/content-services/7.1/develop/rest-api-guide/install.md
@@ -18,7 +18,7 @@ If you just want to have a look at the latest API Explorer, then you can use an 
 ## Installing
 
 Most likely you would want to install the API Explorer into your local ACS installation. You can find the
-Alfresco API Explorer WAR file in [Alfresco’s Nexus repository](https://artifacts.alfresco.com/nexus/#nexus-search;quick~api-explorer){:target="_blank"}.
+Alfresco API Explorer WAR file in Alfresco’s Nexus repository by searching for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/.
 Pick the version that closest matches your ACS installation.
 
 To install the WAR file follow one of two approaches. If you are using a trial version of ACS then you follow the first

--- a/content-services/7.1/develop/sdk.md
+++ b/content-services/7.1/develop/sdk.md
@@ -1901,7 +1901,7 @@ If you're using Windows, you'll need to use the `run.bat` script instead of `run
 #### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}.
 
 The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository 
-([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
+([artifacts.alfresco.com](https://nexus.alfresco.com/nexus/){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
 request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}. 
 
 Once you have suitable credentials, you need to add support for Alfresco private Maven repository to your configuration. This would typically be done by 

--- a/content-services/7.1/install/ansible.md
+++ b/content-services/7.1/install/ansible.md
@@ -24,7 +24,7 @@ There are two types of installations - local and remote:
 
 ## Prerequisites
 
-If you're using the Content Services (Enterprise), then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+If you're using the Content Services (Enterprise), then you need credentials to access the necessary artifacts from [Nexus](https://nexus.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 ## Target O/S
 

--- a/content-services/7.2/develop/rest-api-guide/index.md
+++ b/content-services/7.2/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.2/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
-(note that this API Explorer always shows the API for the latest version of ACS).
+If you want to know what the API Explorer looks like right now, then have a look at the online version at [https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version
 

--- a/content-services/7.2/develop/rest-api-guide/index.md
+++ b/content-services/7.2/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.2/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-If you want to know what the API Explorer looks like right now, then have a look at the online version at 
-[https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} 
+To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
 (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version

--- a/content-services/7.2/develop/rest-api-guide/install.md
+++ b/content-services/7.2/develop/rest-api-guide/install.md
@@ -20,7 +20,7 @@ If you just want to have a look at the latest API Explorer, then you can use an 
 >Check by accessing `http://localhost:8080/api-explorer`
 
 Most likely you would want to install the API Explorer into your local ACS installation. You can find the
-Alfresco API Explorer WAR file in [Alfresco’s Nexus repository](https://artifacts.alfresco.com/nexus/#nexus-search;quick~api-explorer){:target="_blank"}.
+Alfresco API Explorer WAR file in Alfresco’s Nexus repository by searching for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/.
 Pick the version that closest matches your ACS installation.
 
 To install the WAR file follow one of two approaches. If you are using a trial version of ACS then you follow the first

--- a/content-services/7.2/develop/sdk.md
+++ b/content-services/7.2/develop/sdk.md
@@ -1898,7 +1898,7 @@ If you're using Windows, you'll need to use the `run.bat` script instead of `run
 #### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}
 
 The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository 
-([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
+([artifacts.alfresco.com](https://nexus.alfresco.com/nexus/){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
 request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}. 
 
 Once you have suitable credentials, you need to add support for Alfresco private Maven repository to your configuration. This would typically be done by 

--- a/content-services/7.2/install/ansible.md
+++ b/content-services/7.2/install/ansible.md
@@ -87,7 +87,7 @@ We provide example inventories:
 
 ## Prerequisites
 If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from 
-[Nexus](https://artifacts.alfresco.com/nexus/){:target="_blank"}. Customers can request these through 
+[Nexus](https://nexus.alfresco.com/nexus/){:target="_blank"}. Customers can request these through 
 [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 ### Control Node

--- a/content-services/7.3/develop/rest-api-guide/index.md
+++ b/content-services/7.3/develop/rest-api-guide/index.md
@@ -60,9 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.3/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-If you want to know what the API Explorer looks like right now, then have a look at the online version at 
-[https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} 
-(note that this API Explorer always shows the API for the latest version of ACS).
+If you want to know what the API Explorer looks like right now, then have a look at the online version at [https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version
 

--- a/content-services/7.3/develop/rest-api-guide/install.md
+++ b/content-services/7.3/develop/rest-api-guide/install.md
@@ -20,7 +20,7 @@ If you just want to have a look at the latest API Explorer, then you can use an 
 >Check by accessing `http://localhost:8080/api-explorer`
 
 Most likely you would want to install the API Explorer into your local ACS installation. You can find the
-Alfresco API Explorer WAR file in [Alfresco’s Nexus repository](https://artifacts.alfresco.com/nexus/#nexus-search;quick~api-explorer){:target="_blank"}.
+Alfresco API Explorer WAR file in Alfresco’s Nexus repository by searching for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/.
 Pick the version that closest matches your ACS installation.
 
 To install the WAR file follow one of two approaches. If you are using a trial version of ACS then you follow the first

--- a/content-services/7.3/develop/sdk.md
+++ b/content-services/7.3/develop/sdk.md
@@ -1898,7 +1898,7 @@ If you're using Windows, you'll need to use the `run.bat` script instead of `run
 #### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}
 
 The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository 
-([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
+([artifacts.alfresco.com](https://nexus.alfresco.com/nexus/){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can 
 request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}. 
 
 Once you have suitable credentials, you need to add support for Alfresco private Maven repository to your configuration. This would typically be done by 

--- a/content-services/7.3/install/ansible.md
+++ b/content-services/7.3/install/ansible.md
@@ -81,7 +81,7 @@ Complete documentation about the inventory file is available at [Ansible](https:
 
 ## Prerequisites
 
-If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from [Nexus](https://nexus.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 ### Control Node
 

--- a/content-services/7.4/develop/rest-api-guide/index.md
+++ b/content-services/7.4/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.4/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-If you want to know what the API Explorer looks like right now, then have a look at the online version at 
-[https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} 
+To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
 (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version

--- a/content-services/7.4/develop/rest-api-guide/index.md
+++ b/content-services/7.4/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/7.4/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
-(note that this API Explorer always shows the API for the latest version of ACS).
+If you want to know what the API Explorer looks like right now, then have a look at the online version at [https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version
 

--- a/content-services/7.4/develop/rest-api-guide/install.md
+++ b/content-services/7.4/develop/rest-api-guide/install.md
@@ -20,7 +20,7 @@ If you just want to have a look at the latest API Explorer, then you can use an 
 >Check by accessing `http://localhost:8080/api-explorer`
 
 Most likely you would want to install the API Explorer into your local ACS installation. You can find the
-Alfresco API Explorer WAR file in [Alfresco’s Nexus repository](https://artifacts.alfresco.com/nexus/#nexus-search;quick~api-explorer){:target="_blank"}.
+Alfresco API Explorer WAR file in Alfresco’s Nexus repository by searching for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/.
 Pick the version that closest matches your ACS installation.
 
 To install the WAR file follow one of two approaches. If you are using a trial version of ACS then you follow the first

--- a/content-services/7.4/develop/sdk.md
+++ b/content-services/7.4/develop/sdk.md
@@ -1743,7 +1743,7 @@ If you're using Windows, you'll need to use the `run.bat` script instead of `run
 
 #### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}
 
-The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository ([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository ([artifacts.alfresco.com](https://nexus.alfresco.com/nexus/){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 Once you have suitable credentials, you need to add support for Alfresco private Maven repository to your configuration. This would typically be done by adding your access credentials to the `settings.xml` contained in your `~/.m2` directory (for Linux and OS X). On Windows this resolves to `C:\Users\<username>\.m2`.
 

--- a/content-services/7.4/install/ansible.md
+++ b/content-services/7.4/install/ansible.md
@@ -80,7 +80,7 @@ Complete documentation about the inventory file is available at [Ansible](https:
 
 ## Prerequisites
 
-If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from [Nexus](https://nexus.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 ### Control Node
 

--- a/content-services/latest/develop/rest-api-guide/index.md
+++ b/content-services/latest/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/latest/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
-(note that this API Explorer always shows the API for the latest version of ACS).
+If you want to know what the API Explorer looks like right now, then have a look at the online version at [https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version
 

--- a/content-services/latest/develop/rest-api-guide/index.md
+++ b/content-services/latest/develop/rest-api-guide/index.md
@@ -60,8 +60,7 @@ details, and you cannot find any information about it anywhere, consult the API 
 You can find more information about the API Explorer on [this page]({% link content-services/latest/develop/rest-api-guide/install.md %}), 
 which also has information on how to install it for your specific version of ACS.
 
-If you want to know what the API Explorer looks like right now, then have a look at the online version at 
-[https://api-explorer.alfresco.com/api-explorer](https://api-explorer.alfresco.com/api-explorer){:target="_blank} 
+To know what the API Explorer looks like right now, search for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/
 (note that this API Explorer always shows the API for the latest version of ACS).
 
 ### Finding out if an API endpoint is supported in a specific ACS version

--- a/content-services/latest/develop/rest-api-guide/install.md
+++ b/content-services/latest/develop/rest-api-guide/install.md
@@ -20,7 +20,7 @@ If you just want to have a look at the latest API Explorer, then you can use an 
 >Check by accessing `http://localhost:8080/api-explorer`
 
 Most likely you would want to install the API Explorer into your local ACS installation. You can find the
-Alfresco API Explorer WAR file in [Alfresco’s Nexus repository](https://artifacts.alfresco.com/nexus/#nexus-search;quick~api-explorer){:target="_blank"}.
+Alfresco API Explorer WAR file in Alfresco’s Nexus repository by searching for "api-explorer" on the Nexus Repository website available at https://nexus.alfresco.com/nexus/.
 Pick the version that closest matches your ACS installation.
 
 To install the WAR file follow one of two approaches. If you are using a trial version of ACS then you follow the first

--- a/content-services/latest/develop/sdk.md
+++ b/content-services/latest/develop/sdk.md
@@ -1772,7 +1772,7 @@ If you're using Windows, you'll need to use the `run.bat` script instead of `run
 
 #### How to configure private Alfresco Nexus repository {#enterprisemvnrepo}
 
-The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository ([artifacts.alfresco.com](https://artifacts.alfresco.com/nexus/#welcome){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+The first matter to consider is to ensure that you have credentials for the Alfresco Private Repository ([artifacts.alfresco.com](https://nexus.alfresco.com/nexus/){:target="_blank"}), where the Alfresco artifacts are stored. Enterprise customers and partners can request these credentials by opening a ticket in [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 Once you have suitable credentials, you need to add support for Alfresco private Maven repository to your configuration. This would typically be done by adding your access credentials to the `settings.xml` contained in your `~/.m2` directory (for Linux and OS X). On Windows this resolves to `C:\Users\<username>\.m2`.
 

--- a/content-services/latest/install/ansible.md
+++ b/content-services/latest/install/ansible.md
@@ -80,7 +80,7 @@ Complete documentation about the inventory file is available at [Ansible](https:
 
 ## Prerequisites
 
-If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from [Nexus](https://artifacts.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
+If you're using the Enterprise edition of Content Services, then you need credentials to access the necessary artifacts from [Nexus](https://nexus.alfresco.com/nexus/){:target="_blank"}. Customers can request these through [Hyland Community](https://community.hyland.com/){:target="_blank"}.
 
 ### Control Node
 


### PR DESCRIPTION
**Noteworthy:** Links to artifacts.alfresco.com access the same service as nexus.alfresco.com.