### PR TITLE
[DOCS-7828] Update to latest release versions in Alfresco Docs site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ defaults:
       tutorial: true
       support: true
       versions:
-        - 23.x
+        - 23.2
         - 7.4
         - 7.3
         - 7.2
@@ -24,7 +24,7 @@ defaults:
   - scope:
       path: "content-services/latest"
     values:
-      version: 23.x
+      version: 23.2
       latest: true
       release: true
   - scope:
@@ -610,7 +610,7 @@ defaults:
       tutorial: true
       support: true
       versions:
-        - 23.x
+        - 23.2
         - 7.4
         - 7.3
         - 7.2
@@ -624,7 +624,7 @@ defaults:
   - scope:
       path: "governance-services/latest"
     values:
-      version: 23.x
+      version: 23.2
       latest: true
   - scope:
       path: "governance-services/latest/tutorial"
@@ -730,7 +730,7 @@ defaults:
       toc: "process-services"
       support: true
       versions:
-        - 24.x
+        - 24.2
         - 2.4
         - 2.3
         - 2.2
@@ -742,7 +742,7 @@ defaults:
   - scope:
       path: "process-services/latest"
     values:
-      version: 24.x
+      version: 24.2
       latest: true
   - scope:
       path: "process-services/2.4"

--- a/_data/toc/content-services-tutorial.yaml
+++ b/_data/toc/content-services-tutorial.yaml
@@ -1,5 +1,5 @@
-# Alfresco Content Services Tutorials 23.x
-- version: 23.x
+# Alfresco Content Services Tutorials 23.2
+- version: 23.2
   pages:
     - title: 'Tutorials'
       pages:

--- a/_data/toc/content-services.yaml
+++ b/_data/toc/content-services.yaml
@@ -1,5 +1,5 @@
-# Alfresco Content Services 23.x
-- version: 23.x
+# Alfresco Content Services 23.2
+- version: 23.2
   pages:
     - title: 'Introduction'
       path: '/content-services/latest/'

--- a/_data/toc/governance-services-tutorial.yaml
+++ b/_data/toc/governance-services-tutorial.yaml
@@ -1,5 +1,5 @@
-# Alfresco Governance Services 23.x
-- version: 23.x
+# Alfresco Governance Services 23.2
+- version: 23.2
   pages:
     - title: 'Tutorials'
       path: '/governance-services/latest/tutorial/'

--- a/_data/toc/governance-services.yaml
+++ b/_data/toc/governance-services.yaml
@@ -1,5 +1,5 @@
-# Alfresco Governance Services 23.x
-- version: 23.x
+# Alfresco Governance Services 23.2
+- version: 23.2
   pages:
     - title: 'Introduction'
       path: '/governance-services/latest/'

--- a/_data/toc/process-services.yaml
+++ b/_data/toc/process-services.yaml
@@ -1,5 +1,5 @@
-# Alfresco Process Services 24.x
-- version: 24.x
+# Alfresco Process Services 24.2
+- version: 24.2
   pages:
     - title: 'Introduction'
       path: '/process-services/latest/'

--- a/content-services/latest/index.md
+++ b/content-services/latest/index.md
@@ -2,7 +2,7 @@
 title: Alfresco Content Services
 ---
 
-Alfresco Content Services 23.x (or ACS) offers full-featured Enterprise Content Management (ECM) for organizations that require enterprise-grade scalability, performance, and 24x7 support for business-critical content and compliance. It delivers a wide range of use cases such as content and governance services, contextual search and insight, the ability to easily integrate with other applications. At the core of Content Services is a repository supported by a server that persists content, metadata, associations, and full text indexes.
+Alfresco Content Services (or ACS) offers full-featured Enterprise Content Management (ECM) for organizations that require enterprise-grade scalability, performance, and 24x7 support for business-critical content and compliance. It delivers a wide range of use cases such as content and governance services, contextual search and insight, the ability to easily integrate with other applications. At the core of Content Services is a repository supported by a server that persists content, metadata, associations, and full text indexes.
 
 Some of the key capabilities of Content Service include:
 

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -10,6 +10,8 @@ Choose a combination of products to build your own Supported Stack. If anything 
 
 {% capture twenty-three-two %}
 
+> **Note:** Information for this Service Pack is provided for reference only. Please use the latest Service Pack.
+
 | Version | Notes |
 | ------- | ----- |
 | **Operating systems** | |
@@ -207,4 +209,4 @@ Choose a combination of products to build your own Supported Stack. If anything 
 
 {% endcapture %}
 
-{% include tabs.html tableid="supported-platforms" opt1="23.2" content1=twenty-three-two opt2="23.1 (reference only)" content2=twenty-three-one %}
+{% include tabs.html tableid="supported-platforms" opt1="23.2 (reference only)" content1=twenty-three-two opt2="23.1 (reference only)" content2=twenty-three-one %}

--- a/governance-services/latest/support/index.md
+++ b/governance-services/latest/support/index.md
@@ -2,9 +2,13 @@
 title: Supported platforms
 ---
 
-The following are the supported platforms for the Alfresco Governance Services version 23.x:
+The following are the supported platforms for the Alfresco Governance Services.
+
+> **Note:** To get the latest security fixes and updates, use the latest Service Pack for the listed product version. See the Alfresco Software Downloads page in [Hyland Community](https://community.hyland.com/customer-portal/downloads/alfresco){:target="_blank"} for the latest Service Pack versions.
 
 {% capture twenty-three-two %}
+
+> **Note:** Information for this Service Pack is provided for reference only. Please use the latest Service Pack.
 
 | Version | Notes |
 | ------- | ----- |
@@ -14,10 +18,12 @@ The following are the supported platforms for the Alfresco Governance Services v
 
 {% capture twenty-three-one %}
 
+> **Note:** Information for this Service Pack is provided for reference only. Please use the latest Service Pack.
+
 | Version | Notes |
 | ------- | ----- |
 | Alfresco Content Services 23.1 | |
 
 {% endcapture %}
 
-{% include tabs.html tableid="supported-platforms" opt1="23.2" content1=twenty-three-two opt2="23.1" content2=twenty-three-one %}
+{% include tabs.html tableid="supported-platforms" opt1="23.2 (reference only)" content1=twenty-three-two opt2="23.1 (reference only)" content2=twenty-three-one %}

--- a/process-services/latest/support/index.md
+++ b/process-services/latest/support/index.md
@@ -10,6 +10,8 @@ Choose a combination of products to build your own Supported Stack. If anything 
 
 {% capture twenty-four-two %}
 
+> **Note:** Information for this Service Pack is provided for reference only. Please use the latest Service Pack.
+
 | Version | Notes |
 | ------- | ----- |
 | **Operating systems** | |
@@ -125,4 +127,4 @@ Choose a combination of products to build your own Supported Stack. If anything 
 
 {% endcapture %}
 
-{% include tabs.html tableid="supported-platforms" opt1="24.2" content1=twenty-four-two opt2="24.1 (reference only)" content2=twenty-four-one %}
+{% include tabs.html tableid="supported-platforms" opt1="24.2 (reference only)" content1=twenty-four-two opt2="24.1 (reference only)" content2=twenty-four-one %}


### PR DESCRIPTION
These are the **latest** versions documented in GitHub and published to the [Alfresco Docs site](https://docs.alfresco.com/), and will be displayed as follows:

Latest Version in GitHub Docs | Documented Product Versions
-- | --
ACS 23.2 | ACS 23.2 and ACS 23.1
AGS 23.2 | AGS 23.2 and AGS 23.1
APS 24.2 | APS 24.2 and APS 24.1

New versions of these products will be published to the [Hyland Documentation Portal](https://support.hyland.com/).









