### PR TITLE
[DOCS-8027] Add banner for migrated products

### DIFF
--- a/404.html
+++ b/404.html
@@ -39,17 +39,18 @@ redirect_from:
           <ul>
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco APS Action Extension 7.0</a> | <a href="https://docs.alfresco.com/content-services/latest/config/action/">Older versions</a></li>
 
-            <li><a href="https://docs.alfresco.com/microsoft-365/latest/">Alfresco Collaboration Connector for Microsoft 365 2.0</a></li>
-            <li><a href="https://docs.alfresco.com/microsoft-teams/latest/">Alfresco Collaboration Connector for Microsoft Teams 2.0</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Collaboration Connector for Microsoft 365 2.0 and higher</a> | <a href="https://docs.alfresco.com/microsoft-365/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Collaboration Connector for Microsoft Teams 2.0  and higher</a> | <a href="https://docs.alfresco.com/microsoft-teams/latest/">Older versions</a></li>
 
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Accelerator 4.1 and higher</a> | <a href="https://docs.alfresco.com/content-accelerator/latest/">Older versions</a></li>
             
-            <li><a href="https://docs.alfresco.com/aws-s3/latest/">Alfresco Content Connector for AWS S3 6.1</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for AWS S3 6.1 and higher</a> | <a href="https://docs.alfresco.com/aws-s3/latest/">Older versions</a></li>
             
-            <li><a href="https://docs.alfresco.com/microsoft-azure/latest/">Alfresco Content Connector for Azure 5.0</a></li><li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for Salesforce 3.2 and higher</a> | <a href="https://docs.alfresco.com/salesforce/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for Azure 5.0 and higher</a> | <a href="https://docs.alfresco.com/microsoft-azure/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for Salesforce 3.2 and higher</a> | <a href="https://docs.alfresco.com/salesforce/latest/">Older versions</a></li>
             
-            <li><a href="https://docs.alfresco.com/sap/latest/">Alfresco Content Connector for SAP Applications 6.0</a></li>
-            <li><a href="https://docs.alfresco.com/sap-cloud/latest/">Alfresco Content Connector for SAP Cloud 2.0</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for SAP Applications 6.0 and higher</a> | <a href="https://docs.alfresco.com/sap/latest/">AOlder versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Connector for SAP Cloud 2.0 and higher</a> | <a href="https://docs.alfresco.com/sap-cloud/latest/">Older versions</a></li>
 
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Services 23.3 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/">Older versions</a></li>
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Content Services Community Edition 23.3 and higher</a> | <a href="https://docs.alfresco.com/content-services/community/">Older versions</a></li>
@@ -58,7 +59,7 @@ redirect_from:
 
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Digital Workspace 5.0 and higher</a> | <a href="https://docs.alfresco.com/digital-workspace/latest/">Older versions</a></li>
             
-            <li><a href="https://docs.alfresco.com/transformation-engine/latest/">Alfresco Document Transformation Engine 2.4</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Document Transformation Engine 2.4 and higher</a> | <a href="https://docs.alfresco.com/transformation-engine/latest/">Older versions</a></li>
             
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Enterprise Viewer 4.1 and higher</a> | <a href="https://docs.alfresco.com/enterprise-viewer/latest/">Older versions</a></li>
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Extension Inspector 2.1 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/develop/extension-inspector/">Older versions</a></li>
@@ -67,17 +68,18 @@ redirect_from:
             
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco File System Transfer Receiver 7.0</a> | <a href="https://docs.alfresco.com/content-services/latest/admin/import-transfer/#configure-file-system-transfer-receiver">Older versions</a></li>
             
-            <li><a href="https://docs.alfresco.com/google-drive/latest/">Alfresco Google Docs Integration 4.1</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Google Docs Integration 4.1 and higher</a> | <a href="https://docs.alfresco.com/google-drive/latest/">Older versions</a></li>
 
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Governance Services 23.3 and higher</a> | <a href="https://docs.alfresco.com/governance-services/latest/">Older versions</a></li>
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Governance Services Community Edition 23.3 and higher</a> | <a href="https://docs.alfresco.com/governance-services/community/">Older versions</a></li>
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco In-Process SDK 4.9 and higher</a> | <a href="https://docs.alfresco.com/content-services/latest/develop/sdk/">Older versions</a></li>
             
-            <li><a href="https://docs.alfresco.com/intelligence-services/latest/">Alfresco Intelligence Services 3.1</a></li><li><a href="https://support.hyland.com/p/alfresco">Alfresco Office Services 3.1 and higher</a> | <a href="https://docs.alfresco.com/microsoft-office/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Intelligence Services 3.1 and higher</a> | <a href="https://docs.alfresco.com/intelligence-services/latest/">Older versions</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Office Services 3.1 and higher</a> | <a href="https://docs.alfresco.com/microsoft-office/latest/">Older versions</a></li>
 
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Mobile Workspace 1.10 and higher</a> | <a href="https://docs.alfresco.com/mobile-workspace/latest/">Older versions</a></li>
 
-            <li><a href="https://docs.alfresco.com/microsoft-outlook/latest/">Alfresco Outlook Integration 3.0</a></li>
+            <li><a href="https://support.hyland.com/p/alfresco">Alfresco Outlook Integration 3.0 and higher</a> | <a href="https://docs.alfresco.com/microsoft-outlook/latest/">Older versions</a></li>
             
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Process Automation 7.17 and higher</a> | <a href="https://docs.alfresco.com/process-automation/latest/">Older versions</a></li>
             <li><a href="https://support.hyland.com/p/alfresco">Alfresco Process Services 24.3 and higher</a> | <a href="https://docs.alfresco.com/process-services/latest/">Older versions</a></li>

--- a/_config.yml
+++ b/_config.yml
@@ -241,7 +241,7 @@ defaults:
       latest: true
       migrated: true
 
-# Alfresco Google Drive
+# Alfresco Google Docs Integration - Migrated
   - scope:
       path: "google-drive"
     values:
@@ -262,6 +262,7 @@ defaults:
     values:
       version: 4.1
       latest: true
+      migrated: true
   - scope:
       path: "google-drive/4.0"
     values:
@@ -315,7 +316,7 @@ defaults:
     values:
       version: 1.0
 
-# Alfresco Content Connector for Azure
+# Alfresco Content Connector for Azure - Migrated
   - scope:
       path: "microsoft-azure"
     values:
@@ -340,6 +341,7 @@ defaults:
     values:
         version: 5.0
         latest: true
+        migrated: true
   - scope:
       path: "microsoft-azure/4.0"
     values:
@@ -783,7 +785,7 @@ defaults:
     values:
       version: 1.9
 
-# Alfresco Document Transformation Engine (DTE)
+# Alfresco Document Transformation Engine (DTE) - Migrated
   - scope:
       path: "transformation-engine"
     values:
@@ -801,6 +803,7 @@ defaults:
     values:
       version: 2.4
       latest: true
+      migrated: true
   - scope:
       path: "transformation-engine/2.3"
     values:
@@ -810,7 +813,7 @@ defaults:
     values:
       version: 2.2
 
-# Alfresco Content Connector for AWS S3
+# Alfresco Content Connector for AWS S3 - Migrated
   - scope:
       path: "aws-s3"
     values:
@@ -835,6 +838,7 @@ defaults:
     values:
       version: 6.1
       latest: true
+      migrated: true
   - scope:
       path: "aws-s3/6.0"
     values:
@@ -872,7 +876,7 @@ defaults:
     values:
       version: 2.2
 
-# Alfresco Collaboration Connector for Microsoft 365
+# Alfresco Collaboration Connector for Microsoft 365 - Migrated
   - scope:
       path: "microsoft-365"
     values:
@@ -889,7 +893,8 @@ defaults:
       path: "microsoft-365/latest"
     values:
      version: 2.0
-     latest: true       
+     latest: true
+     migrated: true
   - scope:
       path: "microsoft-365/1.1"
     values:
@@ -899,7 +904,7 @@ defaults:
     values:
       version: 1.0
       
-  # Alfresco Collaboration Connector for Teams
+  # Alfresco Collaboration Connector for Teams - Migrated
   - scope:
       path: "microsoft-teams"
     values:
@@ -917,6 +922,7 @@ defaults:
     values:
       version: 2.0
       latest: true
+      migrated: true
   - scope:
       path: "microsoft-teams/1.1"
     values:
@@ -1109,7 +1115,7 @@ defaults:
     values:
       version: 1.1
 
-# Alfresco Content Connector for SAP Applications
+# Alfresco Content Connector for SAP Applications - Migrated
   - scope:
       path: "sap"
     values:
@@ -1129,6 +1135,7 @@ defaults:
     values:
       version: 6.0
       latest: true
+      migrated: true
   - scope:
       path: "sap/5.3"
     values:
@@ -1146,7 +1153,7 @@ defaults:
     values:
       version: 5.0
 
-# Alfresco Content Connector for SAP Cloud
+# Alfresco Content Connector for SAP Cloud - Migrated
   - scope:
       path: "sap-cloud"
     values:
@@ -1165,6 +1172,7 @@ defaults:
     values:
       version: 2.0
       latest: true
+      migrated: true
   - scope:
       path: "sap-cloud/1.2"
     values:
@@ -1437,7 +1445,7 @@ defaults:
     values:
       version: 3.0
 
-# Alfresco Intelligence Services (AIS)
+# Alfresco Intelligence Services (AIS) - Migrated
   - scope:
       path: "intelligence-services"
     values:
@@ -1459,6 +1467,7 @@ defaults:
     values:
       version: 3.1
       latest: true
+      migrated: true
   - scope:
       path: "intelligence-services/1.5"
     values:


### PR DESCRIPTION
Summary of changes:

- Add banner for migrated Alfresco documentation
- Add link to the Hyland Documentation Portal