### PR TITLE
[DOCS-8046] Grant Schema Permissions for PostgreSQL 15+ Compatibility

### DIFF
--- a/content-services/latest/install/zip/index.md
+++ b/content-services/latest/install/zip/index.md
@@ -87,4 +87,6 @@ These steps describe how to prepare a suitable location for data storage and the
     create database alfresco encoding 'utf8';
     create role alfresco LOGIN password 'alfresco';
     grant all on database alfresco to alfresco;
+    grant all on SCHEMA public to alfresco;
+    grant usage on SCHEMA public to alfresco;
     ```


### PR DESCRIPTION
With PostgreSQL 15 and onwards, there has been a change in the way table creation permissions are handled for users. Not directly related to pgAdmin 4, but I think people may run into this.

Normally, after allowing a user to CREATE tables within a database, you didn't have to specifically define that they had the permission to do that within a SCHEMA, since public would be the default one.

With PostgreSQL 15, this has changed [source](https://www.postgresql.org/about/news/postgresql-15-released-2526)

> PostgreSQL 15 also revokes the CREATE permission from all users except a database owner from the public (or default) schema.

**ERROR: permission denied for schema public**

The error occurred during the installation of Alfresco using the ZIP installer with PostgreSQL 17.
To fix this, I added the following two lines to the PostgreSQL configuration:

```sql
GRANT ALL ON SCHEMA public TO alfresco
GRANT USAGE ON SCHEMA public TO alfresco
```