### PR TITLE
[DOCS-7905] Add links to latest releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor
 *.iml
 *.iws
 docker-compose-o.yml
+
+# VS Code
+.vscode/

--- a/404.html
+++ b/404.html
@@ -44,18 +44,18 @@ redirect_from:
 
           <h2>Integrations</h2>
           <ul>
-            <li><a href="https://docs.alfresco.com/sync-service/latest/">Alfresco Sync Service 5.0</a></li>
-            <li><a href="https://docs.alfresco.com/desktop-sync/latest/">Alfresco Desktop Sync 1.18</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Sync Service 5.1 and higher</a> | <a href="https://docs.alfresco.com/sync-service/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Desktop Sync 1.19 and higher</a> | <a href="https://docs.alfresco.com/desktop-sync/latest/">Older versions</a></li>
             <li><a href="https://docs.alfresco.com/transform-service/latest/">Alfresco Transform Service 4.1</a></li>
             <li><a href="https://docs.alfresco.com/transformation-engine/latest/">Alfresco Document Transformation Engine 2.4</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Search Enterprise 4.1 and higher</a> | <a href="https://docs.alfresco.com/search-enterprise/latest/">Older versions</a></li></li>
+            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Search Enterprise 4.1 and higher</a> | <a href="https://docs.alfresco.com/search-enterprise/latest/">Older versions</a></li>
             <li><a href="https://docs.alfresco.com/insight-engine/latest/">Alfresco Search and Insight Engine 2.0</a></li>
             <li><a href="https://docs.alfresco.com/search-services/latest/">Alfresco Search Services 2.0</a></li>
             <li><a href="https://docs.alfresco.com/federation-services/latest/">Alfresco Federation Services 3.2</a></li>
             <li><a href="https://docs.alfresco.com/intelligence-services/latest/">Alfresco Intelligence Services 3.1</a></li>
             <li><a href="https://docs.alfresco.com/aws-s3/latest/">Alfresco Content Connector for AWS S3 6.1</a></li>
             <li><a href="https://docs.alfresco.com/microsoft-azure/latest/">Alfresco Content Connector for Azure 5.0</a></li>
-            <li><a href="https://docs.alfresco.com/salesforce/latest/">Alfresco Content Connector for Salesforce 3.1</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for Salesforce 3.2 and higher</a> | <a href="https://docs.alfresco.com/salesforce/latest/">Older versions</a></li>
             <li><a href="https://docs.alfresco.com/sap/latest/">Alfresco Content Connector for SAP Applications 6.0</a></li>
             <li><a href="https://docs.alfresco.com/sap-cloud/latest/">Alfresco Content Connector for SAP Cloud 2.0</a></li>
             <li><a href="https://docs.alfresco.com/microsoft-365/latest/">Alfresco Collaboration Connector for Microsoft 365 2.0</a></li>

--- a/404.html
+++ b/404.html
@@ -34,46 +34,66 @@ redirect_from:
       <div class="content">
 
         <div class="column">
-          <h2 id="migrated">Services</h2>
-          <ul>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Content Services 23.3 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Process Automation 7.17 and higher</a> | <a href="https://docs.alfresco.com/process-automation/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Process Services 24.3 and higher</a> | <a href="https://docs.alfresco.com/process-services/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Governance Services 23.3 and higher</a> | <a href="https://docs.alfresco.com/governance-services/latest/">Older versions</a></li>
-          </ul>
+          <h2 id="migrated">Latest Releases</h2>
 
-          <h2>Integrations</h2>
           <ul>
-            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Sync Service 5.1 and higher</a> | <a href="https://docs.alfresco.com/sync-service/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Desktop Sync 1.19 and higher</a> | <a href="https://docs.alfresco.com/desktop-sync/latest/">Older versions</a></li>
-            <li><a href="https://docs.alfresco.com/transform-service/latest/">Alfresco Transform Service 4.1</a></li>
-            <li><a href="https://docs.alfresco.com/transformation-engine/latest/">Alfresco Document Transformation Engine 2.4</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Search Enterprise 4.1 and higher</a> | <a href="https://docs.alfresco.com/search-enterprise/latest/">Older versions</a></li>
-            <li><a href="https://docs.alfresco.com/insight-engine/latest/">Alfresco Search and Insight Engine 2.0</a></li>
-            <li><a href="https://docs.alfresco.com/search-services/latest/">Alfresco Search Services 2.0</a></li>
-            <li><a href="https://docs.alfresco.com/federation-services/latest/">Alfresco Federation Services 3.2</a></li>
-            <li><a href="https://docs.alfresco.com/intelligence-services/latest/">Alfresco Intelligence Services 3.1</a></li>
-            <li><a href="https://docs.alfresco.com/aws-s3/latest/">Alfresco Content Connector for AWS S3 6.1</a></li>
-            <li><a href="https://docs.alfresco.com/microsoft-azure/latest/">Alfresco Content Connector for Azure 5.0</a></li>
-            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for Salesforce 3.2 and higher</a> | <a href="https://docs.alfresco.com/salesforce/latest/">Older versions</a></li>
-            <li><a href="https://docs.alfresco.com/sap/latest/">Alfresco Content Connector for SAP Applications 6.0</a></li>
-            <li><a href="https://docs.alfresco.com/sap-cloud/latest/">Alfresco Content Connector for SAP Cloud 2.0</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco APS Action Extension 7.0</a> | <a href="https://docs.alfresco.com/content-services/latest/config/action/">Older versions</a></li>
+
             <li><a href="https://docs.alfresco.com/microsoft-365/latest/">Alfresco Collaboration Connector for Microsoft 365 2.0</a></li>
             <li><a href="https://docs.alfresco.com/microsoft-teams/latest/">Alfresco Collaboration Connector for Microsoft Teams 2.0</a></li>
-            <li><a href="https://docs.alfresco.com/microsoft-outlook/latest/">Alfresco Outlook Integration 3.0</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Office Services 3.1 and higher</a> | <a href="https://docs.alfresco.com/microsoft-office/latest/">Older versions</a></li>
-            <li><a href="https://docs.alfresco.com/google-drive/latest/">Alfresco Google Docs Integration 4.1</a></li>
-          </ul>
-    
-          <h2>Applications</h2>
-          <ul>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Digital Workspace 5.0 and higher</a> | <a href="https://docs.alfresco.com/digital-workspace/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Mobile Workspace 1.10 and higher</a> | <a href="https://docs.alfresco.com/mobile-workspace/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Content Accelerator 4.1 and higher</a> | <a href="https://docs.alfresco.com/content-accelerator/latest/">Older versions</a></li>
-            <li><a href="https://support.hyland.com/search/all?filters=prodname~%2522Alfresco%2522&content-lang=en-US">Alfresco Enterprise Viewer 4.1 and higher</a> | <a href="https://docs.alfresco.com/enterprise-viewer/latest/">Older versions</a></li>
-          </ul>
-        </div>
 
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Accelerator 4.1 and higher</a> | <a href="https://docs.alfresco.com/content-accelerator/latest/">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/aws-s3/latest/">Alfresco Content Connector for AWS S3 6.1</a></li>
+            
+            <li><a href="https://docs.alfresco.com/microsoft-azure/latest/">Alfresco Content Connector for Azure 5.0</a></li><li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for Salesforce 3.2 and higher</a> | <a href="https://docs.alfresco.com/salesforce/latest/">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/sap/latest/">Alfresco Content Connector for SAP Applications 6.0</a></li>
+            <li><a href="https://docs.alfresco.com/sap-cloud/latest/">Alfresco Content Connector for SAP Cloud 2.0</a></li>
+
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Services 23.3 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Services Community Edition 23.3 and higher</a> | <a href="https://docs.alfresco.com/content-services/community/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Control Center 9.0 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/admin/control-center/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Desktop Sync 1.19 and higher</a> | <a href="https://docs.alfresco.com/desktop-sync/latest/">Older versions</a></li>
+
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Digital Workspace 5.0 and higher</a> | <a href="https://docs.alfresco.com/digital-workspace/latest/">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/transformation-engine/latest/">Alfresco Document Transformation Engine 2.4</a></li>
+            
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Enterprise Viewer 4.1 and higher</a> | <a href="https://docs.alfresco.com/enterprise-viewer/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Extension Inspector 2.1 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/develop/extension-inspector/">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/federation-services/latest/">Alfresco Federation Services 3.2</a></li>
+            
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco File System Transfer Receiver 7.0</a> | <a href="https://docs.alfresco.com/content-services/latest/admin/import-transfer/#configure-file-system-transfer-receiver">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/google-drive/latest/">Alfresco Google Docs Integration 4.1</a></li>
+
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Governance Services 23.3 and higher</a> | <a href="https://docs.alfresco.com/governance-services/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Governance Services Community Edition 23.3 and higher</a> | <a href="https://docs.alfresco.com/governance-services/community/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco In-Process SDK 4.9 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/develop/sdk/">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/intelligence-services/latest/">Alfresco Intelligence Services 3.1</a></li><li><a href="https://support.hyland.com/p/alfresco">Alfresco Office Services 3.1 and higher</a> | <a href="https://docs.alfresco.com/microsoft-office/latest/">Older versions</a></li>
+
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Mobile Workspace 1.10 and higher</a> | <a href="https://docs.alfresco.com/mobile-workspace/latest/">Older versions</a></li>
+
+            <li><a href="https://docs.alfresco.com/microsoft-outlook/latest/">Alfresco Outlook Integration 3.0</a></li>
+            
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Process Automation 7.17 and higher</a> | <a href="https://docs.alfresco.com/process-automation/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Process Services 24.3 and higher</a> | <a href="https://docs.alfresco.com/process-services/latest/">Older versions</a></li>
+            
+            <li><a href="https://docs.alfresco.com/insight-engine/latest/">Alfresco Search and Insight Engine 2.0</a></li>
+            
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Search Enterprise 4.1 and higher</a> | <a href="https://docs.alfresco.com/search-enterprise/latest/">Older versions</a></li>
+
+            <li><a href="https://docs.alfresco.com/search-services/latest/">Alfresco Search Services 2.0</a></li>
+
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Sync Service 5.1 and higher</a> | <a href="https://docs.alfresco.com/sync-service/latest/">Older versions</a></li>         
+
+            <li><a href="https://docs.alfresco.com/transform-service/latest/">Alfresco Transform Service 4.1</a></li>
+          </ul>
+
+        </div>
       </div>
     </div>
   </div>

--- a/_config.yml
+++ b/_config.yml
@@ -377,7 +377,7 @@ defaults:
     values:
       version: 1.0
 
-# Alfresco Content Connector for Salesforce
+# Alfresco Content Connector for Salesforce - Migrated
   - scope:
       path: "salesforce"
     values:
@@ -398,6 +398,7 @@ defaults:
     values:
       version: 3.1
       latest: true
+      migration: true
   - scope:
       path: "salesforce/3.0"
     values:
@@ -519,7 +520,7 @@ defaults:
       version: 1.0
       tutorial: false
       
-# Alfresco Desktop Sync
+# Alfresco Desktop Sync - Migrated
   - scope:
       path: "desktop-sync"
     values:
@@ -548,6 +549,7 @@ defaults:
     values:
       version: 1.18
       latest: true
+      migration: true
   - scope:
       path: "desktop-sync/1.17"
     values:
@@ -1352,7 +1354,7 @@ defaults:
     values:
       version: 1.0
 
-# Alfresco Sync Service
+# Alfresco Sync Service - Migrated
   - scope:
       path: "sync-service"
     values:
@@ -1381,6 +1383,7 @@ defaults:
     values:
       version: 5.0
       latest: true
+      migration: true
   - scope:
       path: "sync-service/4.0"
     values:

--- a/content-services/latest/install/ansible.md
+++ b/content-services/latest/install/ansible.md
@@ -630,7 +630,7 @@ Ansible Vault provides two alternative ways to protect secrets:
 In the previous links you can read both advantages and disadvantages of the two approaches.
 
 > If you are upgrading from previous versions of the playbook, you may want to
-> read [upgrade notes](playbook-upgrade.md#secrets-management).
+> read the [upgrade notes](#secrets-management).
 
 ##### Encrypted variables
 

--- a/federation-services/latest/config/index.md
+++ b/federation-services/latest/config/index.md
@@ -340,6 +340,7 @@ etc.
 The following connectors are recommended and supported by the latest version of Federation Services.
 
 | Software Connector | Description |
+| ------------------ | ----------- |
 | [Objective ECM/Nexus](#objective-ecmnexus) | Can be used as an output connector for Manage in Place |
 | [Elasticsearch](#elasticsearch) | Can be used as a content search connector for Manage in Place |
 | [MongoDB](#mongodb), [MongoDB GridFS](#mongodb-gridfs) | Can be used as a content search connector for Manage in Place |
@@ -1272,7 +1273,7 @@ The Tenant, Client ID, and Client Secret, are all provided to you during your Ap
 
 #### Microsoft Graph SharePoint
 
-##### Authentification Connection
+##### Authentication Connection
 
 > **Tip:** Tip:  Its recommended that OAuth be used for Migration only. And Client / Secret Auth be used for Content Service
 
@@ -1803,7 +1804,7 @@ Federation Services supports 3 types of OneDrive:
 
 **Standard Authentication Configuration**
 
-Use this authentication connector when accessing a "SharePoint" Drive. For more information see [Microsoft Graph](microsoft-graph.htm) Authentication Connection.
+Use this authentication connector when accessing a "SharePoint" Drive. For more information see [Microsoft Graph](#microsoft-graph) Authentication Connection.
 
 The application will require the following permissions:
 

--- a/microsoft-outlook/2.10/admin/index.md
+++ b/microsoft-outlook/2.10/admin/index.md
@@ -63,7 +63,7 @@ The Outlook clients initiates the authentication process directly against the Id
 * Client ID
 * Redirect URL
 
-Details about the configuration parameters are in the [configuration]{% link microsoft-outlook/2.10/config/index.md %} page.
+Details about the configuration parameters are in the [configuration]({% link microsoft-outlook/2.10/config/index.md %}) page.
 
 > **Note:** To allow the use of the SAML provider without additional user interaction, you must force the use of the SAML provider. See [Identity Service documentation]({% link identity-service/latest/tutorial/sso/saml.md %}#step-5-optional-enforcing-saml) for
 details.

--- a/microsoft-outlook/latest/admin/index.md
+++ b/microsoft-outlook/latest/admin/index.md
@@ -63,7 +63,7 @@ The Outlook clients initiates the authentication process directly against the Id
 * Client ID
 * Redirect URL
 
-Details about the configuration parameters are in the [configuration]{% link microsoft-outlook/latest/config/index.md %} page.
+Details about the configuration parameters are in the [configuration]({% link microsoft-outlook/latest/config/index.md %}) page.
 
 > **Note:** To allow the use of the SAML provider without additional user interaction, you must force the use of the SAML provider. See [Identity Service documentation]({% link identity-service/latest/tutorial/sso/saml.md %}#step-5-optional-enforcing-saml) for
 details.

--- a/sync-service/4.0/support/index.md
+++ b/sync-service/4.0/support/index.md
@@ -2,20 +2,20 @@
 title: Supported platforms
 ---
 
-The following are the supported platforms for Alfresco Sync Service 4.0:
+The following are the supported platforms for Alfresco Sync Service:
 
 | Version | Notes |
 | ------- | ----- |
-| Alfresco Content Services 23.x | Optionally with Alfresco Governance Services 23.x |
+| Content Services 23.x | Optionally with Governance Services 23.x |
 | Identity Service 2.0 | Required for SAML authentication |
-| Alfresco Desktop Sync for Windows 1.16 | |
-| Alfresco Desktop Sync for Mac 1.16 | |
+| Desktop Sync for Windows 1.16 | |
+| Desktop Sync for Mac 1.16 | |
 | | |
 | | Check the [Alfresco Content Services Supported platforms]({% link content-services/latest/support/index.md %}) page for specific versions of the individual components. |
 | **Java** | |
 | OpenJDK 17 (64-bit) | |
 | | |
-| **Message brokers** |
+| **Message brokers** | |
 | Apache ActiveMQ | |
 | Amazon MQ | |
 | | |
@@ -23,7 +23,7 @@ The following are the supported platforms for Alfresco Sync Service 4.0:
 | Windows Server | |
 | Linux | |
 | | |
-| **Databases** |
+| **Databases** | |
 | PostgreSQL | |
 | MySQL | |
 | Oracle | |

--- a/sync-service/latest/support/index.md
+++ b/sync-service/latest/support/index.md
@@ -2,20 +2,20 @@
 title: Supported platforms
 ---
 
-The following are the supported platforms for Alfresco Sync Service 4.0:
+The following are the supported platforms for Alfresco Sync Service:
 
 | Version | Notes |
 | ------- | ----- |
-| Alfresco Content Services 23.x | Optionally with Alfresco Governance Services 23.x |
+| Content Services 23.x | Optionally with Governance Services 23.x |
 | Identity Service 2.0 | Required for SAML authentication |
-| Alfresco Desktop Sync for Windows 1.16 | |
-| Alfresco Desktop Sync for Mac 1.16 | |
+| Desktop Sync for Windows 1.16 | |
+| Desktop Sync for Mac 1.16 | |
 | | |
 | | Check the [Alfresco Content Services Supported platforms]({% link content-services/latest/support/index.md %}) page for specific versions of the individual components. |
 | **Java** | |
 | OpenJDK 17 (64-bit) | |
 | | |
-| **Message brokers** |
+| **Message brokers** | |
 | Apache ActiveMQ | |
 | Amazon MQ | |
 | | |
@@ -23,7 +23,7 @@ The following are the supported platforms for Alfresco Sync Service 4.0:
 | Windows Server | |
 | Linux | |
 | | |
-| **Databases** |
+| **Databases** | |
 | PostgreSQL | |
 | MySQL | |
 | Oracle | |


### PR DESCRIPTION
This PR adds the links to the Hyland Documentation Portal, using the new Alfresco landing page as a starting point. The links from previous releases are updated to match.

**Summary of changes**

- Add new documentation locations for Desktop Sync 1.19 / Sync Service 5.1 / Salesforce Connector 3.2 and higher
- Change links to new landing page: [support.hyland.com/p/alfresco](https://support.hyland.com/p/alfresco)
- List products in alphabetical order for easier look-up.
