### PR TITLE
DOCS-7841: Add Kubernetes tested versions and flavors

### DIFF
--- a/content-services/7.1/support/index.md
+++ b/content-services/7.1/support/index.md
@@ -20,6 +20,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Ubuntu 20.04 | |
 | Ubuntu 18.04 | |
 |  |  |
+| **Container Orchestration** | |
+| Kubernetes 1.27 | Tested with [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) 8.1.0 |
+| Amazon EKS 1.26 | Tested with [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) 8.1.0 |
+|  |  |
 | **Databases** | |
 | MySQL 8 | `mysql-connector-java-8.0.22.jar` |
 | MySQL 5.7.23 | `mysql-connector-java-5.1.40-bin.jar` |

--- a/content-services/7.2/support/index.md
+++ b/content-services/7.2/support/index.md
@@ -23,6 +23,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Ubuntu 20.04 | |
 | Ubuntu 18.04 | |
 |  |  |
+| **Container Orchestration** | |
+| Kubernetes 1.27 | Tested with [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) 8.1.0 |
+| Amazon EKS 1.26 | Tested with [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) 8.1.0 |
+|  |  |
 | **Databases** | |
 | MySQL 8 | `mysql-connector-java-8.0.27.jar` |
 | MySQL 5.7.28 | `mysql-connector-java-5.1.49-bin.jar` |

--- a/content-services/7.3/support/index.md
+++ b/content-services/7.3/support/index.md
@@ -19,6 +19,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | CentOS 8.3 x64 | |
 | Ubuntu 22.04 | |
 |  |  |
+| **Container Orchestration** | |
+| Kubernetes 1.29 | Tested with latest [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+| Amazon EKS 1.28 | Tested with latest [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+|  |  |
 | **Databases** | |
 | MySQL 8.0 | `mysql-connector-java-8.0.30.jar` |
 | MS SQL Server 2019 | `mssql-jdbc-9.2.1.jre11.jar` |

--- a/content-services/7.4/support/index.md
+++ b/content-services/7.4/support/index.md
@@ -24,6 +24,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Ubuntu 20.04 | |
 | Rocky Linux 8.7 | |
 |  |  |
+| **Container Orchestration** | |
+| Kubernetes 1.29 | Tested with latest [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+| Amazon EKS 1.28 | Tested with latest [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+|  |  |
 | **Databases** | |
 | MySQL 8 | `mysql-connector-java-8.0.27.jar` |
 | MS SQL Server 2019 | `mssql-jdbc-9.2.1.jre11.jar` |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -25,8 +25,8 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Rocky Linux 8.8 | |
 |  |  |
 | **Container Orchestration** | |
-| Kubernetes 1.29 | Tested with [Alfresco Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
-| Amazon EKS 1.28 | Tested with [Alfresco Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+| Kubernetes 1.29 | Tested with latest [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+| Amazon EKS 1.28 | Tested with latest [ACS Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
 |  |  |
 | **Databases** | |
 | MySQL 8 | `mysql-connector-java-8.0.30.jar` |

--- a/content-services/latest/support/index.md
+++ b/content-services/latest/support/index.md
@@ -24,6 +24,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Rocky Linux 9.x | |
 | Rocky Linux 8.8 | |
 |  |  |
+| **Container Orchestration** | |
+| Kubernetes 1.29 | Tested with [Alfresco Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+| Amazon EKS 1.28 | Tested with [Alfresco Helm chart](https://alfresco.github.io/acs-deployment/helm/alfresco-content-services/README.html) |
+|  |  |
 | **Databases** | |
 | MySQL 8 | `mysql-connector-java-8.0.30.jar` |
 | MS SQL Server 2022 | `mssql-jdbc-11.2.0.jre17.jar` |

--- a/process-services/latest/support/index.md
+++ b/process-services/latest/support/index.md
@@ -25,6 +25,10 @@ Choose a combination of products to build your own Supported Stack. If anything 
 | Ubuntu 22.04 | |
 | Amazon Linux 2 | |
 | | |
+| **Container Orchestration** | |
+| Kubernetes 1.29 | Tested with [APS Helm chart](https://github.com/Alfresco/alfresco-process-services-deployment) |
+| Amazon EKS 1.28 | Tested with [APS Helm chart](https://github.com/Alfresco/alfresco-process-services-deployment) |
+|  |  |
 | **Databases** | |
 | MariaDB 10.6 | 3.1.4 |
 | MySQL 8.0 | `mysql-connector-java-8.0.33.jar` |


### PR DESCRIPTION
Ref: DOCS-7841
Mentions Kubernetes' versions and flavours which have been tested as part of our Alfresco Helm charts for APS and ACS (umbrella charts)