### PR TITLE
[DOCS-7865] Identify the latest migrated products

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,10 +8,7 @@ redirect_from:
 - /assets/img/
 - /assets/js/
 - /content-services/23.3/
-- /content-services/community/
-- /process-automation/latest/
 - /governance-services/23.3/
-- /governance-services/community/
 ---
 
 <section class="section section-404">

--- a/404.html
+++ b/404.html
@@ -71,9 +71,9 @@ redirect_from:
           <h2>Applications</h2>
           <ul>
             <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Digital Workspace 5.0 and higher</a> | <a href="https://docs.alfresco.com/digital-workspace/latest/">Older versions</a></li>
-            <li><a href="https://docs.alfresco.com/mobile-workspace/latest/">Alfresco Mobile Workspace 1.9</a></li>
-            <li><a href="https://docs.alfresco.com/content-accelerator/latest/">Alfresco Content Accelerator 4.0</a></li>
-            <li><a href="https://docs.alfresco.com/enterprise-viewer/latest/">Alfresco Enterprise Viewer 4.0</a></li>
+            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Mobile Workspace 1.10 and higher</a> | <a href="https://docs.alfresco.com/mobile-workspace/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Content Accelerator 4.1 and higher</a> | <a href="https://docs.alfresco.com/content-accelerator/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Enterprise Viewer 4.1 and higher</a> | <a href="https://docs.alfresco.com/enterprise-viewer/latest/">Older versions</a></li>
           </ul>
         </div>
 

--- a/_config.yml
+++ b/_config.yml
@@ -226,7 +226,7 @@ defaults:
     values:
       version: 1.5
 
-  # Alfresco Mobile Workspace (AMW)
+  # Alfresco Mobile Workspace (AMW) - Migrated
   - scope:
       path: "mobile-workspace"
     values:
@@ -239,7 +239,7 @@ defaults:
     values:
       version: 1.9
       latest: true
-
+      migrated: true
 
 # Alfresco Google Drive
   - scope:
@@ -1542,7 +1542,7 @@ defaults:
     values:
       version: 2.4
 
-# Alfresco Content Accelerator (ACA)
+# Alfresco Content Accelerator (ACA) - Migrated
   - scope:
       path: "content-accelerator"
     values:
@@ -1561,6 +1561,7 @@ defaults:
     values:
       version: 4.0
       latest: true
+      migrated: true
   - scope:
       path: "content-accelerator/3.7"
     values:
@@ -1574,7 +1575,7 @@ defaults:
     values:
       version: 3.5
 
-# Alfresco Enterprise Viewer (AEV)
+# Alfresco Enterprise Viewer (AEV) - Migrated
   - scope:
       path: "enterprise-viewer"
     values:
@@ -1592,6 +1593,7 @@ defaults:
     values:
       version: 4.0
       latest: true
+      migrated: true
   - scope:
       path: "enterprise-viewer/3.6"
     values:


### PR DESCRIPTION
This PRs identifies the latest Alfresco documentation that has moved to the Hyland Documentation Portal (support.hyland.com).

Related:

- #1566
- #1571 